### PR TITLE
Allow compression to be disabled

### DIFF
--- a/fpx-lib/src/api.rs
+++ b/fpx-lib/src/api.rs
@@ -29,15 +29,14 @@ impl FromRef<ApiState> for Service {
     }
 }
 
+#[derive(Default)]
 pub struct Builder {
     enable_compression: bool,
 }
 
 impl Builder {
     pub fn new() -> Self {
-        Self {
-            enable_compression: false,
-        }
+        Self::default()
     }
 
     pub fn set_compression(mut self, compression: bool) -> Self {

--- a/fpx-lib/src/api.rs
+++ b/fpx-lib/src/api.rs
@@ -4,7 +4,6 @@ use crate::service::Service;
 use axum::extract::FromRef;
 use axum::routing::{get, post};
 use http::StatusCode;
-use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
 use tower_http::decompression::RequestDecompressionLayer;
 
@@ -30,31 +29,54 @@ impl FromRef<ApiState> for Service {
     }
 }
 
-/// Create a API and expose it through a axum router.
-pub fn create_api(service: Service, store: BoxedStore) -> axum::Router {
-    let api_state = ApiState { service, store };
+pub struct Builder {
+    enable_compression: bool,
+}
 
-    axum::Router::new()
-        .route("/v1/traces", post(handlers::otel::trace_collector_handler))
-        .route(
-            "/api/traces/:trace_id/spans/:span_id",
-            get(handlers::spans::span_get_handler),
-        )
-        .route(
-            "/api/traces/:trace_id/spans",
-            get(handlers::spans::span_list_handler),
-        )
-        .route(
-            "/api/traces/:trace_id",
-            get(handlers::traces::traces_get_handler),
-        )
-        .route("/api/traces", get(handlers::traces::traces_list_handler))
-        .with_state(api_state)
-        .fallback(StatusCode::NOT_FOUND)
-        .layer(OtelTraceLayer::default()) // Note: We cannot add this to the ServiceBuilder below, due to type issues.
-        .layer(
-            ServiceBuilder::new()
-                .layer(RequestDecompressionLayer::new())
-                .layer(CompressionLayer::new()),
-        )
+impl Builder {
+    pub fn new() -> Self {
+        Self {
+            enable_compression: false,
+        }
+    }
+
+    pub fn set_compression(mut self, compression: bool) -> Self {
+        self.enable_compression = compression;
+        self
+    }
+
+    pub fn enable_compression(self) -> Self {
+        self.set_compression(true)
+    }
+
+    /// Create a API and expose it through a axum router.
+    pub fn build(self, service: Service, store: BoxedStore) -> axum::Router {
+        let api_state = ApiState { service, store };
+
+        let router = axum::Router::new()
+            .route("/v1/traces", post(handlers::otel::trace_collector_handler))
+            .route(
+                "/api/traces/:trace_id/spans/:span_id",
+                get(handlers::spans::span_get_handler),
+            )
+            .route(
+                "/api/traces/:trace_id/spans",
+                get(handlers::spans::span_list_handler),
+            )
+            .route(
+                "/api/traces/:trace_id",
+                get(handlers::traces::traces_get_handler),
+            )
+            .route("/api/traces", get(handlers::traces::traces_list_handler))
+            .with_state(api_state)
+            .fallback(StatusCode::NOT_FOUND)
+            .layer(OtelTraceLayer::default())
+            .layer(RequestDecompressionLayer::new());
+
+        if self.enable_compression {
+            router.layer(CompressionLayer::new())
+        } else {
+            router
+        }
+    }
 }

--- a/fpx-lib/src/data/sql.rs
+++ b/fpx-lib/src/data/sql.rs
@@ -14,11 +14,12 @@
 /// the sqlite dialect. We might also be able to support configurable table
 /// names. For this reason all functions have a reference to `self` and all
 /// return a owned string.
+#[derive(Default)]
 pub struct SqlBuilder {}
 
 impl SqlBuilder {
     pub fn new() -> Self {
-        Self {}
+        Self::default()
     }
 
     /// Retrieve a single span by trace_id and span_id.

--- a/fpx-workers/src/lib.rs
+++ b/fpx-workers/src/lib.rs
@@ -53,7 +53,7 @@ async fn fetch(
     let boxed_store = Arc::new(store);
 
     let service = service::Service::new(boxed_store.clone(), boxed_events.clone());
-    let api_router = api::create_api(service, boxed_store);
+    let api_router = api::Builder::new().build(service, boxed_store);
 
     let mut router: axum::Router = axum::Router::new()
         .route("/api/ws", get(ws_connect))

--- a/fpx/src/commands/dev.rs
+++ b/fpx/src/commands/dev.rs
@@ -51,7 +51,9 @@ pub async fn handle_command(args: Args) -> Result<()> {
 
     let service = service::Service::new(store.clone(), events.clone());
 
-    let app = api::create_api(service.clone(), store.clone());
+    let app = api::Builder::new()
+        .enable_compression()
+        .build(service.clone(), store.clone());
     let grpc_service = GrpcService::new(service);
 
     let listener = tokio::net::TcpListener::bind(&args.listen_address)


### PR DESCRIPTION
The wrangler environment already takes care of this, so if we do it in our app then we potentially compress it twice, and thus the client would only see a compressed payload and not the JSON payload
