### PR TITLE
Middleware: Update client library to use .js extension for imports

### DIFF
--- a/client-library/package.json
+++ b/client-library/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.2.0",
+  "version": "0.2.1-beta.1",
   "dependencies": {
     "@neondatabase/serverless": "^0.9.3"
   },

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -1,7 +1,8 @@
 import { env } from "hono/adapter";
 import { createMiddleware } from "hono/factory";
-import { replaceFetch } from "./replace-fetch";
-import { RECORDED_CONSOLE_METHODS, log } from "./request-logger";
+
+import { replaceFetch } from "./replace-fetch.js";
+import { RECORDED_CONSOLE_METHODS, log } from "./request-logger.js";
 import {
   errorToJson,
   extractCallerLocation,
@@ -12,7 +13,7 @@ import {
   specialFormatMessage,
   tryCreateFriendlyLink,
   tryPrettyPrintLoggerLog,
-} from "./utils";
+} from "./utils.js";
 
 // Type hack that makes our middleware types play nicely with Hono types
 type RouterRoute = {

--- a/client-library/src/index.ts
+++ b/client-library/src/index.ts
@@ -1,1 +1,1 @@
-export { createHonoMiddleware } from "./honoMiddleware";
+export { createHonoMiddleware } from "./honoMiddleware.js";

--- a/client-library/src/replace-fetch.ts
+++ b/client-library/src/replace-fetch.ts
@@ -1,4 +1,4 @@
-import { IGNORE_FPX_LOGGER_LOG, errorToJson, generateUUID } from "./utils";
+import { IGNORE_FPX_LOGGER_LOG, errorToJson, generateUUID } from "./utils.js";
 
 /**
  * Hacky function that monkey-patches fetch to send data about network requests to fpx.

--- a/client-library/src/request-logger.ts
+++ b/client-library/src/request-logger.ts
@@ -10,7 +10,7 @@ export const RECORDED_CONSOLE_METHODS = [
   "warn",
 ] as const;
 
-import { PRETTIFY_FPX_LOGGER_LOG, type PrintFunc } from "./utils";
+import { PRETTIFY_FPX_LOGGER_LOG, type PrintFunc } from "./utils.js";
 
 // === LOGGER FUNCTION === //
 function logReq(

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       }
     },
     "api": {
+      "name": "@fiberplane/studio",
       "version": "0.3.0",
       "license": "MIT or Apache 2",
       "dependencies": {
@@ -77,7 +78,8 @@
       }
     },
     "client-library": {
-      "version": "0.2.0",
+      "name": "@fiberplane/hono",
+      "version": "0.2.1-beta.1",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@neondatabase/serverless": "^0.9.3"


### PR DESCRIPTION
We should add a linting/tsconfig rule for this to enforce it in the code, or modify the imports in postprocessing, but for now the fix in this branch resolve the issues I was hitting in #71 and #78

Just adds `.js` to all local imports