### PR TITLE
Fix SQL query formatting for neon queris

### DIFF
--- a/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
@@ -204,10 +204,19 @@ function useVendorSpecificSection(span: MizuSpan) {
 
 function NeonSection({ span }: { span: NeonSpan }) {
   const queryValue = useMemo(() => {
-    return format(span.vendorInfo.sql.query, {
-      language: "postgresql",
-      params: span.vendorInfo.sql.params,
-    });
+    try {
+      const paramsFromNeon = span.vendorInfo.sql.params ?? [];
+      // NOTE - sql-formatter expects the index in the array to match the `$nr` syntax from postgres
+      //        this makes the 0th index unused, but it makes the rest of the indices match the `$1`, `$2`, etc.
+      const params = ["", ...paramsFromNeon];
+      return format(span.vendorInfo.sql.query, {
+        language: "postgresql",
+        params,
+      });
+    } catch (e) {
+      // Being very defensive soz
+      return span?.vendorInfo?.sql?.query ?? "";
+    }
   }, [span]);
   return (
     <SubSection>


### PR DESCRIPTION
The sql formatter library expected index of params array to match the `$1` `$2` etc from the query.

This PR fixes the way we pass params to sql formatter to make the sql query in the UI actually accurate yay