### PR TITLE
Log request body

### DIFF
--- a/api/src/routes/logs.ts
+++ b/api/src/routes/logs.ts
@@ -144,15 +144,18 @@ async function transformStack(stack: string) {
 
   const parsedLines = await Promise.all(
     lines.map(async (line) => {
-      const regex =
-        /at (?:(?<method>[^\s]+) \()?file:\/\/(?<file>[^\s]+):(?<lineNumber>\d+):(?<columnNumber>\d+)\)?/;
-
-      const match = line.match(regex);
+      const fileLocationMatch =
+        /file:\/\/(?<file>[^\s]+):(?<lineNumber>\d+):(?<columnNumber>\d+)/;
+      const match = line.match(fileLocationMatch);
       if (!match || !match.groups) {
         return line;
       }
 
-      const { method, file, lineNumber, columnNumber } = match.groups;
+      const { file, lineNumber, columnNumber } = match.groups;
+      const methodMatch = line.match(
+        /at (?<method>(async )?[\w \[\]\.<>]+) (\()?file:\/\//,
+      );
+      const method = methodMatch?.groups?.method;
 
       const filePath = `${file.trim().replace("file://", "")}.map`;
       try {

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -1,4 +1,3 @@
-import type { NeonDbError } from "@neondatabase/serverless";
 import type { Context } from "hono";
 import { replaceFetch } from "./replace-fetch";
 import { RECORDED_CONSOLE_METHODS, log } from "./request-logger";
@@ -6,10 +5,10 @@ import {
   errorToJson,
   extractCallerLocation,
   generateUUID,
-  neonDbErrorToJson,
   polyfillWaitUntil,
   shouldIgnoreMizuLog,
   shouldPrettifyMizuLog,
+  specialFormatMessage,
   tryCreateFriendlyLink,
   tryPrettyPrintLoggerLog,
 } from "./utils";
@@ -89,30 +88,29 @@ export function createHonoMiddleware(options?: {
       });
 
       // TODO - Fix type of `originalMessage`, since devs could really put anything in there...
-      console[level] = (
-        originalMessage: string | Error | NeonDbError,
-        ...args: unknown[]
-      ) => {
+      console[level] = (originalMessage: unknown, ...args: unknown[]) => {
         const timestamp = new Date().toISOString();
 
         const callerLocation = extractCallerLocation(
           (new Error().stack ?? "").split("\n")[2],
         );
 
-        let message = originalMessage;
-        if (typeof message !== "string" && message.name === "NeonDbError") {
-          message = JSON.stringify(neonDbErrorToJson(message as NeonDbError));
-        }
-        if (message instanceof Error) {
-          message = JSON.stringify(errorToJson(message));
-        }
+        const message = specialFormatMessage(originalMessage);
+
+        const argsToSend = args.map((arg) => {
+          if (arg instanceof Error) {
+            return errorToJson(arg);
+          }
+
+          return arg;
+        });
 
         const payload = {
           level,
           traceId,
           service,
           message,
-          args,
+          args: argsToSend,
           callerLocation,
           timestamp,
         };
@@ -147,13 +145,17 @@ export function createHonoMiddleware(options?: {
         if (!libraryDebugMode && shouldPrettifyMizuLog(applyArgs)) {
           // Optionally log a link to the mizu dashboard for the "response" log
           const linkToMizuUi = tryCreateFriendlyLink({
-            message,
+            message: JSON.stringify(message),
             traceId,
             mizuEndpoint: endpoint,
           });
 
           // Try parsing the message as json and extracting all the fields we care about logging prettily
-          tryPrettyPrintLoggerLog(originalConsoleMethod, message, linkToMizuUi);
+          tryPrettyPrintLoggerLog(
+            originalConsoleMethod,
+            JSON.stringify(message),
+            linkToMizuUi,
+          );
         } else {
           originalConsoleMethod.apply(originalConsoleMethod, applyArgs);
         }

--- a/client-library/src/utils.ts
+++ b/client-library/src/utils.ts
@@ -207,3 +207,20 @@ export function tryCreateFriendlyLink({
 
   return friendlyLink;
 }
+
+export function specialFormatMessage(message: unknown) {
+  if (message instanceof Error) {
+    return JSON.stringify(
+      message.name === "NeonDbError"
+        ? neonDbErrorToJson(message as NeonDbError)
+        : errorToJson(message),
+    );
+  }
+
+  // TODO handle `undefined` better as a value
+  if (message === undefined) {
+    return null;
+  }
+
+  return message;
+}

--- a/frontend/src/pages/RequestDetailsPage/RequestDetails.tsx
+++ b/frontend/src/pages/RequestDetailsPage/RequestDetails.tsx
@@ -168,9 +168,11 @@ const RequestLog = ({ log }: { log: MizuLog }) => {
         eventName="Incoming Request"
         description={description}
       />
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -190,9 +192,11 @@ const FetchRequestLog = ({ log }: { log: MizuLog }) => {
         description={description}
       />
 
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -212,9 +216,11 @@ const FetchResponseLog = ({ log }: { log: MizuLog }) => {
         description={description}
       />
 
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -235,9 +241,11 @@ const FetchErrorLog = ({ log }: { log: MizuLog }) => {
         description={description}
       />
 
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -259,9 +267,11 @@ const FetchLoggingErrorLog = ({ log }: { log: MizuLog }) => {
         description={description}
       />
 
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -310,9 +320,11 @@ const ResponseLog = ({ log }: { log: MizuLog }) => {
         description={description}
       />
       {magicSuggestion && <MagicSuggestion suggestion={magicSuggestion} />}
-      <div className="mt-2">
-        <KeyValueGrid data={log.message} />
-      </div>
+      {log.message !== null && (
+        <div className="mt-2">
+          <KeyValueGrid data={log.message} />
+        </div>
+      )}
     </LogCard>
   );
 };
@@ -450,11 +462,7 @@ const ErrorLog = ({
           <CollapsibleContent className="space-y-2">
             <Separator className="my-1" />
             <div className="mt-2 max-h-[200px] overflow-y-scroll text-gray-400">
-              <pre className="font-mono p-1">
-                <code>
-                  <StackTrace stackTrace={stack ?? ""} />
-                </code>
-              </pre>
+              <StackTrace stackTrace={stack ?? ""} />
             </div>
           </CollapsibleContent>
         </Collapsible>
@@ -463,21 +471,33 @@ const ErrorLog = ({
   );
 };
 
-const InfoLog = ({ log }: { log: MizuLog }) => {
-  const description = `${log.message}`;
+const DefaultLogCard = ({ log }: { log: MizuLog }) => {
+  const description = typeof log.message === "string" ? `${log.message}` : null;
   const vsCodeLink = useCallerLocation(log.callerLocation ?? null);
+  const args =
+    typeof log.message === "string" ? log.args : [log.message, ...log.args];
   return (
     <LogCard>
       <LogDetailsHeader
         eventName={`console.${log.level}`}
         traceId={log.traceId}
         timestamp={log.timestamp}
-        description={""}
+        description={description || ""}
       />
-      <div className="mt-2 font-sans">{description}</div>
-      <div className="mt-2 max-h-[200px] overflow-y-scroll text-gray-500 hover:text-gray-700 ">
-        {JSON.stringify(log.args, null, 2)}
-      </div>
+      {args.length > 0 && (
+        <>
+          <div className="mt-2">Args:</div>
+
+          <div className="mt-2 max-h-[200px] overflow-y-scroll text-gray-500 hover:text-gray-700 ">
+            {args.map((arg, index) => {
+              if (isMizuErrorMessage(arg) && arg.stack) {
+                return <StackTrace key={index} stackTrace={arg.stack} />;
+              }
+              return <div key={index}>{JSON.stringify(arg, null, 2)}</div>;
+            })}
+          </div>
+        </>
+      )}
 
       {vsCodeLink && (
         <div className="mt-2 flex justify-end">
@@ -644,7 +664,7 @@ export const LogDetails = ({
 }: { log: MizuLog; handlerSourceCode: string }) => {
   const { message } = log;
   const lifecycle =
-    typeof message === "object" && "lifecycle" in message
+    message && typeof message === "object" && "lifecycle" in message
       ? message.lifecycle
       : null;
 
@@ -684,26 +704,7 @@ export const LogDetails = ({
     );
   }
 
-  if (typeof message === "string") {
-    return <InfoLog log={log} />;
-  }
-
-  return (
-    <div className="rounded-md border mt-2 px-4 py-2 font-mono text-sm shadow-sm">
-      {message &&
-        typeof message === "object" &&
-        Object.entries(message).map(([key, value]) => {
-          return (
-            <div
-              key={key}
-              className="rounded-md border mt-2 px-4 py-2 font-mono text-sm shadow-sm"
-            >
-              {key}: {formatValue(value)}
-            </div>
-          );
-        })}
-    </div>
-  );
+  return <DefaultLogCard log={log} />;
 };
 
 function formatValue(value: unknown): ReactNode {

--- a/frontend/src/pages/RequestDetailsPage/RequestIssues/RelatedIssuesContent/RelatedIssueList.tsx
+++ b/frontend/src/pages/RequestDetailsPage/RequestIssues/RelatedIssuesContent/RelatedIssueList.tsx
@@ -65,7 +65,8 @@ function getQueryFromLog(log: MizuLog) {
   const message =
     typeof log.message === "string"
       ? log.message
-      : "message" in log.message &&
+      : log.message &&
+        "message" in log.message &&
         typeof log.message.message === "string" &&
         log.message.message;
 

--- a/frontend/src/pages/RequestDetailsPage/StackTrace.tsx
+++ b/frontend/src/pages/RequestDetailsPage/StackTrace.tsx
@@ -3,36 +3,45 @@ import { Fragment } from "react";
 export function StackTrace({ stackTrace }: { stackTrace: string }) {
   const lines = stackTrace.split("\n");
 
-  return lines.map((line, index) => {
-    const regex =
-      /at (?:(?<method>[^\s]+) \()?file:\/\/(?<file>[^\s]+):(?<lineNumber>\d+):(?<columnNumber>\d+)\)?/;
+  return (
+    <pre className="font-mono p-1">
+      <code>
+        {lines.map((line, index) => {
+          const fileLocationMatch =
+            /file:\/\/(?<file>[^\s]+):(?<lineNumber>\d+):(?<columnNumber>\d+)/;
+          const match = line.match(fileLocationMatch);
+          if (!match || !match.groups) {
+            return (
+              <Fragment key={index}>
+                {line}
+                {"\n"}
+              </Fragment>
+            );
+          }
 
-    const match = line.match(regex);
-    if (!match || !match.groups) {
-      return (
-        <Fragment key={index}>
-          {line}
-          {"\n"}
-        </Fragment>
-      );
-    }
-
-    const { method, file, lineNumber, columnNumber } = match.groups;
-    return (
-      <Fragment key={index}>
-        {extractIndentation(line)}
-        at {method ? `${method.trim()} (` : ""}
-        <a
-          className="text-primary underline-offset-4 hover:underline"
-          href={`vscode://file/${file.trim()}:${lineNumber}:${columnNumber}`}
-        >
-          {file.trim()}:{lineNumber}:{columnNumber}
-        </a>
-        {method && ")"}
-        {"\n"}
-      </Fragment>
-    );
-  });
+          const { file, lineNumber, columnNumber } = match.groups;
+          const methodMatch = line.match(
+            /at (?<method>(async )?[\w [\].<>]+) (\()?file:\/\//,
+          );
+          const method = methodMatch?.groups?.method;
+          return (
+            <Fragment key={index}>
+              {extractIndentation(line)}
+              at {method ? `${method.trim()} (` : ""}
+              <a
+                className="text-primary underline-offset-4 hover:underline"
+                href={`vscode://file/${file.trim()}:${lineNumber}:${columnNumber}`}
+              >
+                {file.trim()}:{lineNumber}:{columnNumber}
+              </a>
+              {method && ")"}
+              {"\n"}
+            </Fragment>
+          );
+        })}
+      </code>
+    </pre>
+  );
 }
 
 function extractIndentation(source: string) {

--- a/frontend/src/queries/types.ts
+++ b/frontend/src/queries/types.ts
@@ -154,6 +154,7 @@ const MizuKnownMessageSchema = z.union([
 const MizuMessageSchema = z.union([
   MizuKnownMessageSchema,
   z.string(),
+  z.null(),
   z
     .object({})
     .passthrough(), // HACK - catch all other messages
@@ -171,7 +172,7 @@ export const MizuLogSchema = z.object({
   timestamp: z.string(),
   level: z.string(), // TODO - use enum from db schema?
   message: MizuMessageSchema,
-  args: z.unknown().nullish(), // NOTE - arguments passed to console.*
+  args: z.array(z.unknown()), // NOTE - arguments passed to console.*
   callerLocation: CallerLocationSchema.nullish(),
   ignored: z.boolean().nullish(),
   service: z.string().nullish(),


### PR DESCRIPTION
And improve rendering of stacktraces

Example of a log message rendering additional data:
<img width="1141" alt="image" src="https://github.com/fiberplane/fpx/assets/473804/571e0986-055a-4aa5-a031-6f2aac204a97">

I've also tweaked how we render logs with different parameters. From top to bottom:
* console logging a the request body as an object
* console logging the request body as a string
* console logging (undefined) (which is rendered as null because json) (The usecase is that sometimes you want to log the return value of something directly and it might be just null/undefined). I've added a TODO for better handling of undefined, but doing that requires a bigger change.
<img width="1094" alt="image" src="https://github.com/fiberplane/fpx/assets/473804/e1213c3b-72c1-4601-8125-e7101c947e1c">

Sending (and showing) the body of the request (see bottom of request):
<img width="1127" alt="image" src="https://github.com/fiberplane/fpx/assets/473804/36ddbb07-bb3a-4fe3-b556-f1a0f59cbe13">
