### PR TITLE
Improve headers tables

### DIFF
--- a/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
@@ -2,7 +2,7 @@ import { Status } from "@/components/ui/status";
 import { CodeMirrorSqlEditor } from "@/pages/RequestorPage/Editors/CodeMirrorEditor";
 import { getHttpMethodTextColor } from "@/pages/RequestorPage/method";
 import { OtelSpan } from "@/queries";
-import { cn, noop } from "@/utils";
+import { cn, noop, SENSITIVE_HEADERS } from "@/utils";
 import { ClockIcon } from "@radix-ui/react-icons";
 import { useMemo } from "react";
 import { format } from "sql-formatter";
@@ -133,7 +133,7 @@ function GenericFetchSpan({
         {children}
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" />
+          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" sensitiveKeys={SENSITIVE_HEADERS} />
         </SubSection>
 
         {requestBody && (
@@ -149,7 +149,7 @@ function GenericFetchSpan({
         <Divider />
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" />
+          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" sensitiveKeys={SENSITIVE_HEADERS} />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
@@ -2,7 +2,7 @@ import { Status } from "@/components/ui/status";
 import { CodeMirrorSqlEditor } from "@/pages/RequestorPage/Editors/CodeMirrorEditor";
 import { getHttpMethodTextColor } from "@/pages/RequestorPage/method";
 import { OtelSpan } from "@/queries";
-import { cn, noop, SENSITIVE_HEADERS } from "@/utils";
+import { SENSITIVE_HEADERS, cn, noop } from "@/utils";
 import { ClockIcon } from "@radix-ui/react-icons";
 import { useMemo } from "react";
 import { format } from "sql-formatter";
@@ -133,7 +133,11 @@ function GenericFetchSpan({
         {children}
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" sensitiveKeys={SENSITIVE_HEADERS} />
+          <CollapsibleKeyValueTableV2
+            keyValue={requestHeaders}
+            title="Request Headers"
+            sensitiveKeys={SENSITIVE_HEADERS}
+          />
         </SubSection>
 
         {requestBody && (
@@ -149,7 +153,11 @@ function GenericFetchSpan({
         <Divider />
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" sensitiveKeys={SENSITIVE_HEADERS} />
+          <CollapsibleKeyValueTableV2
+            keyValue={responseHeaders}
+            title="Response Headers"
+            sensitiveKeys={SENSITIVE_HEADERS}
+          />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/FetchSpan.tsx
@@ -8,7 +8,7 @@ import { useMemo } from "react";
 import { format } from "sql-formatter";
 import { TextOrJsonViewer } from "../TextJsonViewer";
 import { SectionHeading } from "../shared";
-import { KeyValueTableV2 } from "./KeyValueTableV2";
+import { CollapsibleKeyValueTableV2 } from "./KeyValueTableV2";
 import {
   getRequestBody,
   getRequestHeaders,
@@ -133,8 +133,7 @@ function GenericFetchSpan({
         {children}
 
         <SubSection>
-          <SubSectionHeading>Request Headers</SubSectionHeading>
-          <KeyValueTableV2 keyValue={requestHeaders} />
+          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" />
         </SubSection>
 
         {requestBody && (
@@ -150,8 +149,7 @@ function GenericFetchSpan({
         <Divider />
 
         <SubSection>
-          <SubSectionHeading>Response Headers</SubSectionHeading>
-          <KeyValueTableV2 keyValue={responseHeaders} />
+          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
@@ -111,6 +111,7 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
           <CollapsibleKeyValueTableV2
             keyValue={requestHeaders}
             title="Request Headers"
+            className="max-w-full"
             sensitiveKeys={SENSITIVE_HEADERS}
           />
         </SubSection>

--- a/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
@@ -1,7 +1,7 @@
 import { Status } from "@/components/ui/status";
 import { getHttpMethodTextColor } from "@/pages/RequestorPage/method";
 import { OtelSpan } from "@/queries";
-import { cn, SENSITIVE_HEADERS } from "@/utils";
+import { SENSITIVE_HEADERS, cn } from "@/utils";
 import { ClockIcon } from "@radix-ui/react-icons";
 import { useMemo } from "react";
 import { SectionHeading } from "../shared";
@@ -100,12 +100,19 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
 
         {requestQueryParams && (
           <SubSection>
-            <CollapsibleKeyValueTableV2 keyValue={requestQueryParams} title="Query Parameters" />
+            <CollapsibleKeyValueTableV2
+              keyValue={requestQueryParams}
+              title="Query Parameters"
+            />
           </SubSection>
         )}
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" sensitiveKeys={SENSITIVE_HEADERS} />
+          <CollapsibleKeyValueTableV2
+            keyValue={requestHeaders}
+            title="Request Headers"
+            sensitiveKeys={SENSITIVE_HEADERS}
+          />
         </SubSection>
 
         {canHaveRequestBody && requestBody && (
@@ -124,7 +131,11 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
         <Divider />
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" sensitiveKeys={SENSITIVE_HEADERS} />
+          <CollapsibleKeyValueTableV2
+            keyValue={responseHeaders}
+            title="Response Headers"
+            sensitiveKeys={SENSITIVE_HEADERS}
+          />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
@@ -1,4 +1,3 @@
-import { CountBadge } from "@/components/CountBadge";
 import { Status } from "@/components/ui/status";
 import { getHttpMethodTextColor } from "@/pages/RequestorPage/method";
 import { OtelSpan } from "@/queries";
@@ -7,7 +6,7 @@ import { ClockIcon } from "@radix-ui/react-icons";
 import { useMemo } from "react";
 import { SectionHeading } from "../shared";
 import { BodyViewerV2 } from "./BodyViewerV2";
-import { KeyValueTableV2 } from "./KeyValueTableV2";
+import { CollapsibleKeyValueTableV2 } from "./KeyValueTableV2";
 import {
   getMatchedRoute,
   getRequestBody,
@@ -46,10 +45,6 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
     return getRequestHeaders(span) ?? {};
   }, [span]);
 
-  const requestHeadersCount = useMemo<number>(() => {
-    return Object.keys(requestHeaders).length;
-  }, [requestHeaders]);
-
   const requestBody = useMemo<string>(() => {
     const body = getRequestBody(span);
     return body ?? "";
@@ -58,10 +53,6 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
   const responseHeaders = useMemo<Record<string, string>>(() => {
     return getResponseHeaders(span);
   }, [span]);
-
-  const responseHeadersCount = useMemo<number>(() => {
-    return Object.keys(responseHeaders).length;
-  }, [responseHeaders]);
 
   const responseBody = useMemo<string>(() => {
     return getResponseBody(span) ?? "";
@@ -107,22 +98,15 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
           </div>
         </div>
 
-        <SubSection>
-          <SubSectionHeading>
-            Request Headers <CountBadge count={requestHeadersCount} />
-          </SubSectionHeading>
-          <KeyValueTableV2 keyValue={requestHeaders} />
-        </SubSection>
-
         {requestQueryParams && (
           <SubSection>
-            <SubSectionHeading>
-              Query Parameters{" "}
-              <CountBadge count={Object.keys(requestQueryParams).length} />
-            </SubSectionHeading>
-            <KeyValueTableV2 keyValue={requestQueryParams} />
+            <CollapsibleKeyValueTableV2 keyValue={requestQueryParams} title="Query Parameters" />
           </SubSection>
         )}
+
+        <SubSection>
+          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" />
+        </SubSection>
 
         {canHaveRequestBody && requestBody && (
           <>
@@ -140,10 +124,7 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
         <Divider />
 
         <SubSection>
-          <SubSectionHeading>
-            Response Headers <CountBadge count={responseHeadersCount} />
-          </SubSectionHeading>
-          <KeyValueTableV2 keyValue={responseHeaders} />
+          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/IncomingRequest.tsx
@@ -1,7 +1,7 @@
 import { Status } from "@/components/ui/status";
 import { getHttpMethodTextColor } from "@/pages/RequestorPage/method";
 import { OtelSpan } from "@/queries";
-import { cn } from "@/utils";
+import { cn, SENSITIVE_HEADERS } from "@/utils";
 import { ClockIcon } from "@radix-ui/react-icons";
 import { useMemo } from "react";
 import { SectionHeading } from "../shared";
@@ -105,7 +105,7 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
         )}
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" />
+          <CollapsibleKeyValueTableV2 keyValue={requestHeaders} title="Request Headers" sensitiveKeys={SENSITIVE_HEADERS} />
         </SubSection>
 
         {canHaveRequestBody && requestBody && (
@@ -124,7 +124,7 @@ export function IncomingRequest({ span }: { span: OtelSpan }) {
         <Divider />
 
         <SubSection>
-          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" />
+          <CollapsibleKeyValueTableV2 keyValue={responseHeaders} title="Response Headers" sensitiveKeys={SENSITIVE_HEADERS} />
         </SubSection>
 
         {responseBody && (

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -2,43 +2,25 @@ import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/utils";
 import { useCallback, useMemo, useState } from "react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
-import { Button } from "@/components/ui/button";
+import { CountBadge } from "@/components/CountBadge";
+import { SubSectionHeading } from "./shared";
+import { CaretDownIcon, CaretRightIcon } from "@radix-ui/react-icons";
 
 export function KeyValueTableV2({
   keyValue,
   emptyMessage = "No data",
   className,
-  defaultMaxRows = 10,
-  defaultCollapsed = true,
 }: {
   keyValue: Record<string, string>;
   emptyMessage?: string;
   className?: string;
-  defaultMaxRows?: number;
-  defaultCollapsed?: boolean;
 }) {
-  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
-  const toggleCollapsed = useCallback(() => {
-    setIsCollapsed(c => !c)
-  }, []);
-  const tableEntries = useMemo(() => {
-    return Object.entries(keyValue);
-  }, [keyValue]);
-
-  const displayedEntries = useMemo(() => {
-    return isCollapsed ? tableEntries.slice(0, defaultMaxRows) : tableEntries;
-  }, [isCollapsed, tableEntries, defaultMaxRows]);
-
-  const hiddenHeadersCount = useMemo(() => {
-    return tableEntries.length - displayedEntries.length;
-  }, [tableEntries, displayedEntries]);
-
   return (
     <div className={cn(className)}>
       <Table className="border-0">
         <TableBody className="">
-          {displayedEntries.length > 0 ? (
-            displayedEntries.map(([key, value]) => (
+          {Object.entries(keyValue).length > 0 ? (
+            Object.entries(keyValue).map(([key, value]) => (
               <TableRow key={key}>
                 <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">
                   {key}
@@ -53,19 +35,55 @@ export function KeyValueTableV2({
               </TableCell>
             </TableRow>
           )}
-          {tableEntries.length > defaultMaxRows && (
-            <Collapsible open={!isCollapsed} onOpenChange={toggleCollapsed}>
-              <CollapsibleTrigger asChild>
-                <Button variant="ghost" className="mt-2 text-blue-500">
-                  
-                  {isCollapsed ? `${hiddenHeadersCount} hidden headers - Click to see more` : "Collapse"}
-                </Button>
-              </CollapsibleTrigger>
-            </Collapsible>
-          )}
         </TableBody>
       </Table>
+    </div>
+  );
+}
 
+export function CollapsibleKeyValueTableV2({
+  keyValue,
+  emptyMessage = "No data",
+  className,
+  defaultCollapsed = true,
+  title,
+}: {
+  keyValue: Record<string, string>;
+  emptyMessage?: string;
+  className?: string;
+  defaultCollapsed?: boolean;
+  title: string;
+}) {
+  const [isOpen, setIsOpen] = useState(!defaultCollapsed);
+  const count = useMemo(() => Object.entries(keyValue).length, [keyValue]);
+  const toggleIsOpen = useCallback(() => setIsOpen(o => !o), []);
+
+  // TODO - If count is 0, do not render the collapsible
+
+  return (
+    <div className={cn(className)}>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <SubSectionHeading className="flex items-center gap-2" onClick={toggleIsOpen}>
+            {isOpen ? <CaretDownIcon className="w-4 h-4 cursor-pointer" /> : <CaretRightIcon className="w-4 h-4 cursor-pointer" />}
+            {title} <CountBadge count={count} />
+          </SubSectionHeading>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <KeyValueTableV2 keyValue={keyValue} emptyMessage={emptyMessage} className="pl-6 mt-1" />
+        </CollapsibleContent>
+      </Collapsible>
+      {/* {isCollapsed && (
+        <div className="flex items-center">
+          <span className="font-medium">Request Headers</span>
+          <span className="ml-2 text-gray-400">({Object.entries(keyValue).length})</span>
+          <span className="ml-2 text-gray-400">
+            {Object.entries(keyValue)
+              .map(([key, value]) => `${key}: ${value}`)
+              .join(" | ")}
+          </span>
+        </div>
+      )} */}
     </div>
   );
 }

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -58,8 +58,6 @@ export function CollapsibleKeyValueTableV2({
   const count = useMemo(() => Object.entries(keyValue).length, [keyValue]);
   const toggleIsOpen = useCallback(() => setIsOpen(o => !o), []);
 
-  // TODO - If count is 0, do not render the collapsible
-
   return (
     <div className={cn(className)}>
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -73,17 +71,6 @@ export function CollapsibleKeyValueTableV2({
           <KeyValueTableV2 keyValue={keyValue} emptyMessage={emptyMessage} className="pl-6 mt-1" />
         </CollapsibleContent>
       </Collapsible>
-      {/* {isCollapsed && (
-        <div className="flex items-center">
-          <span className="font-medium">Request Headers</span>
-          <span className="ml-2 text-gray-400">({Object.entries(keyValue).length})</span>
-          <span className="ml-2 text-gray-400">
-            {Object.entries(keyValue)
-              .map(([key, value]) => `${key}: ${value}`)
-              .join(" | ")}
-          </span>
-        </div>
-      )} */}
     </div>
   );
 }

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -18,7 +18,7 @@ import {
   EyeClosedIcon,
   EyeOpenIcon,
 } from "@radix-ui/react-icons";
-import { useCallback, useMemo, useState } from "react";
+import { useState } from "react";
 import { SubSectionHeading } from "./shared";
 
 export const KeyValueRow = ({

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -6,6 +6,11 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/utils";
 import {
   CaretDownIcon,
@@ -29,18 +34,36 @@ export const KeyValueRow = ({
       <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">
         {key}
       </TableCell>
-      <TableCell className="font-mono">
-        {isSensitive && !showSensitive ? "*****" : value}
+      <TableCell className="font-mono flex items-center">
         {isSensitive && (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => setShowSensitive(!showSensitive)}
-            className="ml-2"
-          >
-            {showSensitive ? <EyeClosedIcon /> : <EyeOpenIcon />}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setShowSensitive(!showSensitive)}
+                className="mr-2 flex-shrink-0"
+              >
+                {showSensitive ? (
+                  <EyeClosedIcon className="w-3 h-3" />
+                ) : (
+                  <EyeOpenIcon className="w-3 h-3" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              {showSensitive ? "Hide Sensitive Value" : "Show Sensitive Value"}
+            </TooltipContent>
+          </Tooltip>
         )}
+        <span
+          className={cn(
+            "flex-grow",
+            isSensitive && !showSensitive ? "italic text-muted-foreground" : "",
+          )}
+        >
+          {isSensitive && !showSensitive ? "hidden" : value}
+        </span>
       </TableCell>
     </TableRow>
   );
@@ -60,7 +83,7 @@ export function KeyValueTableV2({
   return (
     <div className={cn(className)}>
       <Table className="border-0">
-        <TableBody className="">
+        <TableBody>
           {Object.entries(keyValue).length > 0 ? (
             Object.entries(keyValue).map((entry) => (
               <KeyValueRow

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -1,25 +1,44 @@
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/utils";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
 
 export function KeyValueTableV2({
   keyValue,
   emptyMessage = "No data",
   className,
+  defaultMaxRows = 10,
+  defaultCollapsed = true,
 }: {
   keyValue: Record<string, string>;
   emptyMessage?: string;
   className?: string;
+  defaultMaxRows?: number;
+  defaultCollapsed?: boolean;
 }) {
+  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const toggleCollapsed = useCallback(() => {
+    setIsCollapsed(c => !c)
+  }, []);
   const tableEntries = useMemo(() => {
     return Object.entries(keyValue);
   }, [keyValue]);
+
+  const displayedEntries = useMemo(() => {
+    return isCollapsed ? tableEntries.slice(0, defaultMaxRows) : tableEntries;
+  }, [isCollapsed, tableEntries, defaultMaxRows]);
+
+  const hiddenHeadersCount = useMemo(() => {
+    return tableEntries.length - displayedEntries.length;
+  }, [tableEntries, displayedEntries]);
+
   return (
     <div className={cn(className)}>
       <Table className="border-0">
         <TableBody className="">
-          {tableEntries.length > 0 ? (
-            tableEntries.map(([key, value]) => (
+          {displayedEntries.length > 0 ? (
+            displayedEntries.map(([key, value]) => (
               <TableRow key={key}>
                 <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">
                   {key}
@@ -34,8 +53,19 @@ export function KeyValueTableV2({
               </TableCell>
             </TableRow>
           )}
+          {tableEntries.length > defaultMaxRows && (
+            <Collapsible open={!isCollapsed} onOpenChange={toggleCollapsed}>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="mt-2 text-blue-500">
+                  
+                  {isCollapsed ? `${hiddenHeadersCount} hidden headers - Click to see more` : "Collapse"}
+                </Button>
+              </CollapsibleTrigger>
+            </Collapsible>
+          )}
         </TableBody>
       </Table>
+
     </div>
   );
 }

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -1,24 +1,43 @@
+import { CountBadge } from "@/components/CountBadge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/utils";
+import {
+  CaretDownIcon,
+  CaretRightIcon,
+  EyeClosedIcon,
+  EyeOpenIcon,
+} from "@radix-ui/react-icons";
 import { useCallback, useMemo, useState } from "react";
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
-import { CountBadge } from "@/components/CountBadge";
 import { SubSectionHeading } from "./shared";
-import { CaretDownIcon, CaretRightIcon, EyeClosedIcon, EyeOpenIcon } from "@radix-ui/react-icons";
-import { Button } from "@/components/ui/button";
 
-export const KeyValueRow = ({ entry, sensitiveKeys = [] }: { entry: [string, string]; sensitiveKeys?: string[] }) => {
+export const KeyValueRow = ({
+  entry,
+  sensitiveKeys = [],
+}: { entry: [string, string]; sensitiveKeys?: string[] }) => {
   const [key, value] = entry;
   const isSensitive = sensitiveKeys.includes(key);
   const [showSensitive, setShowSensitive] = useState(false);
 
   return (
     <TableRow>
-      <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">{key}</TableCell>
+      <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">
+        {key}
+      </TableCell>
       <TableCell className="font-mono">
         {isSensitive && !showSensitive ? "*****" : value}
         {isSensitive && (
-          <Button variant="ghost" size="icon" onClick={() => setShowSensitive(!showSensitive)} className="ml-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setShowSensitive(!showSensitive)}
+            className="ml-2"
+          >
             {showSensitive ? <EyeClosedIcon /> : <EyeOpenIcon />}
           </Button>
         )}
@@ -44,7 +63,11 @@ export function KeyValueTableV2({
         <TableBody className="">
           {Object.entries(keyValue).length > 0 ? (
             Object.entries(keyValue).map((entry) => (
-              <KeyValueRow key={entry[0]} entry={entry} sensitiveKeys={sensitiveKeys} />
+              <KeyValueRow
+                key={entry[0]}
+                entry={entry}
+                sensitiveKeys={sensitiveKeys}
+              />
             ))
           ) : (
             <TableRow>
@@ -76,19 +99,31 @@ export function CollapsibleKeyValueTableV2({
 }) {
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   const count = useMemo(() => Object.entries(keyValue).length, [keyValue]);
-  const toggleIsOpen = useCallback(() => setIsOpen(o => !o), []);
+  const toggleIsOpen = useCallback(() => setIsOpen((o) => !o), []);
 
   return (
     <div className={cn(className)}>
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleTrigger asChild>
-          <SubSectionHeading className="flex items-center gap-2" onClick={toggleIsOpen}>
-            {isOpen ? <CaretDownIcon className="w-4 h-4 cursor-pointer" /> : <CaretRightIcon className="w-4 h-4 cursor-pointer" />}
+          <SubSectionHeading
+            className="flex items-center gap-2"
+            onClick={toggleIsOpen}
+          >
+            {isOpen ? (
+              <CaretDownIcon className="w-4 h-4 cursor-pointer" />
+            ) : (
+              <CaretRightIcon className="w-4 h-4 cursor-pointer" />
+            )}
             {title} <CountBadge count={count} />
           </SubSectionHeading>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <KeyValueTableV2 keyValue={keyValue} emptyMessage={emptyMessage} className="pl-6 mt-1" sensitiveKeys={sensitiveKeys} />
+          <KeyValueTableV2
+            keyValue={keyValue}
+            emptyMessage={emptyMessage}
+            className="pl-6 mt-1"
+            sensitiveKeys={sensitiveKeys}
+          />
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -4,29 +4,47 @@ import { useCallback, useMemo, useState } from "react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { CountBadge } from "@/components/CountBadge";
 import { SubSectionHeading } from "./shared";
-import { CaretDownIcon, CaretRightIcon } from "@radix-ui/react-icons";
+import { CaretDownIcon, CaretRightIcon, EyeClosedIcon, EyeOpenIcon } from "@radix-ui/react-icons";
+import { Button } from "@/components/ui/button";
+
+export const KeyValueRow = ({ entry, sensitiveKeys = [] }: { entry: [string, string]; sensitiveKeys?: string[] }) => {
+  const [key, value] = entry;
+  const isSensitive = sensitiveKeys.includes(key);
+  const [showSensitive, setShowSensitive] = useState(false);
+
+  return (
+    <TableRow>
+      <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">{key}</TableCell>
+      <TableCell className="font-mono">
+        {isSensitive && !showSensitive ? "*****" : value}
+        {isSensitive && (
+          <Button variant="ghost" size="icon" onClick={() => setShowSensitive(!showSensitive)} className="ml-2">
+            {showSensitive ? <EyeClosedIcon /> : <EyeOpenIcon />}
+          </Button>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+};
 
 export function KeyValueTableV2({
   keyValue,
   emptyMessage = "No data",
   className,
+  sensitiveKeys = [],
 }: {
   keyValue: Record<string, string>;
   emptyMessage?: string;
   className?: string;
+  sensitiveKeys?: string[];
 }) {
   return (
     <div className={cn(className)}>
       <Table className="border-0">
         <TableBody className="">
           {Object.entries(keyValue).length > 0 ? (
-            Object.entries(keyValue).map(([key, value]) => (
-              <TableRow key={key}>
-                <TableCell className="px-0 font-medium min-w-[140px] w-[140px] lg:min-w-[200px] uppercase text-xs text-muted-foreground">
-                  {key}
-                </TableCell>
-                <TableCell className="font-mono">{value}</TableCell>
-              </TableRow>
+            Object.entries(keyValue).map((entry) => (
+              <KeyValueRow key={entry[0]} entry={entry} sensitiveKeys={sensitiveKeys} />
             ))
           ) : (
             <TableRow>
@@ -47,12 +65,14 @@ export function CollapsibleKeyValueTableV2({
   className,
   defaultCollapsed = true,
   title,
+  sensitiveKeys = [],
 }: {
   keyValue: Record<string, string>;
   emptyMessage?: string;
   className?: string;
   defaultCollapsed?: boolean;
   title: string;
+  sensitiveKeys?: string[];
 }) {
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   const count = useMemo(() => Object.entries(keyValue).length, [keyValue]);
@@ -68,7 +88,7 @@ export function CollapsibleKeyValueTableV2({
           </SubSectionHeading>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <KeyValueTableV2 keyValue={keyValue} emptyMessage={emptyMessage} className="pl-6 mt-1" />
+          <KeyValueTableV2 keyValue={keyValue} emptyMessage={emptyMessage} className="pl-6 mt-1" sensitiveKeys={sensitiveKeys} />
         </CollapsibleContent>
       </Collapsible>
     </div>

--- a/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/KeyValueTableV2.tsx
@@ -121,8 +121,8 @@ export function CollapsibleKeyValueTableV2({
   sensitiveKeys?: string[];
 }) {
   const [isOpen, setIsOpen] = useState(!defaultCollapsed);
-  const count = useMemo(() => Object.entries(keyValue).length, [keyValue]);
-  const toggleIsOpen = useCallback(() => setIsOpen((o) => !o), []);
+  const count = Object.entries(keyValue).length;
+  const toggleIsOpen = () => setIsOpen((o) => !o);
 
   return (
     <div className={cn(className)}>

--- a/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
@@ -9,7 +9,14 @@ export const SubSectionHeading = ({
   onClick,
   className,
 }: { children: React.ReactNode; onClick?: () => void; className?: string }) => {
-  return <div className={cn("font-semibold text-sm py-1", className)} onClick={onClick}>{children}</div>;
+  return (
+    <div
+      className={cn("font-semibold text-sm py-1", className)}
+      onClick={onClick}
+    >
+      {children}
+    </div>
+  );
 };
 
 export const Divider = () => {

--- a/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
@@ -9,7 +9,7 @@ export const SubSectionHeading = ({
   onClick,
   className,
 }: { children: React.ReactNode; onClick?: () => void; className?: string }) => {
-  return <div className={cn("font-semibold text-sm", className)} onClick={onClick}>{children}</div>;
+  return <div className={cn("font-semibold text-sm py-1", className)} onClick={onClick}>{children}</div>;
 };
 
 export const Divider = () => {

--- a/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/shared.tsx
@@ -1,11 +1,15 @@
+import { cn } from "@/utils";
+
 export const SubSection = ({ children }: { children: React.ReactNode }) => {
   return <div className="flex flex-col gap-2">{children}</div>;
 };
 
 export const SubSectionHeading = ({
   children,
-}: { children: React.ReactNode }) => {
-  return <div className="font-semibold text-sm">{children}</div>;
+  onClick,
+  className,
+}: { children: React.ReactNode; onClick?: () => void; className?: string }) => {
+  return <div className={cn("font-semibold text-sm", className)} onClick={onClick}>{children}</div>;
 };
 
 export const Divider = () => {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -90,7 +90,12 @@ export function isModifierKeyPressed(
   return event.ctrlKey;
 }
 
-export const SENSITIVE_HEADERS = ["authorization", "cookie", "set-cookie", "neon-connection-string"];
+export const SENSITIVE_HEADERS = [
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "neon-connection-string",
+];
 
 export function redactSensitiveHeaders(
   headers?: null | Record<string, string>,

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -90,6 +90,8 @@ export function isModifierKeyPressed(
   return event.ctrlKey;
 }
 
+export const SENSITIVE_HEADERS = ["authorization", "cookie", "set-cookie", "neon-connection-string"];
+
 export function redactSensitiveHeaders(
   headers?: null | Record<string, string>,
 ) {
@@ -97,16 +99,10 @@ export function redactSensitiveHeaders(
     return headers;
   }
 
-  const sensitiveHeaders = [
-    "authorization",
-    "cookie",
-    "set-cookie",
-    "neon-connection-string",
-  ];
   const redactedHeaders: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(headers)) {
-    if (sensitiveHeaders.includes(key.toLowerCase())) {
+    if (SENSITIVE_HEADERS.includes(key.toLowerCase())) {
       redactedHeaders[key] = "REDACTED";
     } else {
       redactedHeaders[key] = value;


### PR DESCRIPTION
This PR will include:

- Collapsible headers tables, so we don't render like 20 rows when you don't need to see all of them immediately
- Blurred out sensitive headers with a UI to show them 