### PR TITLE
Add request headers to root request when present on the request object

### DIFF
--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.3",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/packages/client-library-otel/src/utils/request.ts
+++ b/packages/client-library-otel/src/utils/request.ts
@@ -56,12 +56,12 @@ export async function getRootRequestAttributes(request: Request, env: unknown) {
         ...bodyAttr,
       };
     }
+  }
 
-    if (request.headers) {
-      const headers = headersToObject(new Headers(request.headers));
-      for (const [key, value] of Object.entries(headers)) {
-        attributes[`http.request.header.${key}`] = value;
-      }
+  if (request.headers) {
+    const headers = headersToObject(new Headers(request.headers));
+    for (const [key, value] of Object.entries(headers)) {
+      attributes[`http.request.header.${key}`] = value;
     }
   }
 


### PR DESCRIPTION
Tested locally and with `0.1.0-beta.3` of the otel client middleware