### PR TITLE
Fix issue where body tab was not visible on POST requests in requestor

### DIFF
--- a/frontend/src/pages/RequestorPage/reducer/state.ts
+++ b/frontend/src/pages/RequestorPage/reducer/state.ts
@@ -178,6 +178,10 @@ export const SavedRequestorStateSchema = RequestorStateSchema.pick({
   queryParams: true,
   requestHeaders: true,
   body: true,
+  activeRequestsPanelTab: true,
+  visibleRequestsPanelTabs: true,
+  activeResponsePanelTab: true,
+  visibleResponsePanelTabs: true,
 });
 
 export type SavedRequestorState = z.infer<typeof SavedRequestorStateSchema>;


### PR DESCRIPTION
We have some local persistence of the UI state, but needed to include the active / visible tabs in the Request and Response panels