### PR TITLE
Quickfix: Adding path parameters shouldn't remove the host from the url input field on requestor

### DIFF
--- a/frontend/src/pages/RequestorPage/reducer/reducer.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducer.ts
@@ -348,7 +348,7 @@ function requestorReducer(
       }, state.selectedRoute?.path ?? state.path);
       return {
         ...state,
-        path: nextPath,
+        path: addBaseUrl(state.serviceBaseUrl, nextPath),
         pathParams: action.payload,
       };
     }


### PR DESCRIPTION
title says it all - quickfix