### PR TITLE
Re-discover routes on app update

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -34,6 +34,7 @@
     "drizzle-orm": "^0.30.10",
     "drizzle-zod": "^0.5.1",
     "hono": "^4.3.7",
+    "minimatch": "^10.0.1",
     "octokit": "^4.0.2",
     "openai": "^4.47.1",
     "source-map": "^0.7.4",

--- a/api/src/index.node.ts
+++ b/api/src/index.node.ts
@@ -53,7 +53,7 @@ const ignoredPaths = getIgnoredPaths();
 fs.watch(watchDir, { recursive: true }, async (eventType, filename) => {
   if (!filename) return;
   if (ignoredPaths.includes(filename)) return;
-  console.log(`File ${filename} ${eventType}, sending a new probe`);
+  console.debug(`File ${filename} ${eventType}, sending a new probe`);
 
   probeRoutesWithExponentialBackoff(
     serviceTargetArgument,

--- a/api/src/index.node.ts
+++ b/api/src/index.node.ts
@@ -1,16 +1,16 @@
+import fs from "node:fs";
 import { createServer } from "node:http";
 import { serve } from "@hono/node-server";
 import { config } from "dotenv";
 import { type WebSocket, WebSocketServer } from "ws";
-import fs from "node:fs";
 
 import { createApp } from "./app.js";
+import { getIgnoredPaths } from "./lib/utils.js";
 import { probeRoutesWithExponentialBackoff } from "./probe-routes.js";
 import {
   frontendRoutesHandler,
   staticServerMiddleware,
 } from "./serve-frontend-build.js";
-import { getIgnoredPaths } from "./lib/utils.js";
 
 config({ path: ".dev.vars" });
 
@@ -51,8 +51,8 @@ const watchDir = process.env.FPX_WATCH_DIR ?? process.cwd();
 const ignoredPaths = getIgnoredPaths();
 
 fs.watch(watchDir, { recursive: true }, async (eventType, filename) => {
-  if (!filename) return
-  if (ignoredPaths.includes(filename)) return
+  if (!filename) return;
+  if (ignoredPaths.includes(filename)) return;
   console.log(`File ${filename} ${eventType}, sending a new probe`);
 
   probeRoutesWithExponentialBackoff(
@@ -60,8 +60,7 @@ fs.watch(watchDir, { recursive: true }, async (eventType, filename) => {
     probeMaxRetries,
     probeDelay,
   );
-})
-
+});
 
 const wss = new WebSocketServer({ server, path: "/ws" });
 wss.on("connection", (ws) => {

--- a/api/src/lib/utils.test.ts
+++ b/api/src/lib/utils.test.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+
+import { shouldIgnoreFile } from "./utils.js";
+
+describe("shouldIgnoreFile", () => {
+  const ignoredPaths = [
+    ".git",
+    "node_modules",
+    "dist",
+    "out",
+    "fpx.db",
+    "fpx.db-journal",
+    "mizu.db",
+    "mizu.db-journal",
+    ".fpx",
+    ".fpxconfig",
+    ".swc",
+    ".wrangler",
+    "*.log",
+  ];
+
+  it("should return true for null filename", () => {
+    expect(shouldIgnoreFile(null, ignoredPaths)).toBe(true);
+  });
+
+  it("should return true for filename in ignoredPaths", () => {
+    expect(shouldIgnoreFile("fpx.db", ignoredPaths)).toBe(true);
+  });
+
+  it("should return true for filename matching glob pattern in ignoredPaths", () => {
+    expect(shouldIgnoreFile("somelogfile.log", ignoredPaths)).toBe(true);
+  });
+
+  it("should return true for filename inside ignored directory", () => {
+    expect(
+      shouldIgnoreFile(
+        path.join(".wrangler", "tmp", "somefile.js"),
+        ignoredPaths,
+      ),
+    ).toBe(true);
+  });
+
+  it("should return false for filename not in ignoredPaths", () => {
+    expect(shouldIgnoreFile("somefile.js", ignoredPaths)).toBe(false);
+  });
+
+  it("should return false for filename not matching any pattern in ignoredPaths", () => {
+    expect(shouldIgnoreFile("somefile.txt", ignoredPaths)).toBe(false);
+  });
+
+  it("should return false for filename in subdir not in ignoredPaths", () => {
+    expect(
+      shouldIgnoreFile(path.join("some", "dir", "somefile.js"), ignoredPaths),
+    ).toBe(false);
+  });
+
+  it("should return false for filename in subdir not matching any pattern in ignoredPaths", () => {
+    expect(
+      shouldIgnoreFile(path.join("some", "dir", "somefile.txt"), ignoredPaths),
+    ).toBe(false);
+  });
+});

--- a/api/src/lib/utils.ts
+++ b/api/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 /**
  * Hacky helper in case you want to try parsing a message as json, but want to fall back to its og value
  */
@@ -28,4 +30,30 @@ export function errorToJson(error: Error) {
     stack: error.stack ?? "", // Stack trace of where the error occurred (useful for debugging)
     // Optionally add more properties here if needed
   };
+}
+
+export function getIgnoredPaths() {
+
+const defaultIgnoredPaths = [
+  ".git", 
+  "node_modules",
+  "dist", 
+  ".fpx", 
+  ".swc", 
+  ".wrangler"
+];
+
+  const paths = fs.readdirSync("./", { withFileTypes: true });
+  const gitignoreFiles = paths.filter((path) => path.name === ".gitignore");
+
+  const gitignoredPaths = gitignoreFiles.map((gitignoreFile) => {
+    const content = fs.readFileSync(gitignoreFile.name, "utf8");
+    return content
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .filter((line) => !line.startsWith("#"))
+  });
+
+
+  return defaultIgnoredPaths.concat(...gitignoredPaths);
 }

--- a/api/src/lib/utils.ts
+++ b/api/src/lib/utils.ts
@@ -33,15 +33,14 @@ export function errorToJson(error: Error) {
 }
 
 export function getIgnoredPaths() {
-
-const defaultIgnoredPaths = [
-  ".git", 
-  "node_modules",
-  "dist", 
-  ".fpx", 
-  ".swc", 
-  ".wrangler"
-];
+  const defaultIgnoredPaths = [
+    ".git",
+    "node_modules",
+    "dist",
+    ".fpx",
+    ".swc",
+    ".wrangler",
+  ];
 
   const paths = fs.readdirSync("./", { withFileTypes: true });
   const gitignoreFiles = paths.filter((path) => path.name === ".gitignore");
@@ -51,9 +50,8 @@ const defaultIgnoredPaths = [
     return content
       .split("\n")
       .filter((line) => line.trim() !== "")
-      .filter((line) => !line.startsWith("#"))
+      .filter((line) => !line.startsWith("#"));
   });
-
 
   return defaultIgnoredPaths.concat(...gitignoredPaths);
 }

--- a/api/src/lib/utils.ts
+++ b/api/src/lib/utils.ts
@@ -38,6 +38,11 @@ export function getIgnoredPaths() {
     ".git",
     "node_modules",
     "dist",
+    "out",
+    "fpx.db",
+    "fpx.db-journal",
+    "mizu.db",
+    "mizu.db-journal",
     ".fpx",
     ".fpxconfig",
     ".swc",
@@ -52,10 +57,16 @@ export function getIgnoredPaths() {
     const gitignoredPaths = gitignoreFiles.map((gitignoreFile) => {
       const filePath = path.join(currentDir, gitignoreFile.name);
       const content = fs.readFileSync(filePath, "utf8");
-      return content
-        .split("\n")
-        .filter((line) => line.trim() !== "")
-        .filter((line) => !line.startsWith("#"));
+      return (
+        content
+          .split("\n")
+          .filter((line) => line.trim() !== "")
+          // Filter out comments
+          .filter((line) => !line.startsWith("#"))
+          // Filter out negations, since we're using minimatch on a per-pattern basis
+          // so, `!.yarn/releases` would match like all files
+          .filter((line) => !line.startsWith("!"))
+      );
     });
 
     return defaultIgnoredPaths.concat(...gitignoredPaths.flat());

--- a/api/src/lib/utils.ts
+++ b/api/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { minimatch } from "minimatch";
 
 /**
  * Hacky helper in case you want to try parsing a message as json, but want to fall back to its og value
@@ -31,6 +32,24 @@ export function errorToJson(error: Error) {
     stack: error.stack ?? "", // Stack trace of where the error occurred (useful for debugging)
     // Optionally add more properties here if needed
   };
+}
+
+export function shouldIgnoreFile(
+  filename: string | null,
+  ignoredPaths: string[],
+): boolean {
+  return (
+    !filename ||
+    ignoredPaths.some(
+      (pattern) =>
+        // E.g., ignore everything inside the `.wrangler` directory
+        filename.startsWith(`${pattern}${path.sep}`) ||
+        // E.g., ignore all files with the given name (e.g., `fpx.db`, `.fpxconfig/fpx.db`)
+        path.basename(filename) === pattern ||
+        // E.g., ignore all files that match the given pattern (e.g., *.db`, `*.db-journal`)
+        minimatch(filename, pattern),
+    )
+  );
 }
 
 export function getIgnoredPaths() {

--- a/api/src/probe-routes.ts
+++ b/api/src/probe-routes.ts
@@ -1,3 +1,30 @@
+let debounceTimeout: NodeJS.Timeout | null = null;
+
+// biome-ignore lint/suspicious/noExplicitAny: Trust me, this is easier
+function debounce<T extends (...args: any[]) => void>(func: T, wait: number) {
+  // biome-ignore lint/suspicious/noExplicitAny: Trust me, this is easier
+  return (...args: any[]) => {
+    if (debounceTimeout) {
+      clearTimeout(debounceTimeout);
+    }
+    debounceTimeout = setTimeout(() => {
+      func(...args);
+    }, wait);
+  };
+}
+
+/**
+ * Since we are calling the route probe inside a file watcher, we should implement
+ * debouncing to avoid spamming the service with requests.
+ * 
+ * HACK - Since we are monitoring ts files, we need a short delay to let the code
+ *        for the service recompile.
+ */
+export const debouncedProbeRoutesWithExponentialBackoff = debounce(
+  probeRoutesWithExponentialBackoff,
+  1500,
+);
+
 /**
  * Asynchronously probe the routes of a service with exponential backoff.
  * Makes a request to the service root route with the `X-Fpx-Route-Inspector` header set to `enabled`.

--- a/api/src/probe-routes.ts
+++ b/api/src/probe-routes.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+
+import { getIgnoredPaths, shouldIgnoreFile } from "./lib/utils.js";
+
 let debounceTimeout: NodeJS.Timeout | null = null;
 
 // biome-ignore lint/suspicious/noExplicitAny: Trust me, this is easier
@@ -16,20 +20,51 @@ function debounce<T extends (...args: any[]) => void>(func: T, wait: number) {
 /**
  * Since we are calling the route probe inside a file watcher, we should implement
  * debouncing to avoid spamming the service with requests.
- * 
+ *
  * HACK - Since we are monitoring ts files, we need a short delay to let the code
  *        for the service recompile.
  */
-export const debouncedProbeRoutesWithExponentialBackoff = debounce(
+const debouncedProbeRoutesWithExponentialBackoff = debounce(
   probeRoutesWithExponentialBackoff,
   1500,
 );
+
+export function startRouteProbeWatcher(watchDir: string) {
+  // Fire off an async probe to the service we want to monitor
+  // This will collect information on all routes that the service exposes
+  // Which powers a postman-like UI to ping routes and see responses
+  const serviceTargetArgument = process.env.FPX_SERVICE_TARGET;
+  const probeMaxRetries = 10;
+  const probeDelay = 1000;
+
+  debouncedProbeRoutesWithExponentialBackoff(
+    serviceTargetArgument,
+    probeMaxRetries,
+    probeDelay,
+  );
+
+  const ignoredPaths = getIgnoredPaths();
+
+  fs.watch(watchDir, { recursive: true }, async (eventType, filename) => {
+    if (shouldIgnoreFile(filename, ignoredPaths)) {
+      return;
+    }
+
+    console.debug(`File ${filename} ${eventType}, sending a new probe`);
+
+    debouncedProbeRoutesWithExponentialBackoff(
+      serviceTargetArgument,
+      probeMaxRetries,
+      probeDelay,
+    );
+  });
+}
 
 /**
  * Asynchronously probe the routes of a service with exponential backoff.
  * Makes a request to the service root route with the `X-Fpx-Route-Inspector` header set to `enabled`.
  */
-export async function probeRoutesWithExponentialBackoff(
+async function probeRoutesWithExponentialBackoff(
   serviceArg: string | number | undefined,
   maxRetries: number,
   delay = 1000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "drizzle-orm": "^0.30.10",
         "drizzle-zod": "^0.5.1",
         "hono": "^4.3.7",
+        "minimatch": "^10.0.1",
         "octokit": "^4.0.2",
         "openai": "^4.47.1",
         "source-map": "^0.7.4",
@@ -52,6 +53,20 @@
         "tsx": "^4.10.5",
         "typescript": "^5.4.5",
         "vitest": "^1.6.0"
+      }
+    },
+    "api/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "client-library": {


### PR DESCRIPTION
Resolves FP-3845

Updates the Typescript API to use file watching to restart route probes. This assumes `npx @fiberplane/studio` gets run from the root of the project in question (or that directory is provided over an environment variable).

