### PR TITLE
Show responses from proxied requests in requestor, even if request is not to linked service

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0-unstable.2",
+  "version": "0.7.0-alpha.6",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/api/src/lib/utils.ts
+++ b/api/src/lib/utils.ts
@@ -181,11 +181,7 @@ async function tryGetResponseBodyAsText(response: Response) {
     return "#fpx.binary";
   }
 
-  try {
-    return await response.text();
-  } catch {
-    return null;
-  }
+  return await response.text();
 }
 
 export type SerializedFile = {

--- a/frontend/src/pages/RequestorPage/RequestorInput.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorInput.tsx
@@ -13,7 +13,7 @@ import {
   MixerHorizontalIcon,
   TriangleRightIcon,
 } from "@radix-ui/react-icons";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { RequestMethodCombobox } from "./RequestMethodCombobox";
 import { useAddRoutes } from "./queries";
@@ -32,10 +32,6 @@ type RequestInputProps = {
   handlePathInputChange: (newPath: string) => void;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   isRequestorRequesting?: boolean;
-  addBaseUrl: (
-    path: string,
-    { requestType }: { requestType: RequestType },
-  ) => string;
   formRef: React.RefObject<HTMLFormElement>;
   requestType: RequestType;
   websocketState: WebSocketState;
@@ -51,7 +47,6 @@ export function RequestorInput({
   handlePathInputChange,
   onSubmit,
   isRequestorRequesting,
-  addBaseUrl,
   requestType,
   formRef,
   websocketState,
@@ -60,7 +55,6 @@ export function RequestorInput({
   const { toast } = useToast();
 
   const isWsConnected = websocketState.isConnected;
-  const [value, setValue] = useState("");
 
   const { mutate: addRoutes } = useAddRoutes();
 
@@ -89,14 +83,6 @@ export function RequestorInput({
     preventDefault: getIsInDraftMode(),
   });
 
-  // HACK - If path changes externally, update the value here
-  // This happens if the user clicks a route in the sidebar, for example,
-  // or when they load a request from history
-  useEffect(() => {
-    const url = addBaseUrl(path ?? "", { requestType });
-    setValue(url);
-  }, [path, addBaseUrl, requestType]);
-
   return (
     <form
       ref={formRef}
@@ -111,16 +97,9 @@ export function RequestorInput({
         />
         <Input
           type="text"
-          value={value}
+          value={path}
           onChange={(e) => {
-            setValue(e.target.value);
-            try {
-              const url = new URL(e.target.value);
-              handlePathInputChange(url.pathname);
-            } catch {
-              // TODO - Error state? Toast?
-              console.error("Invalid URL", e.target.value);
-            }
+            handlePathInputChange(e.target.value);
           }}
           className="flex-grow w-full bg-transparent font-mono border-none shadow-none focus:ring-0 ml-0"
         />

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -28,8 +28,9 @@ export const RequestorPage = () => {
   globalThis.requestorState = requestorState;
   const {
     // Routes panel
-    state: { routes },
+    state: { routes, serviceBaseUrl },
     setRoutes,
+    setServiceBaseUrl,
     selectRoute: handleSelectRoute, // TODO - Rename, just not sure to what
     getActiveRoute,
 
@@ -39,6 +40,8 @@ export const RequestorPage = () => {
     updatePath: handlePathInputChange,
     updateMethod: handleMethodChange,
     getIsInDraftMode,
+    addServiceUrlToPath,
+    removeServiceUrlFromPath,
 
     // Request panel
     state: { pathParams, queryParams, requestHeaders, body },
@@ -76,8 +79,10 @@ export const RequestorPage = () => {
 
   const selectedRoute = getActiveRoute();
 
-  const { addBaseUrl } = useRoutes({
+  // NOTE - This sets the `routes` and `serviceBaseUrl` in the reducer
+  useRoutes({
     setRoutes,
+    setServiceBaseUrl,
   });
 
   // NOTE - Use this to test overflow of requests panel
@@ -126,7 +131,7 @@ export const RequestorPage = () => {
   // Send a request when we submit the form
   const onSubmit = useRequestorSubmitHandler({
     body,
-    addBaseUrl,
+    addServiceUrlToPath,
     path,
     method,
     pathParams,
@@ -260,7 +265,6 @@ export const RequestorPage = () => {
         )}
       >
         <RequestorInput
-          addBaseUrl={addBaseUrl}
           requestType={selectedRoute?.requestType}
           method={method}
           handleMethodChange={handleMethodChange}
@@ -336,6 +340,7 @@ export const RequestorPage = () => {
               history={history}
               toggleAiTestGenerationPanel={toggleAiTestGenerationPanel}
               getActiveRoute={getActiveRoute}
+              removeServiceUrl={removeServiceUrl}
             />
           )}
         </div>

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -28,7 +28,7 @@ export const RequestorPage = () => {
   globalThis.requestorState = requestorState;
   const {
     // Routes panel
-    state: { routes, serviceBaseUrl },
+    state: { routes },
     setRoutes,
     setServiceBaseUrl,
     selectRoute: handleSelectRoute, // TODO - Rename, just not sure to what
@@ -340,7 +340,7 @@ export const RequestorPage = () => {
               history={history}
               toggleAiTestGenerationPanel={toggleAiTestGenerationPanel}
               getActiveRoute={getActiveRoute}
-              removeServiceUrl={removeServiceUrl}
+              removeServiceUrlFromPath={removeServiceUrlFromPath}
             />
           )}
         </div>

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -40,7 +40,7 @@ export const RequestorPage = () => {
     updatePath: handlePathInputChange,
     updateMethod: handleMethodChange,
     getIsInDraftMode,
-    addServiceUrlToPath,
+    addServiceUrlIfBarePath,
     removeServiceUrlFromPath,
 
     // Request panel
@@ -131,7 +131,7 @@ export const RequestorPage = () => {
   // Send a request when we submit the form
   const onSubmit = useRequestorSubmitHandler({
     body,
-    addServiceUrlToPath,
+    addServiceUrlIfBarePath,
     path,
     method,
     pathParams,
@@ -177,6 +177,7 @@ export const RequestorPage = () => {
       setPath: handlePathInputChange,
       setRequestHeaders,
       updatePathParamValues,
+      addServiceUrlIfBarePath,
     },
     body,
   );

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -325,10 +325,10 @@ export const RequestorPage = () => {
 
           <ResponsePanel
             activeResponse={activeResponse}
+            tracedResponse={mostRecentRequestornatorForRoute}
             activeResponsePanelTab={activeResponsePanelTab}
             setActiveResponsePanelTab={setActiveResponsePanelTab}
             shouldShowResponseTab={shouldShowResponseTab}
-            response={mostRecentRequestornatorForRoute}
             isLoading={isRequestorRequesting}
             websocketState={websocketState}
             requestType={selectedRoute?.requestType}

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -64,6 +64,10 @@ export const RequestorPage = () => {
     setActiveResponsePanelTab,
     shouldShowResponseTab,
 
+    // Response Panel response body
+    state: { activeResponse },
+    setActiveResponse,
+
     // History (WIP)
     state: { activeHistoryResponseTraceId },
     showResponseBodyFromHistory,
@@ -109,7 +113,7 @@ export const RequestorPage = () => {
   );
 
   const { mutate: makeRequest, isPending: isRequestorRequesting } =
-    useMakeProxiedRequest({ clearResponseBodyFromHistory });
+    useMakeProxiedRequest({ clearResponseBodyFromHistory, setActiveResponse });
 
   // WIP - Allows us to connect to a websocket and send messages through it
   const {
@@ -315,6 +319,7 @@ export const RequestorPage = () => {
           />
 
           <ResponsePanel
+            activeResponse={activeResponse}
             activeResponsePanelTab={activeResponsePanelTab}
             setActiveResponsePanelTab={setActiveResponsePanelTab}
             shouldShowResponseTab={shouldShowResponseTab}

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -378,6 +378,23 @@ function useMostRecentRequestornator(
     // Descending sort by updatedAt
     matchingResponses?.sort(sortRequestornatorsDescending);
 
-    return matchingResponses?.[0];
+    const latestMatch = matchingResponses?.[0];
+
+    if (latestMatch) {
+      return latestMatch;
+    }
+
+    // HACK - We can try to match against the exact request URL
+    //        This is a fallback to support the case where the route doesn't exist,
+    //        perhaps because we made a request to a service we are not explicitly monitoring
+    const matchingResponsesFallback = all?.filter(
+      (r: Requestornator) =>
+        r?.app_requests?.requestUrl === requestInputs.path &&
+        r?.app_requests?.requestMethod === requestInputs.method,
+    );
+
+    matchingResponsesFallback?.sort(sortRequestornatorsDescending);
+
+    return matchingResponsesFallback?.[0];
   }, [all, requestInputs, activeHistoryResponseTraceId]);
 }

--- a/frontend/src/pages/RequestorPage/ResponsePanel.tsx
+++ b/frontend/src/pages/RequestorPage/ResponsePanel.tsx
@@ -74,12 +74,12 @@ export function ResponsePanel({
   // NOTE - If we have a "raw" response, we want to render that, so we can (e.g.,) show binary data
   const responseToRender = activeResponse ?? tracedResponse;
 
-  console.log("responseToRender", responseToRender);
-
   const isFailure = isRequestorActiveResponse(responseToRender)
     ? responseToRender.isFailure
     : responseToRender?.app_responses?.isFailure;
 
+  // FIXME - This should actually look if the trace exists in the database
+  //         Since a trace ID will still be created even if we request a non-existent route OR against a service that doesn't exist
   const hasTraceId = isRequestorActiveResponse(responseToRender)
     ? !!responseToRender?.traceId
     : !!responseToRender?.app_responses?.traceId;
@@ -263,7 +263,10 @@ const BottomToolbar = ({
       <div className="sm:hidden">
         <AiTestGenerationDrawer history={response ? [response] : null} />
       </div>
-      <Link to={`/requests/otel/${traceId}`}>
+      <Link
+        to={`/requests/otel/${traceId}`}
+        className={cn(disableGoToTraceButton && "pointer-events-none")}
+      >
         <Button variant="secondary" disabled={disableGoToTraceButton}>
           {disableGoToTraceButton ? (
             "Cannot Find Trace"
@@ -394,7 +397,6 @@ function ResponseBody({
   response?: Requestornator | RequestorActiveResponse;
   className?: string;
 }) {
-  console.log("[rb] response", response);
   const isFailure = isRequestorActiveResponse(response)
     ? response?.isFailure
     : response?.app_responses?.isFailure;
@@ -405,7 +407,6 @@ function ResponseBody({
   }
 
   if (isRequestorActiveResponse(response)) {
-    console.log("[rb] isRequestorActiveResponse", response);
     const body = response?.responseBody;
     if (body?.type === "error") {
       return <FailedRequest response={response} />;

--- a/frontend/src/pages/RequestorPage/ResponsePanel.tsx
+++ b/frontend/src/pages/RequestorPage/ResponsePanel.tsx
@@ -202,7 +202,7 @@ function CollapsibleBodyContainer({
   const toggleIsOpen = () => setIsOpen((o) => !o);
 
   return (
-    <div className={cn(className)}>
+    <div className={cn(className, "border-t", "pt-2")}>
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleTrigger asChild>
           <SubSectionHeading

--- a/frontend/src/pages/RequestorPage/ResponsePanel.tsx
+++ b/frontend/src/pages/RequestorPage/ResponsePanel.tsx
@@ -349,26 +349,20 @@ function ResponseBody({
       );
     }
 
-    // TODO
+    // TODO - Stylize
     if (body?.type === "unknown") {
       return (
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          Unknown response type
+          Unknown response type, cannot render body
         </div>
       );
     }
 
     // TODO
     if (body?.type === "binary") {
-      return (
-        <div
-          className={cn("overflow-hidden overflow-y-auto w-full", className)}
-        >
-          Binary response
-        </div>
-      );
+      return <ResponseBodyBinary body={body} />;
     }
   }
 
@@ -393,6 +387,37 @@ function ResponseBody({
 
     return <ResponseBodyText body={body ?? ""} className={className} />;
   }
+}
+
+function ResponseBodyBinary({
+  body,
+  className,
+}: {
+  body: { contentType: string; type: "binary"; value: ArrayBuffer };
+  className?: string;
+}) {
+  const isImage = body.contentType.startsWith("image/");
+
+  if (isImage) {
+    const blob = new Blob([body.value], { type: body.contentType });
+    const imageUrl = URL.createObjectURL(blob);
+
+    return (
+      <div className={cn("overflow-hidden overflow-y-auto w-full", className)}>
+        <img
+          src={imageUrl}
+          alt="Response Image"
+          className="max-w-full h-auto"
+          onLoad={() => URL.revokeObjectURL(imageUrl)}
+        />
+      </div>
+    );
+  }
+  return (
+    <div className={cn("overflow-hidden overflow-y-auto w-full", className)}>
+      Binary response {body.contentType}
+    </div>
+  );
 }
 
 export function ResponseBodyText({

--- a/frontend/src/pages/RequestorPage/ResponsePanel.tsx
+++ b/frontend/src/pages/RequestorPage/ResponsePanel.tsx
@@ -318,7 +318,6 @@ function ResponseSummary({
   const method = isRequestorActiveResponse(response)
     ? response?.requestMethod
     : response?.app_requests?.requestMethod;
-  // const url = response?.app_requests?.requestUrl;
   const url = isRequestorActiveResponse(response)
     ? response?.requestUrl
     : parsePathFromRequestUrl(

--- a/frontend/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
+++ b/frontend/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
@@ -17,13 +17,13 @@ import { Method, StatusCode } from "../RequestorHistory";
 import { Requestornator } from "../queries";
 import { useCopyToClipboard, usePrompt } from "./ai-test-generation";
 
-export function AiTestGeneration({
+export function AiTestGenerationDrawer({
   history,
 }: {
-  history: Array<Requestornator>;
+  history: null | Array<Requestornator>;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
-  const lastRequest = history[0];
+  const lastRequest = history?.[0] ?? null;
 
   const [userInput, setUserInput] = useState("");
 
@@ -55,12 +55,14 @@ export function AiTestGeneration({
                 }
               />
             </div>
-            <div className="mt-2">
-              <div className="text-xs uppercase font-bold text-gray-400">
-                Additional context
+            {lastRequest && (
+              <div className="mt-2">
+                <div className="text-xs uppercase font-bold text-gray-400">
+                  Additional context
+                </div>
+                <ContextEntry response={lastRequest} />
               </div>
-              <ContextEntry response={lastRequest} />
-            </div>
+            )}
           </div>
           <DrawerFooter className="mt-4 flex flex-row justify-end px-2">
             <DrawerClose asChild>

--- a/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -29,8 +29,8 @@ export function AiTestGenerationPanel({
 
   const lastMatchingRequest = useMemo<Requestornator | null>(() => {
     const activeRoute = getActiveRoute();
+
     const match = history.find((response) => {
-      // FIXME
       const path = parsePathFromRequestUrl(response.app_requests?.requestUrl);
 
       if (path === null) {
@@ -44,7 +44,16 @@ export function AiTestGenerationPanel({
         activeRoute.requestType,
       );
 
-      return !!match;
+      if (match) {
+        return true;
+      }
+
+      // HACK - For requesets against non-detected routes, we can search for the exact request url...
+      if (response.app_requests?.requestUrl === activeRoute.path) {
+        return true;
+      }
+
+      return false;
     });
 
     return match ?? null;

--- a/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -18,10 +18,12 @@ export function AiTestGenerationPanel({
   history,
   toggleAiTestGenerationPanel,
   getActiveRoute,
+  removeServiceUrlFromPath,
 }: {
   history: Array<Requestornator>;
   toggleAiTestGenerationPanel: () => void;
   getActiveRoute: () => ProbedRoute;
+  removeServiceUrlFromPath: (path: string) => string;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
 
@@ -36,7 +38,7 @@ export function AiTestGenerationPanel({
 
       const match = findMatchedRoute(
         [activeRoute],
-        path,
+        removeServiceUrlFromPath(path),
         activeRoute.method,
         activeRoute.requestType,
       );

--- a/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/frontend/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -30,6 +30,7 @@ export function AiTestGenerationPanel({
   const lastMatchingRequest = useMemo<Requestornator | null>(() => {
     const activeRoute = getActiveRoute();
     const match = history.find((response) => {
+      // FIXME
       const path = parsePathFromRequestUrl(response.app_requests?.requestUrl);
 
       if (path === null) {
@@ -47,7 +48,7 @@ export function AiTestGenerationPanel({
     });
 
     return match ?? null;
-  }, [getActiveRoute, history]);
+  }, [getActiveRoute, history, removeServiceUrlFromPath]);
 
   const [userInput, setUserInput] = useState("");
 

--- a/frontend/src/pages/RequestorPage/ai/ai.ts
+++ b/frontend/src/pages/RequestorPage/ai/ai.ts
@@ -173,6 +173,7 @@ export function useAi(
     setRequestHeaders,
     updatePathParamValues,
     toast,
+    addServiceUrlIfBarePath,
   ]);
 
   return {

--- a/frontend/src/pages/RequestorPage/ai/ai.ts
+++ b/frontend/src/pages/RequestorPage/ai/ai.ts
@@ -21,6 +21,7 @@ type FormSetters = {
   setRequestHeaders: (params: KeyValueParameter[]) => void;
   setPath: (path: string) => void;
   updatePathParamValues: (pathParams: { key: string; value: string }[]) => void;
+  addServiceUrlIfBarePath: (path: string) => string;
 };
 
 export function useAi(
@@ -44,6 +45,7 @@ export function useAi(
     setPath,
     setRequestHeaders,
     updatePathParamValues,
+    addServiceUrlIfBarePath,
   } = formSetters;
 
   const bodyType = body.type;
@@ -144,7 +146,7 @@ export function useAi(
       //        meaning it needs to synchronize path params with the path.
       //        We tell it to do so, but if it makes a mistake, then things get confusing.
       if (path) {
-        setPath(path);
+        setPath(addServiceUrlIfBarePath(path));
       }
 
       // TODO - Validate path params

--- a/frontend/src/pages/RequestorPage/ai/index.ts
+++ b/frontend/src/pages/RequestorPage/ai/index.ts
@@ -1,4 +1,4 @@
 export { useAi, FRIENDLY, HOSTILE, type AiTestingPersona } from "./ai";
 export { useSummarizeError } from "./summarize-traces";
-export { AiTestGeneration } from "./AiTestGenerationDrawer";
+export { AiTestGenerationDrawer } from "./AiTestGenerationDrawer";
 export { AiTestGenerationPanel } from "./AiTestGenerationPanel";

--- a/frontend/src/pages/RequestorPage/ai/utils.ts
+++ b/frontend/src/pages/RequestorPage/ai/utils.ts
@@ -26,13 +26,18 @@ export function appRequestToHttpRequest(entry: Requestornator) {
     ? `${requestUrl}?${queryParams}`
     : requestUrl;
 
+  // HACK - Should we only do this for certain JSON content type? Or text?
+  let requestBody = entry.app_requests.requestBody;
+  if (requestBody && typeof requestBody === "object") {
+    requestBody = JSON.stringify(requestBody);
+  }
   // NOTE - Can we glean the http version somehow, somewhere?
   return [
     "<request>",
     `HTTP/1.1 ${entry.app_requests.requestMethod} ${requestUrlWithParams}`,
     ...Object.entries(requestHeaders).map(([key, value]) => `${key}: ${value}`),
     ``,
-    `${entry.app_requests.requestBody || ""}`,
+    `${requestBody || ""}`,
     "</request>",
   ].join("\n");
 }

--- a/frontend/src/pages/RequestorPage/queries.ts
+++ b/frontend/src/pages/RequestorPage/queries.ts
@@ -169,12 +169,12 @@ export function useMakeProxiedRequest({
       if (data) {
         setActiveResponse(data);
       } else {
-        console.error("No data returned from makeProxiedRequest");
+        console.error("No data returned from makeProxiedRequest - this should not happen!");
+        setActiveResponse(null);
       }
     },
     onError: () => {
       clearResponseBodyFromHistory();
-      // TODO - Clear active response
       setActiveResponse(null);
     },
   });

--- a/frontend/src/pages/RequestorPage/queries.ts
+++ b/frontend/src/pages/RequestorPage/queries.ts
@@ -165,15 +165,20 @@ export function useMakeProxiedRequest({
     onSuccess: (data) => {
       // Invalidate and refetch requestor requests
       queryClient.invalidateQueries({ queryKey: [REQUESTOR_REQUESTS_KEY] });
+
+      // Make sure the response panel is cleared of data, then add the new response
       clearResponseBodyFromHistory();
       if (data) {
         setActiveResponse(data);
       } else {
-        console.error("No data returned from makeProxiedRequest - this should not happen!");
+        console.error(
+          "No data returned from makeProxiedRequest - this should not happen!",
+        );
         setActiveResponse(null);
       }
     },
     onError: () => {
+      // Make sure the response panel is cleared of data
       clearResponseBodyFromHistory();
       setActiveResponse(null);
     },

--- a/frontend/src/pages/RequestorPage/queries.ts
+++ b/frontend/src/pages/RequestorPage/queries.ts
@@ -220,9 +220,11 @@ export function makeProxiedRequest({
   );
 
   // HACK - This is the most secure code I've ever written
+  //        We're serializing the proxy-to url into a header
+  //        and this is the url that ultimately receives the request
   modHeaders["x-fpx-proxy-to"] = addBaseUrl(path);
 
-  // HACK - Serialize headers into the headers
+  // HACK - Serialize headers into the headers waaaaat
   modHeaders["x-fpx-headers-json"] = JSON.stringify(modHeaders);
 
   // We resolve the url with query parameters
@@ -249,7 +251,7 @@ export function makeProxiedRequest({
       responseStatusCode: r.status.toString(),
       isFailure: responseBody.type === "error",
 
-      // Need these fields for UI
+      // NOTE - Need these fields for UI, to render the summary in the response panel
       requestUrl: addBaseUrl(resolvedPath),
       requestMethod: method,
     };

--- a/frontend/src/pages/RequestorPage/queries.ts
+++ b/frontend/src/pages/RequestorPage/queries.ts
@@ -188,7 +188,7 @@ export function useMakeProxiedRequest({
 }
 
 export function makeProxiedRequest({
-  addServiceUrlToPath,
+  addServiceUrlIfBarePath,
   path,
   method,
   body,
@@ -197,7 +197,7 @@ export function makeProxiedRequest({
   queryParams,
   route,
 }: {
-  addServiceUrlToPath: (path: string) => string;
+  addServiceUrlIfBarePath: (path: string) => string;
   path: string;
   method: string;
   body: RequestorBody;
@@ -236,7 +236,7 @@ export function makeProxiedRequest({
   // HACK - This is the most secure code I've ever written
   //        We're serializing the proxy-to url into a header
   //        and this is the url that ultimately receives the request
-  const proxyToUrl = addServiceUrlToPath(path);
+  const proxyToUrl = addServiceUrlIfBarePath(path);
   modHeaders["x-fpx-proxy-to"] = proxyToUrl;
 
   // HACK - Serialize headers into the headers waaaaat

--- a/frontend/src/pages/RequestorPage/reducer/index.ts
+++ b/frontend/src/pages/RequestorPage/reducer/index.ts
@@ -1,3 +1,8 @@
 export { useRequestor } from "./reducer";
 export type { ResponsePanelTab, RequestsPanelTab } from "./tabs";
-export type { RequestBodyType, RequestorBody, RequestorState } from "./state";
+export type {
+  RequestBodyType,
+  RequestorBody,
+  RequestorResponseBody,
+  RequestorState,
+} from "./state";

--- a/frontend/src/pages/RequestorPage/reducer/persistence.ts
+++ b/frontend/src/pages/RequestorPage/reducer/persistence.ts
@@ -1,54 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useBeforeUnload } from "react-router-dom";
-import { z } from "zod";
-import { RequestorStateSchema } from "./state";
-
-/**
- * A subset of the RequestorState that is saved to local storage.
- * We don't save things like `routes` since that could be crufty,
- * and will be refetched when the page reloads anyhow
- */
-const SavedRequestorStateSchema = RequestorStateSchema.pick({
-  path: true,
-  method: true,
-  requestType: true,
-  pathParams: true,
-  queryParams: true,
-  requestHeaders: true,
-  body: true,
-});
-
-type SavedRequestorState = z.infer<typeof SavedRequestorStateSchema>;
-
-const isSavedRequestorState = (
-  state: unknown,
-): state is SavedRequestorState => {
-  const result = SavedRequestorStateSchema.safeParse(state);
-  if (!result.success) {
-    console.error(
-      "SavedRequestorState validation failed:",
-      result.error.format(),
-    );
-  }
-  return result.success;
-};
-
-export function loadUiStateFromLocalStorage(): SavedRequestorState | null {
-  const possibleUiState = localStorage.getItem("requestorUiState");
-  if (!possibleUiState) {
-    return null;
-  }
-
-  try {
-    const uiState = JSON.parse(possibleUiState);
-    if (isSavedRequestorState(uiState)) {
-      return uiState;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
+import { LOCAL_STORAGE_KEY, SavedRequestorState } from "./state";
 
 /**
  * Hook that saves the UI state to local storage when the component unmounts,
@@ -66,10 +18,7 @@ export function useSaveUiState(state: SavedRequestorState) {
 
   const saveUiState = useCallback(() => {
     try {
-      localStorage.setItem(
-        "requestorUiState",
-        JSON.stringify(stateRef.current),
-      );
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(stateRef.current));
     } catch {
       // Ignore errors
       console.error("Error saving state to local storage");
@@ -87,7 +36,7 @@ export function useSaveUiState(state: SavedRequestorState) {
   useBeforeUnload(
     useCallback(() => {
       // NOTE - `removeItem` doesn't throw errors, so we don't need a try-catch
-      localStorage?.removeItem?.("requestorUiState");
+      localStorage?.removeItem?.(LOCAL_STORAGE_KEY);
     }, []),
   );
 }

--- a/frontend/src/pages/RequestorPage/reducer/persistence.ts
+++ b/frontend/src/pages/RequestorPage/reducer/persistence.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useBeforeUnload } from "react-router-dom";
-import { LOCAL_STORAGE_KEY, SavedRequestorState } from "./state";
+import {
+  LOCAL_STORAGE_KEY,
+  SavedRequestorState,
+  SavedRequestorStateSchema,
+} from "./state";
 
 /**
  * Hook that saves the UI state to local storage when the component unmounts,
@@ -18,7 +22,8 @@ export function useSaveUiState(state: SavedRequestorState) {
 
   const saveUiState = useCallback(() => {
     try {
-      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(stateRef.current));
+      const state = SavedRequestorStateSchema.parse(stateRef.current);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
     } catch {
       // Ignore errors
       console.error("Error saving state to local storage");

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -8,6 +8,7 @@ import { RequestMethod, RequestMethodInputValue, RequestType } from "../types";
 import { useSaveUiState } from "./persistence";
 import {
   RequestBodyType,
+  RequestorActiveResponse,
   RequestorBody,
   type RequestorState,
   createInitialState,
@@ -52,6 +53,7 @@ const SET_BODY_TYPE = "SET_BODY_TYPE" as const;
 const SET_WEBSOCKET_MESSAGE = "SET_WEBSOCKET_MESSAGE" as const;
 const LOAD_HISTORICAL_REQUEST = "LOAD_HISTORICAL_REQUEST" as const;
 const CLEAR_HISTORICAL_REQUEST = "CLEAR_HISTORICAL_REQUEST" as const;
+const SET_ACTIVE_RESPONSE = "SET_ACTIVE_RESPONSE" as const;
 const SET_ACTIVE_REQUESTS_PANEL_TAB = "SET_ACTIVE_REQUESTS_PANEL_TAB" as const;
 const SET_ACTIVE_RESPONSE_PANEL_TAB = "SET_ACTIVE_RESPONSE_PANEL_TAB" as const;
 
@@ -121,6 +123,10 @@ type RequestorAction =
     }
   | {
       type: typeof CLEAR_HISTORICAL_REQUEST;
+    }
+  | {
+      type: typeof SET_ACTIVE_RESPONSE;
+      payload: RequestorActiveResponse | null;
     }
   | {
       type: typeof SET_ACTIVE_REQUESTS_PANEL_TAB;
@@ -306,6 +312,8 @@ function requestorReducer(
 
         // HACK - This allows us to stop showing the response body for a historical request
         activeHistoryResponseTraceId: null,
+
+        activeResponse: null,
       };
     }
     case SET_PATH_PARAMS: {
@@ -430,6 +438,9 @@ function requestorReducer(
     }
     case CLEAR_HISTORICAL_REQUEST: {
       return { ...state, activeHistoryResponseTraceId: null };
+    }
+    case SET_ACTIVE_RESPONSE: {
+      return { ...state, activeResponse: action.payload };
     }
     case SET_ACTIVE_REQUESTS_PANEL_TAB: {
       return { ...state, activeRequestsPanelTab: action.payload };
@@ -638,6 +649,13 @@ export function useRequestor() {
     [state.visibleResponsePanelTabs],
   );
 
+  const setActiveResponse = useCallback(
+    (response: RequestorActiveResponse | null) => {
+      dispatch({ type: SET_ACTIVE_RESPONSE, payload: response });
+    },
+    [dispatch],
+  );
+
   return {
     state,
     dispatch,
@@ -667,6 +685,9 @@ export function useRequestor() {
     // Response Panel tabs
     setActiveResponsePanelTab,
     shouldShowResponseTab,
+
+    // Response Panel response body
+    setActiveResponse,
 
     // Selectors
     getActiveRoute,

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -453,7 +453,11 @@ function requestorReducer(
       return { ...state, websocketMessage: action.payload };
     }
     case LOAD_HISTORICAL_REQUEST: {
-      return { ...state, activeHistoryResponseTraceId: action.payload.traceId };
+      return {
+        ...state,
+        activeHistoryResponseTraceId: action.payload.traceId,
+        activeResponse: null,
+      };
     }
     case CLEAR_HISTORICAL_REQUEST: {
       return { ...state, activeHistoryResponseTraceId: null };

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -695,6 +695,11 @@ export function useRequestor() {
     [state.visibleResponsePanelTabs],
   );
 
+  /**
+   * Sets the active response in the response panel
+   * This refers to the ACTUAL response body returned through our proxy,
+   * which allows us to show things like binary data in the response panel
+   */
   const setActiveResponse = useCallback(
     (response: RequestorActiveResponse | null) => {
       dispatch({ type: SET_ACTIVE_RESPONSE, payload: response });

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -280,7 +280,7 @@ function requestorReducer(
       if (didSelectedRouteChange && isDebugTabCurrentlySelected) {
         // If the selected route changed and the debug tab is selected,
         // we want to switch to the "body" tab
-        nextActiveResponsePanelTab = "body";
+        nextActiveResponsePanelTab = "response";
       }
 
       return {

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -652,6 +652,10 @@ export function useRequestor() {
    */
   const getActiveRoute = (): ProbedRoute => _getActiveRoute(state);
 
+  /**
+   * Helper that removes the service url from a path,
+   * otherwise it returns the path unchanged
+   */
   const removeServiceUrlFromPath = useCallback(
     (path: string) => {
       return removeBaseUrl(state.serviceBaseUrl, path);
@@ -659,7 +663,10 @@ export function useRequestor() {
     [state.serviceBaseUrl],
   );
 
-  const addServiceUrlToPath = useCallback(
+  /**
+   * Helper that adds the service url to a path if it doesn't already have a host
+   */
+  const addServiceUrlIfBarePath = useCallback(
     (path: string) => {
       return addBaseUrl(state.serviceBaseUrl, path, {
         requestType: state.requestType,
@@ -726,7 +733,7 @@ export function useRequestor() {
     setRequestHeaders,
     setBody,
     handleRequestBodyTypeChange,
-    addServiceUrlToPath,
+    addServiceUrlIfBarePath,
     removeServiceUrlFromPath,
 
     // Websocket form

--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -174,7 +174,11 @@ function requestorReducer(
       };
     }
     case SET_SERVICE_BASE_URL: {
-      return { ...state, serviceBaseUrl: action.payload };
+      return {
+        ...state,
+        serviceBaseUrl: action.payload,
+        path: addBaseUrl(action.payload, state.path),
+      };
     }
     case PATH_UPDATE: {
       const nextPath = action.payload;

--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -130,6 +130,7 @@ export const initialState: RequestorState = {
   routes: [],
   selectedRoute: null,
   path: "/",
+  serviceBaseUrl: "http://localhost:8787",
   method: "GET",
   requestType: "http",
 

--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -53,7 +53,7 @@ const RequestorActiveResponseSchema = z.object({
   responseBody: RequestorResponseBodySchema,
   responseHeaders: z.record(z.string()).nullable(),
   responseStatusCode: z.string(),
-  isFailure: z.boolean().nullable(),
+  isFailure: z.boolean(),
 
   requestUrl: z.string(),
   requestMethod: z.string(),

--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -145,8 +145,8 @@ export const initialState: RequestorState = {
   activeRequestsPanelTab: "params",
   visibleRequestsPanelTabs: ["params", "headers"],
 
-  activeResponsePanelTab: "body",
-  visibleResponsePanelTabs: ["body", "headers", "debug", "history"],
+  activeResponsePanelTab: "response",
+  visibleResponsePanelTabs: ["response", "debug"],
 
   // HACK - This is used to force us to show a response body for a request loaded from history
   activeHistoryResponseTraceId: null,

--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -168,7 +168,7 @@ export const createInitialState = (initial: RequestorState) => {
  * We don't save things like `routes` since that could be crufty,
  * and will be refetched when the page reloads anyhow
  */
-const SavedRequestorStateSchema = RequestorStateSchema.pick({
+export const SavedRequestorStateSchema = RequestorStateSchema.pick({
   path: true,
   method: true,
   requestType: true,

--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -76,6 +76,7 @@ export const RequestorStateSchema = z.object({
   ),
 
   // Request form
+  serviceBaseUrl: z.string().describe("Base URL for requests"),
   path: z.string().describe("Path input"),
   method: RequestMethodSchema.describe("Method input"),
   requestType: RequestTypeSchema.describe("Request type input"),

--- a/frontend/src/pages/RequestorPage/reducer/tabs.ts
+++ b/frontend/src/pages/RequestorPage/reducer/tabs.ts
@@ -27,13 +27,7 @@ export const getVisibleRequestPanelTabs = (route: {
   return ["params", "headers", "body"];
 };
 
-export const ResponsePanelTabSchema = z.enum([
-  "body",
-  "headers",
-  "messages",
-  "debug",
-  "history",
-]);
+export const ResponsePanelTabSchema = z.enum(["response", "messages", "debug"]);
 
 export type ResponsePanelTab = z.infer<typeof ResponsePanelTabSchema>;
 
@@ -45,7 +39,7 @@ export const getVisibleResponsePanelTabs = (route: {
   requestType: RequestType;
 }): ResponsePanelTab[] => {
   if (route.requestType === "websocket") {
-    return ["body", "headers", "messages", "debug", "history"];
+    return ["response", "messages", "debug"];
   }
-  return ["body", "headers", "debug", "history"];
+  return ["response", "debug"];
 };

--- a/frontend/src/pages/RequestorPage/routes/hooks.ts
+++ b/frontend/src/pages/RequestorPage/routes/hooks.ts
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { ProbedRoute, useProbedRoutes } from "../queries";
-import { RequestType, isWsRequest } from "../types";
 import { WEBSOCKETS_ENABLED } from "../webSocketFeatureFlag";
 
 type UseRoutesOptions = {

--- a/frontend/src/pages/RequestorPage/routes/hooks.ts
+++ b/frontend/src/pages/RequestorPage/routes/hooks.ts
@@ -5,6 +5,7 @@ import { WEBSOCKETS_ENABLED } from "../webSocketFeatureFlag";
 
 type UseRoutesOptions = {
   setRoutes: (routes: ProbedRoute[]) => void;
+  setServiceBaseUrl: (serviceBaseUrl: string) => void;
 };
 
 /**
@@ -41,7 +42,7 @@ const filterRoutes = (routes: ProbedRoute[]) => {
   });
 };
 
-export function useRoutes({ setRoutes }: UseRoutesOptions) {
+export function useRoutes({ setRoutes, setServiceBaseUrl }: UseRoutesOptions) {
   const { data: routesAndMiddleware, isLoading, isError } = useProbedRoutes();
   const routes = useMemo(() => {
     const routes = filterRoutes(routesAndMiddleware?.routes ?? []);
@@ -57,40 +58,23 @@ export function useRoutes({ setRoutes }: UseRoutesOptions) {
     );
   }, [routesAndMiddleware]);
 
+  // HACK - Antipattern, add serviceBaseUrl to the reducer based off of external changes
+  // HACK - Defaults to localhost:8787 if not set
+  const serviceBaseUrl =
+    routesAndMiddleware?.baseUrl ?? "http://localhost:8787";
+  useEffect(() => {
+    setServiceBaseUrl(serviceBaseUrl);
+  }, [serviceBaseUrl, setServiceBaseUrl]);
+
   // HACK - Antipattern, add routes to the reducer based off of external changes
   // NOTE - This will only add routes if they don't exist
   useEffect(() => {
     setRoutes(routes);
   }, [routes, setRoutes]);
 
-  // TODO - Support swapping out base url in UI,
-  //        right now you can only change it by modifying FPX_SERVICE_TARGET in the API
-  const addBaseUrl = useCallback(
-    (
-      path: string,
-      { requestType }: { requestType: RequestType } = { requestType: "http" },
-    ) => {
-      const baseUrl = routesAndMiddleware?.baseUrl ?? "http://localhost:8787";
-      const parsedBaseUrl = new URL(baseUrl);
-      if (isWsRequest(requestType)) {
-        parsedBaseUrl.protocol = "ws";
-      }
-      let updatedBaseUrl = parsedBaseUrl.toString();
-      if (updatedBaseUrl.endsWith("/")) {
-        updatedBaseUrl = updatedBaseUrl.slice(0, -1);
-      }
-      if (path?.startsWith(updatedBaseUrl)) {
-        return path;
-      }
-      return `${updatedBaseUrl}${path}`;
-    },
-    [routesAndMiddleware],
-  );
-
   return {
     isError,
     isLoading,
     routes,
-    addBaseUrl,
   };
 }

--- a/frontend/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorHistory.ts
@@ -1,4 +1,3 @@
-import { parsePathFromRequestUrl } from "@/utils";
 import { useMemo } from "react";
 import { KeyValueParameter, createKeyValueParameters } from "./KeyValueForm";
 import { useSessionHistory } from "./RequestorSessionHistoryContext";

--- a/frontend/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorHistory.ts
@@ -84,8 +84,7 @@ export function useRequestorHistory({
         handleSelectRoute(matchedRoute.route, pathParams);
 
         // Reset the path to the *exact* path of the request, instead of the route pattern
-        const path =
-          parsePathFromRequestUrl(match.app_requests.requestUrl) ?? "";
+        const path = match.app_requests.requestUrl ?? "";
         setPath(path);
 
         const headers = match.app_requests.requestHeaders ?? {};
@@ -124,8 +123,7 @@ export function useRequestorHistory({
       } else {
         // HACK - move this logic into the reducer
         // Reset the path to the *exact* path of the request, instead of the route pattern
-        const path =
-          parsePathFromRequestUrl(match.app_requests.requestUrl) ?? "";
+        const path = match.app_requests.requestUrl ?? "";
         setPath(path);
 
         const requestType = match.app_requests.requestUrl.startsWith("ws")

--- a/frontend/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -10,7 +10,7 @@ export function useRequestorSubmitHandler({
   selectedRoute,
   body,
   path,
-  addServiceUrlToPath,
+  addServiceUrlIfBarePath,
   method,
   pathParams,
   queryParams,
@@ -19,7 +19,9 @@ export function useRequestorSubmitHandler({
   connectWebsocket,
   recordRequestInSessionHistory,
 }: {
-  addServiceUrlToPath: ReturnType<typeof useRequestor>["addServiceUrlToPath"];
+  addServiceUrlIfBarePath: ReturnType<
+    typeof useRequestor
+  >["addServiceUrlIfBarePath"];
   selectedRoute: ProbedRoute | null;
   body: RequestorBody;
   path: string;
@@ -38,7 +40,7 @@ export function useRequestorSubmitHandler({
       e.preventDefault();
 
       if (isWsRequest(requestType)) {
-        const url = addServiceUrlToPath(path);
+        const url = addServiceUrlIfBarePath(path);
         connectWebsocket(url);
         toast({
           description: "Connecting to websocket",
@@ -71,7 +73,7 @@ export function useRequestorSubmitHandler({
 
       // TODO - Check me
       if (isWsRequest(requestType)) {
-        const url = addServiceUrlToPath(path);
+        const url = addServiceUrlIfBarePath(path);
         connectWebsocket(url);
         toast({
           description: "Connecting to websocket",
@@ -81,7 +83,7 @@ export function useRequestorSubmitHandler({
 
       makeRequest(
         {
-          addServiceUrlToPath,
+          addServiceUrlIfBarePath,
           path,
           method,
           body,
@@ -114,7 +116,7 @@ export function useRequestorSubmitHandler({
       body,
       requestHeaders,
       makeRequest,
-      addServiceUrlToPath,
+      addServiceUrlIfBarePath,
       path,
       method,
       pathParams,

--- a/frontend/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -2,8 +2,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { useCallback } from "react";
 import { KeyValueParameter } from "./KeyValueForm";
 import { MakeProxiedRequestQueryFn, ProbedRoute } from "./queries";
-import { RequestorBody, RequestorState } from "./reducer";
-import { useRoutes } from "./routes";
+import { RequestorBody, RequestorState, useRequestor } from "./reducer";
 import { isWsRequest } from "./types";
 
 export function useRequestorSubmitHandler({
@@ -11,7 +10,7 @@ export function useRequestorSubmitHandler({
   selectedRoute,
   body,
   path,
-  addBaseUrl,
+  addServiceUrlToPath,
   method,
   pathParams,
   queryParams,
@@ -20,7 +19,7 @@ export function useRequestorSubmitHandler({
   connectWebsocket,
   recordRequestInSessionHistory,
 }: {
-  addBaseUrl: ReturnType<typeof useRoutes>["addBaseUrl"];
+  addServiceUrlToPath: ReturnType<typeof useRequestor>["addServiceUrlToPath"];
   selectedRoute: ProbedRoute | null;
   body: RequestorBody;
   path: string;
@@ -39,9 +38,7 @@ export function useRequestorSubmitHandler({
       e.preventDefault();
 
       if (isWsRequest(requestType)) {
-        const url = addBaseUrl(path, {
-          requestType,
-        });
+        const url = addServiceUrlToPath(path);
         connectWebsocket(url);
         toast({
           description: "Connecting to websocket",
@@ -74,9 +71,7 @@ export function useRequestorSubmitHandler({
 
       // TODO - Check me
       if (isWsRequest(requestType)) {
-        const url = addBaseUrl(path, {
-          requestType: requestType,
-        });
+        const url = addServiceUrlToPath(path);
         connectWebsocket(url);
         toast({
           description: "Connecting to websocket",
@@ -86,7 +81,7 @@ export function useRequestorSubmitHandler({
 
       makeRequest(
         {
-          addBaseUrl,
+          addServiceUrlToPath,
           path,
           method,
           body,
@@ -119,7 +114,7 @@ export function useRequestorSubmitHandler({
       body,
       requestHeaders,
       makeRequest,
-      addBaseUrl,
+      addServiceUrlToPath,
       path,
       method,
       pathParams,

--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-beta.1",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/packages/client-library-otel/src/utils/request.ts
+++ b/packages/client-library-otel/src/utils/request.ts
@@ -192,6 +192,40 @@ function formDataValueToString(value: string | File) {
 async function tryGetResponseBodyAsText(
   response: GlobalResponse | WorkerResponse,
 ) {
+  const contentType = response.headers.get("content-type");
+  if (contentType?.includes("image/")) {
+    return "#fpx.image";
+  }
+  if (contentType?.includes("application/pdf")) {
+    return "#fpx.pdf";
+  }
+  if (contentType?.includes("application/zip")) {
+    return "#fpx.zip";
+  }
+  if (contentType?.includes("audio/")) {
+    return "#fpx.audio";
+  }
+  if (contentType?.includes("video/")) {
+    return "#fpx.video";
+  }
+  if (
+    contentType?.includes("application/octet-stream") ||
+    contentType?.includes("application/vnd.ms-excel") ||
+    contentType?.includes(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ) ||
+    contentType?.includes("application/vnd.ms-powerpoint") ||
+    contentType?.includes(
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ) ||
+    contentType?.includes("application/msword") ||
+    contentType?.includes(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+  ) {
+    return "#fpx.binary";
+  }
+
   try {
     return await response.text();
   } catch {


### PR DESCRIPTION
Summary:

- Render response AS-IS (when we can) for requests made through requestor
  - For binary responses, we only handle images right now
  
- Allow requests to services other than the target service for FPX
  - This required A TON of changes since it broke a fundamental assumption of the UI, that you're only testing your service

- Simplify `RequestorInput` to be fully controlled by the `path` state inside the main Requestor reducer
  - This required reconfiguring how we automagically add the service baseUrl to requests, as well as how we match history entries to the form input fields

- Remove the `Headers` tab from the response panel and put headers as a collapsed bit above the response body

***

To test:

- Go through your usual flow, make sure nothing broke
- Make requests to a non-monitored service, and make sure the responses render as expected
- Try loading entries from history
- Try filling in request parameters, generating a prompt for testing, etc