### PR TITLE
Fix storing a span that does not have a parent_span

### DIFF
--- a/fpx-workers/src/data.rs
+++ b/fpx-workers/src/data.rs
@@ -111,6 +111,11 @@ impl Store for D1Store {
         span: models::Span,
     ) -> Result<models::Span, DbError> {
         SendFuture::new(async {
+            let parent_span = match span.parent_span_id {
+                Some(val) => val.into(),
+                None => JsValue::null(),
+            };
+
             self.fetch_one(
                 "INSERT INTO spans
                     (
@@ -129,7 +134,7 @@ impl Store for D1Store {
                 &[
                     span.trace_id.into(),
                     span.span_id.into(),
-                    span.parent_span_id.unwrap_or_default().into(),
+                    parent_span,
                     span.name.into(),
                     span.kind.into(),
                     span.start_time.into(),

--- a/scripts/otel_collector/config.yaml
+++ b/scripts/otel_collector/config.yaml
@@ -13,6 +13,11 @@ exporters:
     encoding: json
     compression: none
 
+  otlphttp/fpx-workers:
+    endpoint: http://localhost:8787
+    encoding: json
+    compression: none
+
   otlp:
     endpoint: http://localhost:4567
     tls:
@@ -25,7 +30,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [debug, otlphttp]
+      exporters: [debug, otlphttp/fpx-workers]
 
   telemetry:
     logs:


### PR DESCRIPTION
Previously this was fixed by just storing a empty string, now it will be stored as a null value. By default Option::None get serialized as undefined, which was an issue for D1

Also add a fpx-workers exporter to the otel_collector

Resolves: FP-3973
