### PR TITLE
Middleware: Fix execution context errors in Node, Deno

### DIFF
--- a/client-library/package.json
+++ b/client-library/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.2.1-beta.1",
+  "version": "0.2.1-beta.2",
   "dependencies": {
     "@neondatabase/serverless": "^0.9.3"
   },

--- a/client-library/package.json
+++ b/client-library/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.2.1-beta.3",
+  "version": "0.2.1-beta.4",
   "dependencies": {
     "@neondatabase/serverless": "^0.9.3"
   },

--- a/client-library/package.json
+++ b/client-library/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.2.1-beta.2",
+  "version": "0.2.1-beta.3",
   "dependencies": {
     "@neondatabase/serverless": "^0.9.3"
   },

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -4,7 +4,7 @@ import { createMiddleware } from "hono/factory";
 import { replaceFetch } from "./replace-fetch.js";
 import { RECORDED_CONSOLE_METHODS, log } from "./request-logger.js";
 import {
-  ExtendedExecutionContext,
+  type ExtendedExecutionContext,
   errorToJson,
   extractCallerLocation,
   generateUUID,
@@ -96,12 +96,15 @@ export function createHonoMiddleware<App extends HonoApp>(
 
     const service = env<FpxEnv>(c).FPX_SERVICE_NAME || "unknown";
 
-    const ctx = getRuntimeKey() === 'workerd' ? c.executionCtx : {
-      // HACK - Untested
-      waitUntil: async (p: Promise<unknown>) => {
-       await p
-      }
-    };
+    const ctx =
+      getRuntimeKey() === "workerd"
+        ? c.executionCtx
+        : {
+            // HACK - Untested
+            waitUntil: async (p: Promise<unknown>) => {
+              await p;
+            },
+          };
 
     if (!app) {
       // Logging here before we patch the console.* methods so we don't cause trouble
@@ -114,7 +117,7 @@ export function createHonoMiddleware<App extends HonoApp>(
     //         https://github.com/highlight/highlight/pull/6480
     // NOTE - This "getRuntimeKey" check is necessary to not throw errors on long-running envs that do not have an executionCtx
     //        I actually still need to look up when "workerd" is the runtime key!!!
-    if (getRuntimeKey() === 'workerd') {
+    if (getRuntimeKey() === "workerd") {
       // Type coercion is valid here because we know we're in workerd
       polyfillWaitUntil(ctx as ExtendedExecutionContext);
     }
@@ -187,7 +190,6 @@ export function createHonoMiddleware<App extends HonoApp>(
           headers.append("x-Fpx-Route-Inspector", "enabled");
         }
 
-        
         ctx.waitUntil(
           // Use `originalFetch` to avoid an infinite loop of logging to FPX
           // If we use our monkeyPatched version, then each fetch logs to FPX,

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -100,9 +100,15 @@ export function createHonoMiddleware<App extends HonoApp>(
       getRuntimeKey() === "workerd"
         ? c.executionCtx
         : {
-            // HACK - Untested
+            // HACK - In non-Cloudflare environments we need to provide some sort of "waitUntil" implementation
+            //        In the future we may want to have different middleware for different runtimes
             waitUntil: async (p: Promise<unknown>) => {
-              await p;
+              // NOTE - We need to handle this error so we don't crash the server (like in Deno or Node)
+              try {
+                await p;
+              } catch (_e) {
+                // TODO - Should we log even? Or just fail siliently
+              }
             },
           };
 

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -4,6 +4,7 @@ import { createMiddleware } from "hono/factory";
 import { replaceFetch } from "./replace-fetch.js";
 import { RECORDED_CONSOLE_METHODS, log } from "./request-logger.js";
 import {
+  ExtendedExecutionContext,
   errorToJson,
   extractCallerLocation,
   generateUUID,
@@ -114,7 +115,8 @@ export function createHonoMiddleware<App extends HonoApp>(
     // NOTE - This "getRuntimeKey" check is necessary to not throw errors on long-running envs that do not have an executionCtx
     //        I actually still need to look up when "workerd" is the runtime key!!!
     if (getRuntimeKey() === 'workerd') {
-      polyfillWaitUntil(ctx);
+      // Type coercion is valid here because we know we're in workerd
+      polyfillWaitUntil(ctx as ExtendedExecutionContext);
     }
 
     const teardownFunctions: Array<() => void> = [];

--- a/client-library/src/honoMiddleware.ts
+++ b/client-library/src/honoMiddleware.ts
@@ -1,4 +1,4 @@
-import { env, getRuntimeKey } from "hono/adapter";
+import { env } from "hono/adapter";
 import { createMiddleware } from "hono/factory";
 
 import { replaceFetch } from "./replace-fetch.js";
@@ -7,12 +7,12 @@ import {
   errorToJson,
   extractCallerLocation,
   generateUUID,
+  getRuntimeContext,
   shouldIgnoreFpxLog,
   shouldPrettifyFpxLog,
   specialFormatMessage,
   tryCreateFriendlyLink,
   tryPrettyPrintLoggerLog,
-  getRuntimeContext,
 } from "./utils.js";
 
 // Type hack that makes our middleware types play nicely with Hono types
@@ -185,10 +185,7 @@ export function createHonoMiddleware<App extends HonoApp>(
           }).catch((error) => {
             // NOTE - We handle errors here to avoid crashing the client runtime
             if (libraryDebugMode) {
-              originalConsoleError(
-                "Failed to send telemetry data:",
-                error,
-              );
+              originalConsoleError("Failed to send telemetry data:", error);
             }
           }),
         );

--- a/client-library/src/utils.ts
+++ b/client-library/src/utils.ts
@@ -1,11 +1,15 @@
 import type { NeonDbError } from "@neondatabase/serverless";
+import { Context } from "hono";
+import { getRuntimeKey } from "hono/adapter";
 
 // HACK - We inject this symbol in our request/response logger in order to skip logging massive payloads
 export const PRETTIFY_FPX_LOGGER_LOG = Symbol("PRETTIFY_FPX_LOGGER_LOG");
 // HACK - We inject this symbol in our request/response logger to avoid infintie loop of logging on fetches
 export const IGNORE_FPX_LOGGER_LOG = Symbol("IGNORE_FPX_LOGGER_LOG");
 
-export type ExtendedExecutionContext = ExecutionContext & {
+type WaitUntilable = Pick<ExecutionContext, 'waitUntil'>;
+
+export type ExtendedExecutionContext = WaitUntilable & {
   __waitUntilTimer?: ReturnType<typeof setInterval>;
   __waitUntilPromises?: Promise<void>[];
   waitUntilFinished?: () => Promise<void>;
@@ -100,7 +104,14 @@ export function neonDbErrorToJson(error: NeonDbError) {
     // internalQuery: error?.sourceError?.internalQuery,
   };
 }
-export function polyfillWaitUntil(ctx: ExtendedExecutionContext) {
+
+/**
+ * Polyfill for `waitUntil` in non-Cloudflare environments
+ * 
+ * This will be more important when we support OTEL.
+ * See: https://github.com/highlight/highlight/pull/6480
+ */
+function polyfillWaitUntil(ctx: ExtendedExecutionContext) {
   if (typeof ctx.waitUntil !== "function") {
     if (!Array.isArray(ctx.__waitUntilPromises)) {
       ctx.__waitUntilPromises = [];
@@ -125,6 +136,33 @@ export function polyfillWaitUntil(ctx: ExtendedExecutionContext) {
       await Promise.allSettled(ctx.__waitUntilPromises);
     }
   };
+}
+
+function isCloudflareRuntime() {
+  return getRuntimeKey() === 'workerd';
+}
+
+/**
+ * Runtime-safe way of accessing `executionCtx`
+ * 
+ * At the time of writing, `executionCtx` is not available in all runtimes,
+ * and we need to provide a polyfill for non-Cloudflare environments.
+ * Otherwise, we get a runtime error in Node, Deno, etc.
+ * 
+ * In the future, we should use different middleware for different runtimes.
+ */
+export function getRuntimeContext(c: Context, printFn?: PrintFunc): ExtendedExecutionContext {
+  if (isCloudflareRuntime()) {
+    return c.executionCtx as ExtendedExecutionContext;
+  }
+
+  // HACK - This is the polyfill for waitUntil
+  //        I'm not entirely sure if this will lead to a memory leak in certain runtimes,
+  //        since each request will get its own execution context,
+  //        and it's not clear to me that this object will be garbage collected after all of its promises resolve
+  const fakeCtx = {} as WaitUntilable;
+  polyfillWaitUntil(fakeCtx);
+  return fakeCtx;
 }
 
 /**

--- a/client-library/src/utils.ts
+++ b/client-library/src/utils.ts
@@ -1,5 +1,5 @@
 import type { NeonDbError } from "@neondatabase/serverless";
-import { Context } from "hono";
+import type { Context } from "hono";
 import { getRuntimeKey } from "hono/adapter";
 
 // HACK - We inject this symbol in our request/response logger in order to skip logging massive payloads
@@ -7,7 +7,7 @@ export const PRETTIFY_FPX_LOGGER_LOG = Symbol("PRETTIFY_FPX_LOGGER_LOG");
 // HACK - We inject this symbol in our request/response logger to avoid infintie loop of logging on fetches
 export const IGNORE_FPX_LOGGER_LOG = Symbol("IGNORE_FPX_LOGGER_LOG");
 
-type WaitUntilable = Pick<ExecutionContext, 'waitUntil'>;
+type WaitUntilable = Pick<ExecutionContext, "waitUntil">;
 
 export type ExtendedExecutionContext = WaitUntilable & {
   __waitUntilTimer?: ReturnType<typeof setInterval>;
@@ -107,7 +107,7 @@ export function neonDbErrorToJson(error: NeonDbError) {
 
 /**
  * Polyfill for `waitUntil` in non-Cloudflare environments
- * 
+ *
  * This will be more important when we support OTEL.
  * See: https://github.com/highlight/highlight/pull/6480
  */
@@ -144,19 +144,19 @@ function polyfillWaitUntil(ctx: ExtendedExecutionContext) {
 }
 
 function isCloudflareRuntime() {
-  return getRuntimeKey() === 'workerd';
+  return getRuntimeKey() === "workerd";
 }
 
 /**
  * Runtime-safe way of accessing `executionCtx`
- * 
+ *
  * At the time of writing, `executionCtx` is not available in all runtimes,
  * and we need to provide a polyfill for non-Cloudflare environments.
  * Otherwise, we get a runtime error in Node, Deno, etc.
- * 
+ *
  * In the future, we should use different middleware for different runtimes.
  */
-export function getRuntimeContext(c: Context, printFn?: PrintFunc): ExtendedExecutionContext {
+export function getRuntimeContext(c: Context): ExtendedExecutionContext {
   if (isCloudflareRuntime()) {
     return c.executionCtx as ExtendedExecutionContext;
   }

--- a/client-library/src/utils.ts
+++ b/client-library/src/utils.ts
@@ -131,6 +131,11 @@ function polyfillWaitUntil(ctx: ExtendedExecutionContext) {
     };
   }
 
+  // NOTE - We do not make use of this here, but it could be helpful for OTEL
+  //        Highlight uses this in `consumeAndFlush` for errors
+  //        See: sdk/highlight-next/src/util/with-highlight-edge.ts
+  //             In the following PR:
+  //             https://github.com/highlight/highlight/pull/6480/files#diff-5a425baa46cb0362f4f233565c28ad4b43c8fa8274ef38f14f2c56d526b35b23R39
   ctx.waitUntilFinished = async function waitUntilFinished() {
     if (ctx.__waitUntilPromises) {
       await Promise.allSettled(ctx.__waitUntilPromises);

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     },
     "client-library": {
       "name": "@fiberplane/hono",
-      "version": "0.2.1-beta.2",
+      "version": "0.2.1-beta.3",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@neondatabase/serverless": "^0.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     },
     "client-library": {
       "name": "@fiberplane/hono",
-      "version": "0.2.1-beta.3",
+      "version": "0.2.1-beta.4",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@neondatabase/serverless": "^0.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
     },
     "client-library": {
       "name": "@fiberplane/hono",
-      "version": "0.2.1-beta.1",
+      "version": "0.2.1-beta.2",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@neondatabase/serverless": "^0.9.3"


### PR DESCRIPTION
**NOTE** - This is branched off of #79 

***

We get execution context errors outside of Cloudflare envs (specifically, Deno, Node).

Until we have middleware for different environments, we should try our hardest not to break outside of Cloudflare.

To that end, this PR adds:

- A polyfill for `executionCtx`, specifically `executionCtx.waitUntil`
- Error handling for our call to the local FPX service, so we don't crash long-running processes when FPX Studio is not running