### PR TITLE
Show service host in history if it is not target service

### DIFF
--- a/frontend/src/pages/RequestorPage/RequestorHistory.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorHistory.tsx
@@ -5,11 +5,13 @@ import { Requestornator } from "./queries";
 type RequestorHistoryProps = {
   history: Array<Requestornator>;
   loadHistoricalRequest: (traceId: string) => void;
+  removeServiceUrlFromPath: (path: string) => string;
 };
 
 export function RequestorHistory({
   history,
   loadHistoricalRequest,
+  removeServiceUrlFromPath,
 }: RequestorHistoryProps) {
   return (
     <>
@@ -29,6 +31,7 @@ export function RequestorHistory({
               traceId={traceId}
               response={h}
               loadHistoricalRequest={loadHistoricalRequest}
+              removeServiceUrlFromPath={removeServiceUrlFromPath}
             />
           );
         })}
@@ -40,22 +43,27 @@ type HistoryEntryProps = {
   traceId: string;
   response: Requestornator;
   loadHistoricalRequest?: (traceId: string) => void;
+  removeServiceUrlFromPath: (path: string) => string;
 };
 
 export function HistoryEntry({
   traceId,
   response,
   loadHistoricalRequest,
+  removeServiceUrlFromPath,
 }: HistoryEntryProps) {
   const isFailure = response?.app_responses?.isFailure;
   const requestMethod = response.app_requests?.requestMethod;
   const responseStatusCode = response.app_responses?.responseStatusCode;
 
+  const path = parsePathFromRequestUrl(
+    response.app_requests?.requestUrl,
+    response.app_requests?.requestQueryParams ?? undefined,
+    { preserveHost: true },
+  );
+
   const fallbackUrl = truncatePathWithEllipsis(
-    parsePathFromRequestUrl(
-      response.app_requests?.requestUrl,
-      response.app_requests?.requestQueryParams ?? undefined,
-    ),
+    path ? removeServiceUrlFromPath(path) : path,
   );
 
   return (

--- a/frontend/src/pages/RequestorPage/RequestorPage.tsx
+++ b/frontend/src/pages/RequestorPage/RequestorPage.tsx
@@ -248,6 +248,7 @@ export const RequestorPage = () => {
           handleRouteClick={handleSelectRoute}
           history={history}
           loadHistoricalRequest={loadHistoricalRequest}
+          removeServiceUrlFromPath={removeServiceUrlFromPath}
         />
       </div>
 

--- a/frontend/src/pages/RequestorPage/RoutesPanel.tsx
+++ b/frontend/src/pages/RequestorPage/RoutesPanel.tsx
@@ -24,6 +24,7 @@ type RoutesPanelProps = {
   deleteDraftRoute?: () => void;
   history: Array<Requestornator>;
   loadHistoricalRequest: (traceId: string) => void;
+  removeServiceUrlFromPath: (path: string) => string;
 };
 
 export function RoutesPanel({
@@ -33,6 +34,7 @@ export function RoutesPanel({
   deleteDraftRoute,
   history,
   loadHistoricalRequest,
+  removeServiceUrlFromPath,
 }: RoutesPanelProps) {
   const { width, handleResize } = useResizableWidth(320);
   const styleWidth = useStyleWidth(width);
@@ -157,6 +159,7 @@ export function RoutesPanel({
             <HistorySection
               history={filteredHistory}
               loadHistoricalRequest={loadHistoricalRequest}
+              removeServiceUrlFromPath={removeServiceUrlFromPath}
             />
           )}
 
@@ -212,11 +215,13 @@ export function RoutesPanel({
 type HistorySectionProps = {
   history: Array<Requestornator>;
   loadHistoricalRequest: (traceId: string) => void;
+  removeServiceUrlFromPath: (path: string) => string;
 };
 
 function HistorySection({
   history,
   loadHistoricalRequest,
+  removeServiceUrlFromPath,
 }: HistorySectionProps) {
   const [showHistorySection, setShowHistorySection] = useState(false);
   const ShowHistorySectionIcon = showHistorySection
@@ -243,6 +248,7 @@ function HistorySection({
         <RequestorHistory
           history={history}
           loadHistoricalRequest={loadHistoricalRequest}
+          removeServiceUrlFromPath={removeServiceUrlFromPath}
         />
       )}
     </>

--- a/frontend/src/pages/RequestorPage/routes/hooks.ts
+++ b/frontend/src/pages/RequestorPage/routes/hooks.ts
@@ -62,6 +62,7 @@ export function useRoutes({ setRoutes, setServiceBaseUrl }: UseRoutesOptions) {
   const serviceBaseUrl =
     routesAndMiddleware?.baseUrl ?? "http://localhost:8787";
   useEffect(() => {
+    console.log("setting serviceBaseUrl", serviceBaseUrl);
     setServiceBaseUrl(serviceBaseUrl);
   }, [serviceBaseUrl, setServiceBaseUrl]);
 

--- a/frontend/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorHistory.ts
@@ -83,9 +83,10 @@ export function useRequestorHistory({
         // NOTE - Helps us set path parameters correctly
         handleSelectRoute(matchedRoute.route, pathParams);
 
-        // TODO - Remove query parameters that are explicitly in the `queryParams`
         // Reset the path to the *exact* path of the request, instead of the route pattern
         const queryParams = match.app_requests.requestQueryParams ?? {};
+        // NOTE - We remove the query parameters that are explicitly in the `queryParams`
+        //        So we do not duplicate them between the path and the form
         const path = removeQueryParams(
           match.app_requests.requestUrl ?? "",
           queryParams,
@@ -125,10 +126,11 @@ export function useRequestorHistory({
           setBody(safeBody);
         }
       } else {
-        // TODO - Remove query parameters that are explicitly in the `queryParams`
         // HACK - move this logic into the reducer
         // Reset the path to the *exact* path of the request, instead of the route pattern
         const queryParams = match.app_requests.requestQueryParams ?? {};
+        // NOTE - We remove the query parameters that are explicitly in the `queryParams`
+        //        So we do not duplicate them between the path and the form
         const path = removeQueryParams(
           match.app_requests.requestUrl ?? "",
           queryParams,

--- a/frontend/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/frontend/src/pages/RequestorPage/useRequestorHistory.ts
@@ -1,3 +1,4 @@
+import { removeQueryParams } from "@/utils";
 import { useMemo } from "react";
 import { KeyValueParameter, createKeyValueParameters } from "./KeyValueForm";
 import { useSessionHistory } from "./RequestorSessionHistoryContext";
@@ -82,8 +83,13 @@ export function useRequestorHistory({
         // NOTE - Helps us set path parameters correctly
         handleSelectRoute(matchedRoute.route, pathParams);
 
+        // TODO - Remove query parameters that are explicitly in the `queryParams`
         // Reset the path to the *exact* path of the request, instead of the route pattern
-        const path = match.app_requests.requestUrl ?? "";
+        const queryParams = match.app_requests.requestQueryParams ?? {};
+        const path = removeQueryParams(
+          match.app_requests.requestUrl ?? "",
+          queryParams,
+        );
         setPath(path);
 
         const headers = match.app_requests.requestHeaders ?? {};
@@ -99,7 +105,6 @@ export function useRequestorHistory({
           ),
         );
 
-        const queryParams = match.app_requests.requestQueryParams ?? {};
         setQueryParams(
           createKeyValueParameters(
             Object.entries(queryParams).map(([key, value]) => ({
@@ -120,9 +125,14 @@ export function useRequestorHistory({
           setBody(safeBody);
         }
       } else {
+        // TODO - Remove query parameters that are explicitly in the `queryParams`
         // HACK - move this logic into the reducer
         // Reset the path to the *exact* path of the request, instead of the route pattern
-        const path = match.app_requests.requestUrl ?? "";
+        const queryParams = match.app_requests.requestQueryParams ?? {};
+        const path = removeQueryParams(
+          match.app_requests.requestUrl ?? "",
+          queryParams,
+        );
         setPath(path);
 
         const requestType = match.app_requests.requestUrl.startsWith("ws")
@@ -144,7 +154,6 @@ export function useRequestorHistory({
           ),
         );
 
-        const queryParams = match.app_requests.requestQueryParams ?? {};
         setQueryParams(
           createKeyValueParameters(
             Object.entries(queryParams).map(([key, value]) => ({

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -42,6 +42,7 @@ export function isJson(str: string) {
 export function parsePathFromRequestUrl(
   url: string,
   queryParams?: Record<string, string>,
+  { preserveHost = false } = {},
 ) {
   try {
     const fancyUrl = new URL(url);
@@ -50,9 +51,33 @@ export function parsePathFromRequestUrl(
         fancyUrl.searchParams.set(key, value);
       }
     }
+    if (preserveHost) {
+      return fancyUrl.toString();
+    }
     return `${fancyUrl.pathname}${fancyUrl.search}`;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Removes specified query parameters from a URL
+ */
+export function removeQueryParams(
+  url: string,
+  queryParams: Record<string, string>,
+) {
+  if (!url) {
+    return url;
+  }
+  try {
+    const newUrl = new URL(url);
+    for (const [key] of Object.entries(queryParams)) {
+      newUrl.searchParams.delete(key);
+    }
+    return newUrl.toString();
+  } catch {
+    return url;
   }
 }
 


### PR DESCRIPTION
Also:

- Fix problem with initial load that always set the first url's host to `http://localhost:8787`

- When loading a request from history, only reload query params in the path input if they were defined explicitly in the path. Otherwise, load query params into teh Query Params form in the UI


<img width="580" alt="image" src="https://github.com/user-attachments/assets/a9c5e84e-3b8e-45a6-9580-7baf4a97ed22">
