### PR TITLE
add proc macro derive for `ApiError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -111,7 +111,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -119,6 +119,36 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attribute-derive"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1ee502851995027b06f99f5ffbeffa1406b38d0b318a1ebfa469332c6cbafd"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3601467f634cfe36c4780ca9c75dea9a5b34529c1f2810676a337e7e0997f954"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "autocfg"
@@ -230,7 +260,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.72",
  "which",
 ]
 
@@ -333,7 +363,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -341,6 +371,12 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "collection_literals"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
 
 [[package]]
 name = "colorchoice"
@@ -381,6 +417,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -454,6 +501,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
+ "fpx-macros",
  "futures-util",
  "hex",
  "http",
@@ -483,6 +531,16 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "fpx-macros"
+version = "0.1.0"
+dependencies = [
+ "attribute-derive",
+ "proc-macro-error",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -541,7 +599,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -833,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1031,29 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "manyhow"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91ea592d76c0b6471965708ccff7e6a5d277f676b90ab31f4d3f3fc77fade64"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64621e2c08f2576e4194ea8be11daf24ac01249a4f53cd8befcbb7077120ead"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "matchers"
@@ -1182,7 +1269,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1216,7 +1303,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f59e109e2f795a5070e69578c4dc101068139f74616778025ae1011d4cd41a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -1248,7 +1370,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1304,6 +1426,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "quote-use"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e96ac59974192a2fa6ee55a41211cf1385c5b2a8636a4c3068b3b3dd599ece"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c57308e9dde4d7be9af804f6deeaa9951e1de1d5ffce6142eb964750109f7e"
+dependencies = [
+ "derive-where",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1553,7 +1698,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1573,7 +1718,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1584,7 +1729,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1720,7 +1865,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1728,6 +1873,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1770,7 +1925,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1790,7 +1945,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1874,7 +2029,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2055,7 +2210,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2159,7 +2314,7 @@ dependencies = [
  "lazy_format",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "thiserror",
 ]
 
@@ -2261,7 +2416,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2295,7 +2450,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2561,7 +2716,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["fpx", "xtask"]
+members = ["fpx", "fpx-macros", "xtask"]
 default-members = ["fpx"]
 
 [workspace.package]

--- a/fpx-macros/Cargo.toml
+++ b/fpx-macros/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fpx-macros"
+version = "0.1.0"
+edition = "2021"
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+attribute-derive = "0.9.2"
+syn = { version = "2.0.72", features = ["full"] }
+proc-macro-error = "1.0.4"
+quote = "1.0.36"

--- a/fpx-macros/src/lib.rs
+++ b/fpx-macros/src/lib.rs
@@ -1,0 +1,46 @@
+use proc_macro::TokenStream;
+use attribute_derive::FromAttr;
+use proc_macro_error::{abort_call_site, proc_macro_error};
+use quote::quote;
+use syn::{Data, DeriveInput, Expr, parse_macro_input};
+
+#[derive(FromAttr)]
+#[attribute(ident = api_error)]
+#[attribute(error(missing_field = "`{field}` was not specified"))]
+struct ApiErrorAttribute {
+    status_code: Expr
+}
+
+#[proc_macro_derive(ApiError, attributes(status_code))]
+#[proc_macro_error]
+pub fn derive_api_error(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let Data::Enum(data) = &input.data else {
+        abort_call_site!("`ApiError` derive is only supported on enums");
+    };
+
+    let struct_ident = &input.ident;
+    let mut variants = vec![];
+
+    for variant in &data.variants {
+        let ident = &variant.ident;
+
+        let attribute = ApiErrorAttribute::from_attributes(&variant.attrs).unwrap();
+        let status_code = &attribute.status_code;
+
+        variants.push(quote! {
+            #struct_ident::#ident => #status_code
+        });
+    }
+
+    (quote! {
+        impl crate::api::errors::ApiError for #struct_ident {
+            fn status_code(&self) -> http::StatusCode {
+                match self {
+                    #(#variants,)*
+                }
+            }
+        }
+    }).into()
+}

--- a/fpx-macros/src/lib.rs
+++ b/fpx-macros/src/lib.rs
@@ -11,7 +11,7 @@ struct ApiErrorAttribute {
     status_code: Expr
 }
 
-#[proc_macro_derive(ApiError, attributes(status_code))]
+#[proc_macro_derive(ApiError, attributes(api_error))]
 #[proc_macro_error]
 pub fn derive_api_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/fpx/Cargo.toml
+++ b/fpx/Cargo.toml
@@ -22,6 +22,7 @@ axum = { version = "0.7", features = [
 clap = { workspace = true, features = ["derive", "env"] }
 bytes = { version = "1.6" }
 futures-util = { version = "0.3" }
+fpx-macros = { version = "0.1.0", path = "../fpx-macros" }
 hex = { version = "0.4" }
 http = { version = "1.1" }
 http-body-util = { version = "0.1" }

--- a/fpx/src/api/errors.rs
+++ b/fpx/src/api/errors.rs
@@ -4,6 +4,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
+use fpx_macros::ApiError;
 
 pub trait ApiError {
     fn status_code(&self) -> StatusCode;
@@ -124,17 +125,12 @@ where
     }
 }
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Error, Serialize, Deserialize, ApiError)]
 #[serde(tag = "error", content = "details", rename_all = "camelCase")]
 pub enum CommonError {
+    #[api_error(status_code = StatusCode::INTERNAL_SERVER_ERROR)]
     #[error("Internal server error")]
     InternalServerError,
-}
-
-impl ApiError for CommonError {
-    fn status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
-    }
 }
 
 #[cfg(test)]
@@ -142,24 +138,17 @@ mod tests {
     use super::*;
     use http_body_util::BodyExt;
 
-    #[derive(Debug, Serialize, Deserialize, Error)]
+    #[derive(Debug, Serialize, Deserialize, Error, ApiError)]
     #[serde(tag = "error", content = "details", rename_all = "camelCase")]
     #[non_exhaustive]
     pub enum RequestGetError {
+        #[api_error(status_code = StatusCode::NOT_FOUND)]
         #[error("Request not found")]
         RequestNotFound,
 
+        #[api_error(status_code = StatusCode::BAD_REQUEST)]
         #[error("Provided ID is invalid")]
         InvalidId,
-    }
-
-    impl ApiError for RequestGetError {
-        fn status_code(&self) -> StatusCode {
-            match self {
-                RequestGetError::RequestNotFound => StatusCode::NOT_FOUND,
-                RequestGetError::InvalidId => StatusCode::BAD_REQUEST,
-            }
-        }
     }
 
     /// Test to convert Service Error in a ApiServerError to a ApiClientError.

--- a/fpx/src/api/handlers/requests.rs
+++ b/fpx/src/api/handlers/requests.rs
@@ -7,6 +7,7 @@ use axum::Json;
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use fpx_macros::ApiError;
 
 #[tracing::instrument(skip_all)]
 pub async fn request_get_handler(
@@ -20,20 +21,13 @@ pub async fn request_get_handler(
     Ok(Json(request))
 }
 
-#[derive(Debug, Serialize, Deserialize, Error)]
+#[derive(Debug, Serialize, Deserialize, Error, ApiError)]
 #[serde(tag = "error", content = "details", rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum RequestGetError {
+    #[api_error(status_code = StatusCode::NOT_FOUND)]
     #[error("Request not found")]
     RequestNotFound,
-}
-
-impl ApiError for RequestGetError {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            RequestGetError::RequestNotFound => StatusCode::NOT_FOUND,
-        }
-    }
 }
 
 impl From<DbError> for ApiServerError<RequestGetError> {

--- a/fpx/src/api/handlers/requests.rs
+++ b/fpx/src/api/handlers/requests.rs
@@ -1,4 +1,4 @@
-use crate::api::errors::{ApiError, ApiServerError, CommonError};
+use crate::api::errors::{ApiServerError, CommonError};
 use crate::api::models::Request;
 use crate::data::{DbError, Store};
 use axum::extract::{Path, State};

--- a/fpx/src/api/handlers/spans.rs
+++ b/fpx/src/api/handlers/spans.rs
@@ -1,4 +1,4 @@
-use crate::api::errors::{ApiError, ApiServerError, CommonError};
+use crate::api::errors::{ApiServerError, CommonError};
 use crate::api::models::Span;
 use crate::data::{DbError, Store};
 use axum::extract::{Path, State};

--- a/fpx/src/api/handlers/spans.rs
+++ b/fpx/src/api/handlers/spans.rs
@@ -7,6 +7,7 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::error;
+use fpx_macros::ApiError;
 
 #[tracing::instrument(skip_all)]
 pub async fn span_get_handler(

--- a/fpx/src/api/handlers/spans.rs
+++ b/fpx/src/api/handlers/spans.rs
@@ -24,27 +24,21 @@ pub async fn span_get_handler(
     Ok(Json(span.into()))
 }
 
-#[derive(Debug, Serialize, Deserialize, Error)]
+#[derive(Debug, Serialize, Deserialize, Error, ApiError)]
 #[serde(tag = "error", content = "details", rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum SpanGetError {
+    #[api_error(status_code = StatusCode::NOT_FOUND)]
     #[error("Span not found")]
     SpanNotFound,
 
+    #[api_error(status_code = StatusCode::BAD_REQUEST)]
     #[error("Trace ID is invalid")]
     InvalidTraceId,
 
+    #[api_error(status_code = StatusCode::BAD_REQUEST)]
     #[error("Span ID is invalid")]
     InvalidSpanId,
-}
-
-impl ApiError for SpanGetError {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            SpanGetError::InvalidSpanId | SpanGetError::InvalidTraceId => StatusCode::BAD_REQUEST,
-            SpanGetError::SpanNotFound => StatusCode::NOT_FOUND,
-        }
-    }
 }
 
 impl From<DbError> for ApiServerError<SpanGetError> {
@@ -75,20 +69,13 @@ pub async fn span_list_handler(
     Ok(Json(spans))
 }
 
-#[derive(Debug, Serialize, Deserialize, Error)]
+#[derive(Debug, Serialize, Deserialize, Error, ApiError)]
 #[serde(tag = "error", content = "details", rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum SpanListError {
+    #[api_error(status_code = StatusCode::BAD_REQUEST)]
     #[error("Trace ID is invalid")]
     InvalidTraceId,
-}
-
-impl ApiError for SpanListError {
-    fn status_code(&self) -> StatusCode {
-        match self {
-            SpanListError::InvalidTraceId => StatusCode::BAD_REQUEST,
-        }
-    }
 }
 
 impl From<DbError> for ApiServerError<SpanListError> {


### PR DESCRIPTION
fixes FP-3863

usage:

```rust
#[derive(Debug, Error, Serialize, Deserialize, ApiError)]
#[serde(tag = "error", content = "details", rename_all = "camelCase")]
pub enum CommonError {
    #[api_error(status_code = StatusCode::INTERNAL_SERVER_ERROR)]
    #[error("Internal server error")]
    InternalServerError,
}
```

<img width="381" alt="4tv7ty4wstgh" src="https://github.com/user-attachments/assets/2a8efdce-d4a0-43c1-bfdc-41fd65d42dba">