### PR TITLE
Support safe production deploys 

### DIFF
--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -80,7 +80,7 @@ export function createHonoMiddleware<App extends HonoApp>(
     } = mergeConfigs(defaultConfig, config);
 
     // NOTE - We used to have a handy default for the fpx endpoint, but we need to remove that,
-    //        so that people won't accidentally deploy to production with our middleware and 
+    //        so that people won't accidentally deploy to production with our middleware and
     //        start sending data to the default url.
     const endpoint = env<FpxEnv>(c).FPX_ENDPOINT;
     const isEnabled = !!endpoint;


### PR DESCRIPTION
Before putting this stuff out in the wild, it'd be nice to have some reassurances that deploying an app with our middleware won't make things go haywire in production.

This PR:

- Skips middleware when no `FPX_ENDPOINT` is defined
- Logs to the console if `FPX_ENDPOINT` is not defined
- ...