### PR TITLE
Add tsc-alias

### DIFF
--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -24,6 +24,7 @@
     "hono": "^4.3.9",
     "nodemon": "^3.1.4",
     "rimraf": "^6.0.1",
+    "tsc-alias": "^1.8.10",
     "typescript": "^5.4.5"
   },
   "publishConfig": {
@@ -42,8 +43,9 @@
     "format": "biome check . --write",
     "lint": "biome lint .",
     "typecheck": "tsc --noEmit",
-    "build": "pnpm run clean && npm run build:types && pnpm run build:swc",
-    "build:types": "tsc --project tsconfig.json --emitDeclarationOnly",
+    "build": "pnpm run clean && npm run build:types && pnpm run build:swc && pnpm run build:alias",
+    "build:types": "tsc --project tsconfig.json",
+    "build:alias": "tsc-alias -p tsconfig.json -f",
     "build:swc": "cd src && swc . -d ../dist --source-maps",
     "dev": "wrangler dev sample/index.ts",
     "prepublishOnly": "pnpm run build",

--- a/packages/client-library-otel/src/patch/fetch.ts
+++ b/packages/client-library-otel/src/patch/fetch.ts
@@ -1,11 +1,13 @@
 import { SpanKind } from "@opentelemetry/api";
-import { wrap } from "shimmer";
+import shimmer from "shimmer";
 import { measure } from "../measure";
 import {
   getRequestAttributes,
   getResponseAttributes,
   isWrapped,
 } from "../utils";
+
+const { wrap } = shimmer;
 
 export function patchFetch() {
   // Check if the function is already patched

--- a/packages/client-library-otel/src/patch/log.ts
+++ b/packages/client-library-otel/src/patch/log.ts
@@ -1,5 +1,5 @@
 import { trace } from "@opentelemetry/api";
-import { wrap } from "shimmer";
+import shimmer from "shimmer";
 import {
   errorToJson,
   isLikelyNeonDbError,
@@ -7,6 +7,8 @@ import {
   neonDbErrorToJson,
   safelySerializeJSON,
 } from "../utils";
+
+const { wrap } = shimmer;
 
 type DEBUG = "debug";
 type LOG = "log";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
+      tsc-alias:
+        specifier: ^1.8.10
+        version: 1.8.10
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
@@ -5333,6 +5336,10 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mylas@2.1.13:
+    resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
+    engines: {node: '>=12.0.0'}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -5701,6 +5708,10 @@ packages:
   pkg-types@1.1.3:
     resolution: {integrity: sha512-+JrgthZG6m3ckicaOB74TwQ+tBWsFl3qVQg7mN8ulwSOElJ7gBhKzj2VkCPnZ4NlF6kEquYU+RIYNVAvzd54UA==}
 
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -5809,6 +5820,10 @@ packages:
   query-string@9.1.0:
     resolution: {integrity: sha512-t6dqMECpCkqfyv2FfwVS1xcB6lgXW/0XZSaKdsCNGYkqMO76AFiJEg4vINzoDKcZa6MS7JX+OHIjwh06K5vczw==}
     engines: {node: '>=18'}
+
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -6523,6 +6538,10 @@ packages:
 
   ts-to-zod@3.10.0:
     resolution: {integrity: sha512-2ROmyoKNKUIyJf9IPXK2yYNllnoON250DkYEbqkdmy2zBgn3qALZlhTbe9rzdd/t4nj2JTIoTQbfwVdt2pWA2A==}
+    hasBin: true
+
+  tsc-alias@1.8.10:
+    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
     hasBin: true
 
   tsconfck@3.1.1:
@@ -12369,6 +12388,8 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mylas@2.1.13: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -12760,6 +12781,10 @@ snapshots:
       mlly: 1.7.1
       pathe: 1.1.2
 
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
+
   postcss-import@15.1.0(postcss@8.4.41):
     dependencies:
       postcss: 8.4.41
@@ -12889,6 +12914,8 @@ snapshots:
       decode-uri-component: 0.4.1
       filter-obj: 5.1.0
       split-on-first: 3.0.0
+
+  queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
 
@@ -13749,6 +13776,15 @@ snapshots:
       zod: 3.23.8
     transitivePeerDependencies:
       - supports-color
+
+  tsc-alias@1.8.10:
+    dependencies:
+      chokidar: 3.6.0
+      commander: 9.5.0
+      globby: 11.1.0
+      mylas: 2.1.13
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
 
   tsconfck@3.1.1(typescript@5.5.4):
     optionalDependencies:


### PR DESCRIPTION
This updates the imports in the compiled code to include extensions

So for instance `dist/index.js` for the otel library changes from:

``` js
export { instrument } from "./instrumentation";
export { measure } from "./measure";

//# sourceMappingURL=index.js.map% 
```
to:

``` js
export { instrument } from "./instrumentation.js";
export { measure } from "./measure.js";

//# sourceMappingURL=index.js.map%  
```