### PR TITLE
CLI: Handle Deno project detection better when initializing

### DIFF
--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -152,10 +152,7 @@ async function getFpxPort() {
 async function updateEnvFileWithFpxEndpoint(fpxPort) {
   const LOCALHOST_ENDPOINT = `http://localhost:${fpxPort}/v0/logs`;
   const DOCKER_ENDPOINT = `http://host.docker.internal:${fpxPort}/v0/logs`;
-  const expectedFpxEndpoints = [
-    LOCALHOST_ENDPOINT,
-    DOCKER_ENDPOINT,
-  ];
+  const expectedFpxEndpoints = [LOCALHOST_ENDPOINT, DOCKER_ENDPOINT];
 
   if (shouldCreateDevVarsFile()) {
     touchDevVarsFile();

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -11,10 +11,10 @@ import {
   askUser,
   cliAnswerToBool,
   findInParentDirs,
-  selectClosestPath,
   isPortTaken,
   safeParseJSONFile,
   safeParseTomlFile,
+  selectClosestPath,
 } from "./utils.js";
 
 // Shim __filename and __dirname since we're using esm
@@ -41,10 +41,7 @@ const CONFIG_FILE_NAME = "fpx.v0.config.json";
 // Paths to relevant project directories and files
 const WRANGLER_TOML_PATH = findInParentDirs("wrangler.toml");
 const PACKAGE_JSON_PATH = findInParentDirs("package.json");
-const DENO_CONFIG_PATH = findInParentDirs([
-  "deno.json",
-  "deno.jsonc",
-]);
+const DENO_CONFIG_PATH = findInParentDirs(["deno.json", "deno.jsonc"]);
 const PROJECT_ROOT_DIR = findProjectRoot();
 
 // Loading some possible configuration from the environment

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -275,8 +275,10 @@ function findProjectRoot() {
     DENO_CONFIG_PATH,
   ]);
   if (!projectRoot) {
+    logger.debug("No project root detected");
     return null;
   }
+  logger.debug("Project root detected:", projectRoot);
   return path.dirname(projectRoot);
 }
 

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -150,7 +150,12 @@ async function getFpxPort() {
  * if we can determine the env file to update.
  */
 async function updateEnvFileWithFpxEndpoint(fpxPort) {
-  const expectedFpxEndpoint = `http://localhost:${fpxPort}/v0/logs`;
+  const LOCALHOST_ENDPOINT = `http://localhost:${fpxPort}/v0/logs`;
+  const DOCKER_ENDPOINT = `http://host.docker.internal:${fpxPort}/v0/logs`;
+  const expectedFpxEndpoints = [
+    LOCALHOST_ENDPOINT,
+    DOCKER_ENDPOINT,
+  ];
 
   if (shouldCreateDevVarsFile()) {
     touchDevVarsFile();
@@ -159,7 +164,7 @@ async function updateEnvFileWithFpxEndpoint(fpxPort) {
   const envFilePath = findEnvVarFile();
   const envFileName = envFilePath && path.basename(envFilePath);
   const fpxEndpoint = envFilePath && getFpxEndpointFromEnvFile(envFilePath);
-  const isDifferent = fpxEndpoint !== expectedFpxEndpoint;
+  const isDifferent = !expectedFpxEndpoints.includes(fpxEndpoint);
 
   // Ask the user if we should update the env file
   // - if an env file exists and the fpx endpoint is missing
@@ -170,7 +175,8 @@ async function updateEnvFileWithFpxEndpoint(fpxPort) {
     return;
   }
 
-  const envVarLine = `FPX_ENDPOINT=${expectedFpxEndpoint}`;
+  // NOTE - Default to adding a localhost endpoint instead of a docker one
+  const envVarLine = `FPX_ENDPOINT=${LOCALHOST_ENDPOINT}`;
   const lede = !fpxEndpoint
     ? `  ⚠️ ${envFileName} needs to point to a local FPX Studio to work properly`
     : `  ⚠️ ${envFileName} points to a different FPX Studio endpoint`;

--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -41,6 +41,7 @@ const CONFIG_FILE_NAME = "fpx.v0.config.json";
 // Paths to relevant project directories and files
 const WRANGLER_TOML_PATH = findInParentDirs("wrangler.toml");
 const PACKAGE_JSON_PATH = findInParentDirs("package.json");
+// NOTE - Deno projects might also not necessarily have a deno.json
 const DENO_CONFIG_PATH = findInParentDirs(["deno.json", "deno.jsonc"]);
 const PROJECT_ROOT_DIR = findProjectRoot();
 

--- a/api/bin/utils.js
+++ b/api/bin/utils.js
@@ -73,7 +73,7 @@ export function findInParentDirs(fileNames) {
  * @returns {string|null} - The closest file path, or null if none found
  */
 export function selectClosestPath(filePaths) {
- const paths = filePaths.filter(Boolean);
+  const paths = filePaths.filter(Boolean);
 
   if (paths.length === 0) {
     return null;
@@ -85,7 +85,7 @@ export function selectClosestPath(filePaths) {
     return aDepth - bDepth;
   });
 
-  return paths[0]
+  return paths[0];
 }
 
 /**

--- a/api/bin/utils.js
+++ b/api/bin/utils.js
@@ -33,9 +33,68 @@ export async function askUser(prompt, defaultValue) {
 }
 
 /**
- * Find the path to a file, recurisvely searching the parent directories
+ * Find the closest matching full path to a file or list of files, searching parent directories
+ *
+ * @param {string | string[]} fileNames - A single filename, or a list of file names to search for
+ * @returns {string|null} - The closest file path, or null if none found
  */
-export function findInParentDirs(fileName) {
+export function findInParentDirs(fileNames) {
+  const results = Array.isArray(fileNames)
+    ? fileNames.map(findSingleFileInParentDirs)
+    : [findSingleFileInParentDirs(fileNames)];
+
+  // Filter out null results
+  /** @type {string[]} */
+  const paths = [];
+  for (const result of results) {
+    if (result) {
+      paths.push(result);
+    }
+  }
+
+  if (paths.length === 0) {
+    return null;
+  }
+
+  paths.sort((a, b) => {
+    const aDepth = a.split(path.sep).length;
+    const bDepth = b.split(path.sep).length;
+    return aDepth - bDepth;
+  });
+
+  return paths[0];
+}
+
+/**
+ * Select the closest path from a list of paths
+ * @NOTE - Assumes that all paths are either in current directory or in parent directory!!!
+ *
+ * @param {Array<string|null>} filePaths - The list of file paths to search for
+ * @returns {string|null} - The closest file path, or null if none found
+ */
+export function selectClosestPath(filePaths) {
+ const paths = filePaths.filter(Boolean);
+
+  if (paths.length === 0) {
+    return null;
+  }
+
+  paths.sort((a, b) => {
+    const aDepth = a.split(path.sep).length;
+    const bDepth = b.split(path.sep).length;
+    return aDepth - bDepth;
+  });
+
+  return paths[0]
+}
+
+/**
+ * Find the path to a file, recurisvely searching the parent directories
+ *
+ * @param {string} fileName - The name of the file to search for
+ * @returns {string|null} - The full path to the file, or null if not found
+ */
+function findSingleFileInParentDirs(fileName) {
   let currentDir = process.cwd();
   const visitedDirs = new Set();
   while (currentDir !== path.parse(currentDir).root) {

--- a/api/bin/utils.js
+++ b/api/bin/utils.js
@@ -82,7 +82,7 @@ export function selectClosestPath(filePaths) {
   paths.sort((a, b) => {
     const aDepth = a.split(path.sep).length;
     const bDepth = b.split(path.sep).length;
-    return aDepth - bDepth;
+    return bDepth - aDepth;
   });
 
   return paths[0];

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.0-beta.6",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-beta.6",
+  "version": "0.3.0-beta.7",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "api": {
       "name": "@fiberplane/studio",
-      "version": "0.3.0-beta.6",
+      "version": "0.3.0-beta.7",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@hono/node-server": "^1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "api": {
       "name": "@fiberplane/studio",
-      "version": "0.3.0",
+      "version": "0.3.0-beta.6",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@hono/node-server": "^1.11.1",


### PR DESCRIPTION
Tested with `npx @fiberplane/studio@0.3.0-beta.7`

***

I ran into an issue during the Honcathon, where the FPX cli didn't play nicely with our Deno project.

The issue lies in how we detect the project root. Current CLI only looks for `package.json` or `wrangler.toml`. It does not consider a `deno.json` or `deno.jsonc` file. 

Since I had a rogue `package.json` a few levels above the project root, my `.fpxconfig` ended up being created outside of the project directory.

This PR fixes the issue by looking for the closest matching filepath to the current directory amongst `wrangler.toml`, `package.json`, `deno.json`, and `deno.jsonc`.

***

This also includes a fix that considers `host.docker.internal` the same as `localhost` when detecting whether or not the user's .env definition of `FPX_ENDPOINT` needs to be changed.

During the Honcathon, our project used tilt + docker containers. So, to access fpx, our API needed to specify `host.docker.internal`. Every time I ran the CLI, it asked if i wanted to update the fpx endpoint, since it didn't use localhost.
