### PR TITLE
WIP: replay requests from the detail view

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "react-dom": "^18.2.0",
     "react-highlight-words": "^0.20.0",
     "react-hook-form": "^7.52.0",
+    "react-hotkeys-hook": "^4.5.0",
     "react-markdown": "^9.0.1",
     "react-query": "^3.39.3",
     "react-resizable": "^3.0.5",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,19 +21,21 @@ export function App() {
     <QueryClientProvider client={queryClient}>
       <RequestorSessionHistoryProvider>
         <Router>
-          <Layout>
+          {/* <Layout> */}
             <Routes>
-              <Route path="/" element={<Redirect />} />
-              <Route path="/requests" element={<RequestsPage />} />
-              <Route
-                path="/requests/:traceId"
-                element={<RequestDetailsPage />}
-              />
-              <Route path="/requestor" element={<RequestorPage />} />
-              <Route path="/issues" element={<IssuesPage />} />
-              <Route path="/settings" element={<SettingsPage />} />
+              <Route element={<Layout />}>
+                <Route path="/" element={<Redirect />} />
+                <Route path="/requests" element={<RequestsPage />} />
+                <Route
+                  path="/requests/:traceId"
+                  element={<RequestDetailsPage />}
+                />
+                <Route path="/requestor" element={<RequestorPage />} />
+                <Route path="/issues" element={<IssuesPage />} />
+                <Route path="/settings" element={<SettingsPage />} />
+              </Route>
             </Routes>
-          </Layout>
+          {/* </Layout> */}
         </Router>
       </RequestorSessionHistoryProvider>
     </QueryClientProvider>

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { ComponentProps, useEffect, useState } from "react";
+import { ComponentProps, useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, Outlet, useParams } from "react-router-dom";
 import {
   Breadcrumb,
@@ -50,21 +50,25 @@ export const Layout: React.FC<{ children?: React.ReactNode }> = () => {
 const RequestLink = ({ props }: { props?: ComponentProps<typeof NavLink> }) => {
   const { traceId } = useParams();
   const { trace } = useRequestDetails(traceId);
-  const { data: traces } = useMizuTraces();
+  const { data: traces, isLoading, isFetching } = useMizuTraces();
 
-  const mostRecentRequest = traces?.find(
+  const mostRecentRequest = useMemo(() => traces?.find(
     (t) => t.method === trace?.method && t.path === trace?.path,
-  );
+  ), [traces, trace]);
 
   const [isMostRecent, setIsMostRecent] = useState(true);
 
+  const checkMostRecentRequest = useCallback(() => trace?.id === mostRecentRequest?.id, [trace, mostRecentRequest])
+
   useEffect(() => {
-    if (trace?.id === mostRecentRequest?.id) {
-      setIsMostRecent(true);
-    } else {
-      setIsMostRecent(false);
-    }
-  }, [mostRecentRequest, trace]);
+    console.log("isFetching", isFetching)
+    console.log("isLoading", isLoading)
+    console.log("TRACES CHANGED", traces)
+  }, [traces, isFetching, isLoading])
+
+  useEffect(() => {
+    setIsMostRecent(checkMostRecentRequest());
+  }, [checkMostRecentRequest]);
 
   if (!traceId && !trace) {
     return (

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { ComponentProps } from "react";
 import { NavLink } from "react-router-dom";
+import { NavLink, Outlet, useParams } from "react-router-dom";
 import FpxIcon from "./fpx.svg";
 import { cn } from "./utils";
 
@@ -33,7 +34,7 @@ export const Layout: React.FC<{ children?: React.ReactNode }> = ({
       <main
         className={cn("md:gap-8", "overflow-hidden", "h-[calc(100vh-64px)]")}
       >
-        {children}
+        <Outlet />
       </main>
     </div>
   );

--- a/frontend/src/Layout.tsx
+++ b/frontend/src/Layout.tsx
@@ -1,13 +1,18 @@
 import type React from "react";
 import { ComponentProps, useEffect, useState } from "react";
 import { NavLink, Outlet, useParams } from "react-router-dom";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "./components/ui/breadcrumb";
+import { Status } from "./components/ui/status";
 import FpxIcon from "./fpx.svg";
-import { cn } from "./utils";
-import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbSeparator } from "./components/ui/breadcrumb";
 import { useRequestDetails } from "./hooks";
 import { RequestMethod } from "./pages/RequestDetailsPage/shared";
-import { Status } from "./components/ui/status";
 import { useMizuTraces } from "./queries";
+import { cn } from "./utils";
 
 const Branding = () => {
   return (
@@ -17,9 +22,7 @@ const Branding = () => {
   );
 };
 
-export const Layout: React.FC<{ children?: React.ReactNode }> = ({
-  children,
-}) => {
+export const Layout: React.FC<{ children?: React.ReactNode }> = () => {
   return (
     <div className="flex min-h-screen w-full flex-col bg-muted/30 max-w-128 overflow-hidden">
       <nav className="flex gap-4 sm:gap-4 py-4 sm:py-0 justify-between items-center h-[64px] border-b">
@@ -49,8 +52,9 @@ const RequestLink = ({ props }: { props?: ComponentProps<typeof NavLink> }) => {
   const { trace } = useRequestDetails(traceId);
   const { data: traces } = useMizuTraces();
 
-
-  const mostRecentRequest = traces?.find((t) => t.method === trace?.method && t.path === trace?.path)
+  const mostRecentRequest = traces?.find(
+    (t) => t.method === trace?.method && t.path === trace?.path,
+  );
 
   const [isMostRecent, setIsMostRecent] = useState(true);
 
@@ -60,36 +64,48 @@ const RequestLink = ({ props }: { props?: ComponentProps<typeof NavLink> }) => {
     } else {
       setIsMostRecent(false);
     }
-  }, [mostRecentRequest, trace])
+  }, [mostRecentRequest, trace]);
 
   if (!traceId && !trace) {
-    return <HeaderNavLink {...props} to="/requests">Requests</HeaderNavLink>
+    return (
+      <HeaderNavLink {...props} to="/requests">
+        Requests
+      </HeaderNavLink>
+    );
   }
 
   return (
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
-          <NavLink className="pl-4 py-2 text-white" to="/requests">Requests</NavLink>
+          <NavLink className="pl-4 py-2 text-white" to="/requests">
+            Requests
+          </NavLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <NavLink to={`/requests/${traceId}`} className="rounded bg-muted px-4 py-2 flex gap-2 items-center text-white">
-            <RequestMethod method={trace?.method} />
+          <NavLink
+            to={`/requests/${traceId}`}
+            className="rounded bg-muted px-4 py-2 flex gap-2 items-center text-white"
+          >
+            {trace && <RequestMethod method={trace?.method} />}
             <span>{trace?.path}</span>
             <Status statusCode={Number(trace?.status)} />
           </NavLink>
         </BreadcrumbItem>
-        {!isMostRecent && 
+        {!isMostRecent && (
           <BreadcrumbItem className="ml-4">
             <NavLink to={`/requests/${mostRecentRequest?.id}`}>
-              <span className="text-white bg-blue-800 px-4 py-2 rounded">Go to the most recent response</span>
+              <span className="text-white bg-blue-800 px-4 py-2 rounded">
+                Go to the most recent response
+              </span>
             </NavLink>
-        </BreadcrumbItem>}
+          </BreadcrumbItem>
+        )}
       </BreadcrumbList>
     </Breadcrumb>
-  )
-}
+  );
+};
 
 const HeaderNavLink = (props: ComponentProps<typeof NavLink>) => {
   return (

--- a/frontend/src/components/ui/DataTable.tsx
+++ b/frontend/src/components/ui/DataTable.tsx
@@ -6,7 +6,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useKeySequence } from "@/hooks";
 import { isModifierKeyPressed } from "@/utils";
 import { useHandler } from "@fiberplane/hooks";
 import {
@@ -22,6 +21,7 @@ import {
 } from "@tanstack/react-table";
 import { clsx } from "clsx";
 import { useMemo, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import {
   Pagination,
   PaginationContent,
@@ -137,9 +137,9 @@ export function DataTable<TData, TValue>({
     }
   });
 
-  useKeySequence(["j"], handleNextRow);
-  useKeySequence(["k"], handlePrevRow);
-  useKeySequence(["Enter"], handleRowSelect);
+  useHotkeys(["j"], handleNextRow);
+  useHotkeys(["k"], handlePrevRow);
+  useHotkeys(["Enter"], handleRowSelect);
 
   return (
     <div>

--- a/frontend/src/pages/RequestDetailsPage/RequestDetailsPage.tsx
+++ b/frontend/src/pages/RequestDetailsPage/RequestDetailsPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import { Status } from "@/components/ui/status";
-import { useKeySequence } from "@/hooks";
 import {
   MizuLog,
   MizuRequestEnd,
@@ -24,6 +23,7 @@ import {
 } from "@/queries/types";
 import { cn } from "@/utils";
 import { useEffect, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { z } from "zod";
 import { FetchRequestErrorLog } from "./FetchRequestErrorLog";
 import { FetchRequestLog } from "./FetchRequestLog";
@@ -84,7 +84,7 @@ export function RequestDetailsPage() {
     };
   }, []);
 
-  useKeySequence(["Escape"], () => {
+  useHotkeys(["Escape"], () => {
     // catch all the cases where the user is in the input field
     // and we don't want to exit the page
     if (isInputFocused) {

--- a/frontend/src/pages/RequestorPage/RequestorInput.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorInput.tsx
@@ -3,6 +3,8 @@ import { Input } from "@/components/ui/input";
 import { TriangleRightIcon } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
 import { RequestMethodCombobox } from "./RequestMethodCombobox";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Badge } from "@/components/ui/badge";
 
 type RequestInputProps = {
   method: string;
@@ -64,15 +66,27 @@ export function RequestorInput({
         />
       </div>
       <div className="flex items-center space-x-2 p-2">
-        <Button
-          size="sm"
-          type="submit"
-          disabled={isRequestorRequesting}
-          className="p-2 md:p-2.5"
-        >
-          <span className="hidden md:inline">Send</span>
-          <TriangleRightIcon className="md:hidden w-6 h-6" />
-        </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                size="sm"
+                type="submit"
+                disabled={isRequestorRequesting}
+                className="p-2 md:p-2.5"
+              >
+                <span className="hidden md:inline">Send</span>
+                <TriangleRightIcon className="md:hidden w-6 h-6" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="bg-muted/75 text-white">
+              <p>Send Request
+                {/* Figoure ot if mac or other */}
+              <Badge className="ml-1" variant="outline">⌘ + ↩</Badge>
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
     </form>
   );

--- a/frontend/src/pages/RequestorPage/RequestorInput.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorInput.tsx
@@ -12,6 +12,7 @@ type RequestInputProps = {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   isRequestorRequesting?: boolean;
   addBaseUrl: (path: string) => string;
+  formRef: React.RefObject<HTMLFormElement>;
 };
 
 export function RequestorInput({
@@ -22,6 +23,7 @@ export function RequestorInput({
   onSubmit,
   isRequestorRequesting,
   addBaseUrl,
+  formRef
 }: RequestInputProps) {
   const [value, setValue] = useState("");
 
@@ -35,6 +37,7 @@ export function RequestorInput({
 
   return (
     <form
+      ref={formRef}
       onSubmit={onSubmit}
       className="flex items-center justify-between rounded-md bg-muted border"
     >

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { cn, isJson, parsePathFromRequestUrl } from "@/utils";
 import { MagicWandIcon } from "@radix-ui/react-icons";
-import { useCallback, useMemo } from "react";
+import { FormEvent, useCallback, useMemo, useRef } from "react";
 import { KeyValueParameter, createKeyValueParameters } from "./KeyValueForm";
 import { RequestPanel } from "./RequestPanel";
 import { RequestorInput } from "./RequestorInput";
@@ -22,6 +22,7 @@ import { findMatchedRoute, useReselectRouteHack, useRoutes } from "./routes";
 // We need some special CSS for grid layout that tailwind cannot handle
 import "./RequestorPage.css";
 import { BACKGROUND_LAYER } from "./styles";
+import { useHotkeys } from "react-hotkeys-hook";
 
 export const RequestorPage = () => {
   const browserHistoryState = usePersistedUiState();
@@ -107,6 +108,15 @@ export const RequestorPage = () => {
     makeRequest,
     recordRequestInSessionHistory,
     selectedRoute,
+  });
+
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // trigger submit event on cmd+enter
+  useHotkeys("mod+enter", () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    }
   });
 
   const {
@@ -202,6 +212,7 @@ export const RequestorPage = () => {
           handlePathInputChange={handlePathInputChange}
           onSubmit={onSubmit}
           isRequestorRequesting={isRequestorRequesting}
+          formRef={formRef}
         />
 
         <div

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { cn, isJson, parsePathFromRequestUrl } from "@/utils";
 import { MagicWandIcon } from "@radix-ui/react-icons";
-import { FormEvent, useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { KeyValueParameter, createKeyValueParameters } from "./KeyValueForm";
 import { RequestPanel } from "./RequestPanel";
 import { RequestorInput } from "./RequestorInput";
@@ -21,8 +21,8 @@ import {
 import { findMatchedRoute, useReselectRouteHack, useRoutes } from "./routes";
 // We need some special CSS for grid layout that tailwind cannot handle
 import "./RequestorPage.css";
-import { BACKGROUND_LAYER } from "./styles";
 import { useHotkeys } from "react-hotkeys-hook";
+import { BACKGROUND_LAYER } from "./styles";
 
 export const RequestorPage = () => {
   const browserHistoryState = usePersistedUiState();
@@ -115,7 +115,9 @@ export const RequestorPage = () => {
   // trigger submit event on cmd+enter
   useHotkeys("mod+enter", () => {
     if (formRef.current) {
-      formRef.current.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+      formRef.current.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "react-dom": "^18.2.0",
         "react-highlight-words": "^0.20.0",
         "react-hook-form": "^7.52.0",
+        "react-hotkeys-hook": "^4.5.0",
         "react-markdown": "^9.0.1",
         "react-query": "^3.39.3",
         "react-resizable": "^3.0.5",
@@ -9042,6 +9043,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz",
+      "integrity": "sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
Addresses:
- FP-3855
- FP-3834

This PR does a few things:
- replaces the homebrew keyboard hook with a battle-tested library
- adds a keyboard shortcut for triggering a request (mod+enter)
- makes layout comps aware of the route
- adds breadcrumbs and a "go to most recent"
- adds a replay request functionality

TODO:
- [ ] refactor needed badly
- [ ] query refetches but doesn't cause a timely render - need to investigate