### PR TITLE
FPX Worker hibernating WebSocket restoration

### DIFF
--- a/fpx-workers/src/ws/worker.rs
+++ b/fpx-workers/src/ws/worker.rs
@@ -18,10 +18,12 @@ pub struct WebSocketHibernationServer {
 #[durable_object]
 impl DurableObject for WebSocketHibernationServer {
     fn new(state: State, env: Env) -> Self {
+        let connections = state.get_websockets();
+
         Self {
             env,
             state,
-            connections: vec![],
+            connections,
         }
     }
 

--- a/fpx-workers/wrangler.toml
+++ b/fpx-workers/wrangler.toml
@@ -2,22 +2,17 @@ name = "fpx-workers"
 main = "build/worker/shim.mjs"
 compatibility_date = "2024-07-30"
 
-[env.dev]
-d1_databases = [
-  { binding = "DB", database_name = "fpx_test", database_id = "" },
-]
-
-[env.production]
-d1_databases = [
-  { binding = "DB", database_name = "DB", database_id = "c6a49b5e-b1c9-4cee-8c91-3440c5bd3233" },
-]
-
-[build]
-command = "cargo install -q worker-build && worker-build --release"
-
 [[durable_objects.bindings]]
 name = "WEBSOCKET_HIBERNATION_SERVER"
 class_name = "WebSocketHibernationServer"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "DB"
+database_id = "c6a49b5e-b1c9-4cee-8c91-3440c5bd3233"
+
+[build]
+command = "cargo install -q worker-build && worker-build --release"
 
 [[migrations]]
 tag = "v1"


### PR DESCRIPTION
Makes sure to restore hibernated websockets.

Also includes some temporary `wrangler.toml` changes as the environments in workers seem to be a bit picky, we can fix this later