### PR TITLE
Fix CLI isPortTaken utility on Ubuntu and gitignore the fpxconfig json file

### DIFF
--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -21,7 +21,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const args = process.argv.slice(2);
-const script = args[0];
+// NOTE - Handle emptystring script
+const script = (args[0] ?? "").trim();
 
 // HACK - If no script is specified, migrate the db then start running studio
 //        This is a quick way to get started!

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -21,7 +21,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const args = process.argv.slice(2);
-// NOTE - Handle emptystring script
+// Handle emptystring script (I don't think this happens in practice but let's be defensive)
 const script = (args[0] ?? "").trim();
 
 // HACK - If no script is specified, migrate the db then start running studio

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -297,7 +297,8 @@ function readUserConfig() {
   const configDir = path.join(PROJECT_ROOT_DIR, CONFIG_DIR_NAME);
   const configPath = path.join(configDir, CONFIG_FILE_NAME);
   const gitignorePath = path.join(configDir, ".gitignore");
-  const gitignoreEntry = "\n# fpx local database\nfpx.db\n";
+  const gitignoreEntry =
+    "\n# fpx local database\nfpx.db\n# fpx local env vars\nfpx.v0.config.json\n";
 
   // Create the .fpxconfig directory if it doesn't exist
   if (!fs.existsSync(configDir)) {

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -124,11 +124,16 @@ async function getFpxPort() {
       nextFallback = (Number.parseInt(nextFallback, 10) + 1).toString();
     }
 
-    if (hasConfiguredFpxPort) {
+    // HACK - If the nextFallback exceeds 65535, we're out of port range.
+    //        So, we'll just default to 8787.
+    if (hasConfiguredFpxPort || nextFallback > 65535) {
       FPX_PORT = await askUser(
         `  ⚠️ ${portAlreadyInUse}\n  Please choose a different port for FPX.`,
-        nextFallback,
+        nextFallback > 65535 ? "8787" : nextFallback,
       );
+      if (nextFallback > 65535) {
+        break;
+      }
     } else {
       FPX_PORT = nextFallback;
     }

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "api": {
       "name": "@fiberplane/studio",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@hono/node-server": "^1.11.1",


### PR DESCRIPTION
title says it all

the "isPortTaken" logic didn't work on Ubuntu and that is no bueno. Also there is no need to have the fpxconfig json file in version control. The env var for the database is a local path, which would not work cross platform 

***

**NOTE** This has not yet been released, but will be released under `0.2.2` of the api/cli