### PR TITLE
Fix serialization of log messages (and args) that are attached to otel event attrs

### DIFF
--- a/client-library-otel/package.json
+++ b/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.8",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/client-library-otel/src/patch/log.ts
+++ b/client-library-otel/src/patch/log.ts
@@ -39,7 +39,7 @@ function patchMethod(methodName: LEVELS, level: string) {
         });
       }
 
-      return original(message, ...args);
+      return original(rawMessage, ...args);
     };
   });
 }

--- a/client-library-otel/src/patch/log.ts
+++ b/client-library-otel/src/patch/log.ts
@@ -1,6 +1,12 @@
 import { trace } from "@opentelemetry/api";
 import { wrap } from "shimmer";
-import { isWrapped, safelySerializeJSON } from "../utils";
+import {
+  errorToJson,
+  isLikelyNeonDbError,
+  isWrapped,
+  neonDbErrorToJson,
+  safelySerializeJSON,
+} from "../utils";
 
 type DEBUG = "debug";
 type LOG = "log";
@@ -25,21 +31,67 @@ function patchMethod(methodName: LEVELS, level: string) {
   }
 
   wrap(console, methodName, (original) => {
-    return (rawMessage: string, ...args: unknown[]) => {
+    // NOTE - Original message needs to be typed as `string` to be compatible with the original method,
+    //        but in fact it is `unknown`.
+    //        People pass non-string arguments to console.log all the time.
+    return (originalMessage: string, ...args: unknown[]) => {
       const span = trace.getActiveSpan();
-      const messageType = rawMessage === null ? "null" : typeof rawMessage;
-      const message =
-        messageType === "string" ? rawMessage : safelySerializeJSON(rawMessage);
+
       if (span) {
+        const { message, messageType } = serializeLogMessage(originalMessage);
+
         span.addEvent("log", {
-          message,
+          message: message,
           messageType,
           level,
-          arguments: JSON.stringify(args),
+          arguments: safelySerializeJSON(args?.map(transformLogMessage)),
         });
       }
 
-      return original(rawMessage, ...args);
+      // IMPORTANT - We need to return the original message, otherwise the console method will not work as expected
+      return original(originalMessage, ...args);
     };
   });
+}
+
+/**
+ * Helper that takes the first argument to a log method and transforms it into a string
+ * that can be logged.
+ *
+ * Also returns `messageType` to be used in the log event, as a hint to the UI.
+ */
+function serializeLogMessage(rawMessage: unknown) {
+  const messageType = rawMessage === null ? "null" : typeof rawMessage;
+  const transformedMessage = transformLogMessage(rawMessage);
+  const stringifiedMessage =
+    transformedMessage === "string"
+      ? transformedMessage
+      : safelySerializeJSON(transformedMessage);
+
+  return {
+    message: stringifiedMessage,
+    messageType,
+  };
+}
+
+/**
+ * Helper that takes a log message and transforms it into something that
+ * hopefully can be stringified (into JSON), we don't lose information on
+ * what was logged.
+ *
+ * The reason this is necessary is because Error objects do not
+ * serialize well to JSON.
+ *
+ * Also NeonDbErrors do not extend the Error class, so they need their own handling.
+ */
+function transformLogMessage(message: unknown) {
+  if (isLikelyNeonDbError(message)) {
+    return neonDbErrorToJson(message);
+  }
+
+  if (message instanceof Error) {
+    return errorToJson(message);
+  }
+
+  return message;
 }

--- a/client-library-otel/src/utils/errors.ts
+++ b/client-library-otel/src/utils/errors.ts
@@ -1,0 +1,49 @@
+export function errorToJson(error: Error) {
+  return {
+    name: error.name, // Includes the name of the error, e.g., 'TypeError'
+    message: error.message, // The message string of the error
+    stack: error.stack, // Stack trace of where the error occurred (useful for debugging)
+  };
+}
+
+type LikelyNeonDbError = {
+  name: string;
+  message: string;
+  sourceError?: Error;
+};
+
+/**
+ * Quick and dirty type guard to check if an error is *likely* a NeonDbError
+ */
+export function isLikelyNeonDbError(
+  error: unknown,
+): error is LikelyNeonDbError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof error.name === "string" &&
+    "message" in error &&
+    typeof error.message === "string" &&
+    (!("sourceError" in error) || error.sourceError instanceof Error)
+  );
+}
+
+export function neonDbErrorToJson(error: LikelyNeonDbError) {
+  return {
+    name: error.name,
+    message: error.message,
+    sourceError: error.sourceError ? errorToJson(error.sourceError) : undefined,
+
+    // NOTE - NeonDbError does not include a stack trace! https://github.com/neondatabase/serverless/issues/82
+    stack: error?.sourceError?.stack,
+
+    // TODO - Figure out how to extract these fields from NeonDbError...
+    //
+    // where: error?.sourceError?.where,
+    // table: error?.sourceError?.table,
+    // column: error?.sourceError?.column,
+    // dataType: error?.sourceError?.dataType,
+    // internalQuery: error?.sourceError?.internalQuery,
+  };
+}

--- a/client-library-otel/src/utils/index.ts
+++ b/client-library-otel/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./errors";
 export * from "./json";
 export * from "./request";
 export * from "./wrapper";

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
     },
     "client-library-otel": {
       "name": "@fiberplane/hono-otel",
-      "version": "0.1.0-alpha.6",
+      "version": "0.1.0-alpha.8",
       "license": "MIT or Apache 2",
       "dependencies": {
         "@opentelemetry/api": "~1.9.0",
@@ -125,6 +125,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.7.3",
         "@cloudflare/workers-types": "^4.20240403.0",
+        "@neondatabase/serverless": "^0.9.4",
         "@swc/cli": "^0.4.0",
         "@swc/core": "^1.5.22",
         "@swc/plugin-transform-imports": "^2.0.4",
@@ -2155,8 +2156,9 @@
       "license": "MIT"
     },
     "node_modules/@neondatabase/serverless": {
-      "version": "0.9.3",
-      "license": "MIT",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-0.9.4.tgz",
+      "integrity": "sha512-D0AXgJh6xkf+XTlsO7iwE2Q1w8981E1cLCPAALMU2YKtkF/1SF6BiAzYARZFYo175ON+b1RNIy9TdSFHm5nteg==",
       "dependencies": {
         "@types/pg": "8.11.6"
       }


### PR DESCRIPTION
The issue had to do with the fact that `Error` does not JSON serialize. Just shows up as an empty object.