### PR TITLE
Update content-type headers dynamically when you change body types

### DIFF
--- a/frontend/src/pages/RequestorPage/reducer/content-type.ts
+++ b/frontend/src/pages/RequestorPage/reducer/content-type.ts
@@ -5,6 +5,21 @@ import {
 import { isDraftParameter } from "../KeyValueForm/data";
 import { RequestorBody, RequestorState } from "./state";
 
+/**
+ * This makes sure to synchronize the content type header with the body type.
+ * But there are a few caveats!
+ *
+ * - If the body is a multipart form, we don't want to add the content type header
+ *   We only want to remove the content type header if it's set to text/* or application/json
+ *
+ * - If the body is a file, we only want to remove the content type header if it's set to text/* or application/json
+ *   We don't want to add a content type header for files, to give the user the ability to set the content type themselves,
+ *   otherwise fetch will just add application/octet-stream
+ *
+ * - If the body is a json, we want to set/update the content type to application/json
+ *
+ * - If the body is a text, we want to set/update the content type to text/plain
+ */
 export function addContentTypeHeader(state: RequestorState): RequestorState {
   const currentHeaders = state.requestHeaders;
   const currentContentTypeHeader = getCurrentContentType(state);
@@ -92,14 +107,22 @@ function getUpdateOperation(
 ) {
   const nextContentTypeValue = mapBodyToContentType(currentBody);
 
+  // `null` means "no change"
   if (currentContentTypeHeader?.value?.startsWith(nextContentTypeValue)) {
     return null;
   }
 
+  // If there's no content type header, we might want to add one
   if (!currentContentTypeHeader) {
-    // HACK - Avoid adding the content type header when it's already set to multipart/form-data
-    //        We don't want to mess up the form boundary added by fetch
+    // HACK - Avoid adding the content type header when the body is multipart form-data
+    //        We don't want to mess up the form boundary added by fetch (it will cause errors)
     if (currentBody.type === "form-data" && currentBody.isMultipart) {
+      return null;
+    }
+
+    // If the body is a file, we don't want to add the content type header, in order to give the user the ability to set the content type themselves
+    // If the user doesn't define a content type, fetch will just add application/octet-stream
+    if (currentBody.type === "file") {
       return null;
     }
 
@@ -115,11 +138,26 @@ function getUpdateOperation(
     };
   }
 
-  if (currentBody.type === "form-data" && currentBody.isMultipart) {
+  // Remove the content type header if the new body is multipart form-data,
+  // and the user hasn't specified a multipart/form-data content type
+  if (
+    currentBody.type === "form-data" &&
+    currentBody.isMultipart &&
+    !currentContentTypeHeader.value?.startsWith("multipart/form-data")
+  ) {
     return {
       type: "remove",
       value: currentContentTypeHeader,
     };
+  }
+
+  if (currentBody.type === "file") {
+    if (currentContentTypeHeader.value?.startsWith("text/") || currentContentTypeHeader.value?.startsWith("application/json")) {
+      return {
+        type: "remove",
+        value: currentContentTypeHeader,
+      };
+    }
   }
 
   // Update the content type header

--- a/frontend/src/pages/RequestorPage/reducer/content-type.ts
+++ b/frontend/src/pages/RequestorPage/reducer/content-type.ts
@@ -1,0 +1,133 @@
+import {
+  KeyValueParameter,
+  enforceTerminalDraftParameter,
+} from "../KeyValueForm";
+import { isDraftParameter } from "../KeyValueForm/data";
+import { RequestorBody, RequestorState } from "./state";
+
+export function addContentTypeHeader(state: RequestorState): RequestorState {
+  const currentHeaders = state.requestHeaders;
+  const currentContentTypeHeader = getCurrentContentType(state);
+
+  const updateOperation = getUpdateOperation(
+    currentContentTypeHeader,
+    state.body,
+  );
+
+  let nextHeaders = currentHeaders;
+  if (updateOperation?.type === "add") {
+    nextHeaders = addHeader(currentHeaders, updateOperation.value);
+  }
+  if (updateOperation?.type === "update") {
+    nextHeaders = updateHeader(currentHeaders, updateOperation.value);
+  }
+  if (updateOperation?.type === "remove") {
+    nextHeaders = removeHeader(currentHeaders, updateOperation.value);
+  }
+
+  return {
+    ...state,
+    requestHeaders: enforceTerminalDraftParameter(nextHeaders),
+  };
+}
+
+function addHeader(
+  currentHeaders: KeyValueParameter[],
+  newHeader: KeyValueParameter,
+) {
+  return currentHeaders.filter((p) => !isDraftParameter(p)).concat(newHeader);
+}
+
+function updateHeader(
+  currentHeaders: KeyValueParameter[],
+  newHeader: KeyValueParameter,
+) {
+  return currentHeaders.map((p) => (p.id === newHeader.id ? newHeader : p));
+}
+
+function removeHeader(
+  currentHeaders: KeyValueParameter[],
+  header: KeyValueParameter,
+) {
+  return currentHeaders.filter((p) => p.id !== header.id);
+}
+
+function mapBodyToContentType(body: RequestorBody) {
+  if (body.type === "form-data" && body.isMultipart) {
+    return "multipart/form-data";
+  }
+  if (body.type === "form-data" && !body.isMultipart) {
+    return "application/x-www-form-urlencoded";
+  }
+
+  // TODO - Sniff the file extension, this could otherwise be very very annoying
+  //        if we keep resetting their content type header when it's already set to like "application/iamge"
+  if (body.type === "file") {
+    return "application/octet-stream";
+  }
+
+  if (body.type === "json") {
+    return "application/json";
+  }
+  if (body.type === "text") {
+    return "text/plain";
+  }
+
+  return "text/plain";
+}
+
+function getCurrentContentType(state: RequestorState) {
+  const currentContentType = state.requestHeaders.find(
+    (header) => header.key?.toLowerCase() === "content-type",
+  );
+  if (!currentContentType) {
+    return null;
+  }
+  return currentContentType;
+}
+
+function getUpdateOperation(
+  currentContentTypeHeader: KeyValueParameter | null,
+  currentBody: RequestorBody,
+) {
+  const nextContentTypeValue = mapBodyToContentType(currentBody);
+
+  if (currentContentTypeHeader?.value?.startsWith(nextContentTypeValue)) {
+    return null;
+  }
+
+  if (!currentContentTypeHeader) {
+    // HACK - Avoid adding the content type header when it's already set to multipart/form-data
+    //        We don't want to mess up the form boundary added by fetch
+    if (currentBody.type === "form-data" && currentBody.isMultipart) {
+      return null;
+    }
+
+    // Add the content type header
+    return {
+      type: "add",
+      value: {
+        id: crypto.randomUUID(),
+        key: "Content-Type",
+        value: nextContentTypeValue,
+        enabled: true,
+      },
+    };
+  }
+
+  if (currentBody.type === "form-data" && currentBody.isMultipart) {
+    return {
+      type: "remove",
+      value: currentContentTypeHeader,
+    };
+  }
+
+  // Update the content type header
+  return {
+    type: "update",
+    value: {
+      ...currentContentTypeHeader,
+      value: nextContentTypeValue,
+    },
+  };
+}

--- a/frontend/src/pages/RequestorPage/reducer/reducers/content-type.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducers/content-type.ts
@@ -1,9 +1,9 @@
 import {
   KeyValueParameter,
   enforceTerminalDraftParameter,
-} from "../KeyValueForm";
-import { isDraftParameter } from "../KeyValueForm/data";
-import { RequestorBody, RequestorState } from "./state";
+} from "../../KeyValueForm";
+import { isDraftParameter } from "../../KeyValueForm/data";
+import { RequestorBody, RequestorState } from "../state";
 
 /**
  * This makes sure to synchronize the content type header with the body type.
@@ -152,7 +152,10 @@ function getUpdateOperation(
   }
 
   if (currentBody.type === "file") {
-    if (currentContentTypeHeader.value?.startsWith("text/") || currentContentTypeHeader.value?.startsWith("application/json")) {
+    if (
+      currentContentTypeHeader.value?.startsWith("text/") ||
+      currentContentTypeHeader.value?.startsWith("application/json")
+    ) {
       return {
         type: "remove",
         value: currentContentTypeHeader,

--- a/frontend/src/pages/RequestorPage/reducer/reducers/index.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducers/index.ts
@@ -1,0 +1,2 @@
+export * from "./content-type";
+export * from "./set-body-type";

--- a/frontend/src/pages/RequestorPage/reducer/reducers/set-body-type.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducers/set-body-type.ts
@@ -54,7 +54,9 @@ export function setBodyTypeReducer(
     };
   }
 
-  // Handle the case where the body type is changing to text or json, so we want to clear the body value and make it an empty string
+  // At this point, we know the next body type is going to be text or json, soooo
+  // Let's handle the case where the body type is changing to text or json,
+  // meaning we want to clear the body value and make it an empty string
   if (oldBodyType === "form-data") {
     return {
       ...state,
@@ -62,7 +64,7 @@ export function setBodyTypeReducer(
     };
   }
 
-  // HACK - These new few lines makes things clearer for typescript, but are a nightmare to read, i'm so sorry
+  // HACK - These new few lines makes things clearer for typescript, but are a nightmare to read and reason about, i'm so sorry
   const isNonTextOldBody =
     Array.isArray(oldBodyValue) || oldBodyValue instanceof File;
   const newBodyValue = isNonTextOldBody ? "" : oldBodyValue;

--- a/frontend/src/pages/RequestorPage/reducer/reducers/set-body-type.ts
+++ b/frontend/src/pages/RequestorPage/reducer/reducers/set-body-type.ts
@@ -1,0 +1,74 @@
+import { enforceFormDataTerminalDraftParameter } from "../../FormDataForm";
+import { RequestBodyType, RequestorState } from "../state";
+
+/**
+ * This reducer is responsible for setting the body type of the request.
+ * There's a lot of logic here to handle the different body types and their interactions.
+ * It's messy, but it's its own function! SO we can start testing it. Some day.
+ * We have big plans for this reducer function. Big plans.
+ */
+export function setBodyTypeReducer(
+  state: RequestorState,
+  {
+    type: newBodyType,
+    isMultipart,
+  }: {
+    type: RequestBodyType;
+    isMultipart?: boolean;
+  },
+): RequestorState {
+  const oldBodyValue = state.body.value;
+  const oldBodyType = state.body.type;
+  // Handle the case where the body type is the same, but the multipart flag is different
+  if (oldBodyType === newBodyType) {
+    // HACK - Refactor
+    if (state.body.type === "form-data") {
+      return {
+        ...state,
+        body: {
+          ...state.body,
+          isMultipart: !!isMultipart,
+        },
+      };
+    }
+    return state;
+  }
+
+  // Handle the case where the body type is changing to form-data, so we want to clear the body value
+  if (newBodyType === "form-data") {
+    return {
+      ...state,
+      body: {
+        type: newBodyType,
+        isMultipart: !!isMultipart,
+        value: enforceFormDataTerminalDraftParameter([]),
+      },
+    };
+  }
+
+  // Handle the case where the body type is changing to file, so we want to clear the body value and make it undefined
+  if (newBodyType === "file") {
+    return {
+      ...state,
+      body: { type: newBodyType, value: undefined },
+    };
+  }
+
+  // Handle the case where the body type is changing to text or json, so we want to clear the body value and make it an empty string
+  if (oldBodyType === "form-data") {
+    return {
+      ...state,
+      body: { type: newBodyType, value: "" },
+    };
+  }
+
+  // HACK - These new few lines makes things clearer for typescript, but are a nightmare to read, i'm so sorry
+  const isNonTextOldBody =
+    Array.isArray(oldBodyValue) || oldBodyValue instanceof File;
+  const newBodyValue = isNonTextOldBody ? "" : oldBodyValue;
+
+  return {
+    ...state,
+    body: { type: newBodyType, value: newBodyValue },
+  };
+}


### PR DESCRIPTION
Factored out the set-body-type reducer to make it easier to add or update or remove the content-type header after updating the body type

This solution needs work. But it will suffice for now!