### PR TITLE
Several timeline improvements

### DIFF
--- a/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/RequestDetailsPageV2Content.tsx
+++ b/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/RequestDetailsPageV2Content.tsx
@@ -121,6 +121,9 @@ export function RequestDetailsPageContentV2({
       </div>
       <div className={cn("grid grid-rows-[auto_1fr] gap-4")}>
         <SummaryV2 requestSpan={rootSpan.span} />
+        <div className="min-w-0 overflow-hidden w-full lg:hidden">
+          <TraceDetailsTimeline waterfall={waterfall} />
+        </div>
         <ResizablePanelGroup
           direction="horizontal"
           className={cn("grid grid-rows-[auto_1fr] w-full border-t")}
@@ -142,14 +145,10 @@ export function RequestDetailsPageContentV2({
             className={cn(
               "grid items-center gap-4 overflow-x-auto relative",
               "w-full",
-              "max-lg:grid-rows-[auto_1fr]",
               "lg:items-start",
               "lg:p-4",
             )}
           >
-            <div className="w-full lg:hidden">
-              <TraceDetailsTimeline waterfall={waterfall} />
-            </div>
             <TraceDetailsV2 waterfall={waterfall} />
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs.ts
+++ b/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs.ts
@@ -7,6 +7,7 @@ import { getString } from "../v2/otel-helpers";
 export function useOrphanLogs(traceId: string, spans: Array<OtelSpan>) {
   // NOTE - Flatten out events into orphan logs to allow the UI to render them
   const orphanLogs = useMemo(() => {
+    console.log('creating orhapnlogs', spans.map(span => span.end_time).sort());
     const orphans: MizuOrphanLog[] = [];
     for (const span of spans ?? []) {
       if (span.events) {
@@ -47,7 +48,7 @@ function convertEventToOrphanLog(
 ) {
   const argsAsString = getString(event.attributes.arguments);
   const parsedArgs = argsAsString ? safeParseJson(argsAsString) : [];
-
+  console.log('event.timestamp', event);
   return {
     id: logId,
     traceId,

--- a/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs.ts
+++ b/frontend/src/pages/RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs.ts
@@ -7,7 +7,6 @@ import { getString } from "../v2/otel-helpers";
 export function useOrphanLogs(traceId: string, spans: Array<OtelSpan>) {
   // NOTE - Flatten out events into orphan logs to allow the UI to render them
   const orphanLogs = useMemo(() => {
-    console.log('creating orhapnlogs', spans.map(span => span.end_time).sort());
     const orphans: MizuOrphanLog[] = [];
     for (const span of spans ?? []) {
       if (span.events) {
@@ -48,7 +47,7 @@ function convertEventToOrphanLog(
 ) {
   const argsAsString = getString(event.attributes.arguments);
   const parsedArgs = argsAsString ? safeParseJson(argsAsString) : [];
-  console.log('event.timestamp', event);
+
   return {
     id: logId,
     traceId,

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -356,16 +356,14 @@ const WaterfallRowSpan: React.FC<{
   const spanDuration =
     new Date(span.end_time).getTime() - new Date(span.start_time).getTime();
   const normalizedDuration = spanDuration / duration;
-  // NOTE - We want to render a single line, instead of a tai-fighter shape, if the span is less than 1% of the total duration
-  const shouldRenderSingleLine = normalizedDuration < 0.01;
   const percentageWidth =
     duration === 0 ? 100 : (normalizedDuration * 100).toFixed(4);
-  const lineWidth = `${percentageWidth}%`;
+  const lineWidth = `calc(${4 * 0.0625}rem + ${percentageWidth}%)`;
   const lineOffsetNumeric =
     duration === 0
       ? 0
       : ((new Date(span.start_time).getTime() - startTime) / duration) * 100;
-  const lineOffset = `calc(${lineOffsetNumeric.toFixed(4)}% - ${(shouldRenderSingleLine ? 1 : 2) * /*0.0625*/ 1}px)`;
+  const lineOffset = `calc(${lineOffsetNumeric.toFixed(4)}% - ${2 * 0.0625}rem)`;
   const icon = useTimelineIcon(span, { vendorInfo });
   const title = useTimelineTitle({ span, vendorInfo });
 
@@ -384,11 +382,10 @@ const WaterfallRowSpan: React.FC<{
     >
       <div className={cn(icon ? "mr-2" : "mr-0")}>{icon}</div>
       <div className="flex flex-col w-20 overflow-hidden">{title}</div>
-      <div className="text-gray-400 flex flex-grow items-center mx-4">
+      <div className="text-gray-400 flex flex-grow items-center mx-4 relative h-0.5">
         <div
           className={cn(
-            "h-2.5 border-l-2 border-r-2 border-blue-500 flex items-center min-w-0  flex-grow-0",
-            shouldRenderSingleLine && "border-r-0",
+            "h-2.5 border-l-2 border-r-2 border-blue-500 flex items-center min-w-0 absolute",
           )}
           style={{ width: lineWidth, marginLeft: lineOffset }}
           title={`${span.start_time} - ${span.end_time}`}
@@ -396,7 +393,6 @@ const WaterfallRowSpan: React.FC<{
           <div
             className={cn(
               "h-0.5 min-w-0.5 bg-blue-500 w-full",
-              shouldRenderSingleLine && "bg-transparent",
             )}
           ></div>
         </div>
@@ -416,7 +412,8 @@ const WaterfallRowLog: React.FC<{
 }> = ({ log, duration, startTime, isActive }) => {
   const left =
     ((new Date(log.timestamp).getTime() - startTime) / duration) * 100;
-  const lineOffset = `calc(${left}% - ${3 * 0.0625}rem)`;
+  // const lineOffset = `calc(${left}% - ${3 * 0.0625}rem)`;
+  const lineOffset = `calc(${left.toFixed(4)}% - ${3 * 0.0625}rem)`;
   const icon = useTimelineIcon(log, {
     colorOverride: getColorForLevel(log.level),
   });
@@ -434,7 +431,6 @@ const WaterfallRowLog: React.FC<{
       )}
       href={`#${log.id}`}
     >
-      {/* <> */}
       <div className={cn(icon ? "mr-2" : "mr-0")}>{icon}</div>
       <div className="flex flex-col w-20 overflow-hidden">
         <div className="font-mono font-normal text-xs truncate text-gray-200">
@@ -443,7 +439,7 @@ const WaterfallRowLog: React.FC<{
       </div>
       <div className="text-gray-400 flex flex-grow items-center mx-4">
         <div
-          className="h-2.5 flex items-center min-w-1"
+          className="h-2.5 items-center min-w-1"
           style={{ marginLeft: lineOffset }}
           title={log.timestamp}
         >
@@ -451,7 +447,6 @@ const WaterfallRowLog: React.FC<{
         </div>
       </div>
       <div className="ml-auto text-gray-400 text-xs w-12 px-2" />
-      {/* </> */}
     </a>
   );
 };

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -390,7 +390,7 @@ const WaterfallRowSpan: React.FC<{
           style={{ width: lineWidth, marginLeft: lineOffset }}
           title={`${span.start_time} - ${span.end_time}`}
         >
-          <div className={cn("h-0.5 min-w-0.5 bg-blue-500 w-full")}></div>
+          <div className={"h-0.5 min-w-0.5 bg-blue-500 w-full"}></div>
         </div>
       </div>
       <div className="text-gray-400 text-xs w-12 px-2">

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -119,7 +119,6 @@ export const TraceDetailsTimeline: React.FC<TraceDetailsTimelineProps> = ({
     >
       <h3 className="text-muted-foreground text-sm uppercase mb-4">Timeline</h3>
       <div className="flex flex-col">
-      {/* <div className="grid grid-cols-[1rem_minmax(0,5rem)_minmax(0,auto)_3rem] gap-2 items-center"> */}
         {waterfall.map((spanOrLog) => {
           if (isMizuOrphanLog(spanOrLog)) {
             return (
@@ -356,12 +355,9 @@ const WaterfallRowSpan: React.FC<{
   const id = span.span_id;
   const spanDuration =
     new Date(span.end_time).getTime() - new Date(span.start_time).getTime();
-    console.log(
-      'span.end_time', span.end_time, 'span.start_time', span.start_time, 'spanDuration', spanDuration);
   const normalizedDuration = spanDuration / duration;
   // NOTE - We want to render a single line, instead of a tai-fighter shape, if the span is less than 1% of the total duration
   const shouldRenderSingleLine = normalizedDuration < 0.01;
-  // console.log("should render a single line", shouldRenderSingleLine, span.name)
   const percentageWidth =
     duration === 0 ? 100 : (normalizedDuration * 100).toFixed(4);
   const lineWidth = `${percentageWidth}%`;

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { SpanKind } from "@/constants";
 import { MizuOrphanLog, OtelSpan, isMizuOrphanLog } from "@/queries";
 import { cn, safeParseJson } from "@/utils";
+import { CommitIcon, PaperPlaneIcon, TimerIcon } from "@radix-ui/react-icons";
 import { formatDistanceStrict } from "date-fns";
 import React, {
   useCallback,
@@ -24,7 +25,6 @@ import {
   isNeonVendorInfo,
   isOpenAIVendorInfo,
 } from "./vendorify-traces";
-import { CommitIcon, PaperPlaneIcon, TimerIcon } from "@radix-ui/react-icons";
 
 type TraceDetailsTimelineProps = {
   waterfall: Waterfall;
@@ -368,7 +368,7 @@ const WaterfallRowSpan: React.FC<{
   const lineOffset = `calc(${lineOffsetNumeric.toFixed(4)}% - ${(shouldRenderSingleLine ? 1 : 2) * /*0.0625*/ 1}px)`;
   const icon = useTimelineIcon(span, { vendorInfo });
   const title = useTimelineTitle({ span, vendorInfo });
-  
+
   return (
     <a
       data-toc-id={id}
@@ -387,25 +387,24 @@ const WaterfallRowSpan: React.FC<{
       <div className="text-gray-400 flex flex-grow items-center mx-4">
         <div
           className={cn(
-          "h-2.5 border-l-2 border-r-2 border-blue-500 flex items-center min-w-0  flex-grow-0",
-          shouldRenderSingleLine && "border-r-0",
-        )}
-        style={{ width: lineWidth, marginLeft: lineOffset }}
-        title={
-          `${span.start_time} - ${span.end_time}`}
-      >
-        <div
-          className={cn(
-            "h-0.5 min-w-0.5 bg-blue-500 w-full",
-            shouldRenderSingleLine && "bg-transparent",
+            "h-2.5 border-l-2 border-r-2 border-blue-500 flex items-center min-w-0  flex-grow-0",
+            shouldRenderSingleLine && "border-r-0",
           )}
-        ></div>
+          style={{ width: lineWidth, marginLeft: lineOffset }}
+          title={`${span.start_time} - ${span.end_time}`}
+        >
+          <div
+            className={cn(
+              "h-0.5 min-w-0.5 bg-blue-500 w-full",
+              shouldRenderSingleLine && "bg-transparent",
+            )}
+          ></div>
+        </div>
       </div>
-    </div>
-    <div className="text-gray-400 text-xs w-12 px-2">
-      {formatDuration(span.start_time, span.end_time)}
-    </div>
-   </a>
+      <div className="text-gray-400 text-xs w-12 px-2">
+        {formatDuration(span.start_time, span.end_time)}
+      </div>
+    </a>
   );
 };
 
@@ -415,7 +414,8 @@ const WaterfallRowLog: React.FC<{
   startTime: number;
   isActive: boolean;
 }> = ({ log, duration, startTime, isActive }) => {
-  const left = ((new Date(log.timestamp).getTime() - startTime) / duration) * 100;
+  const left =
+    ((new Date(log.timestamp).getTime() - startTime) / duration) * 100;
   const lineOffset = `calc(${left}% - ${3 * 0.0625}rem)`;
   const icon = useTimelineIcon(log, {
     colorOverride: getColorForLevel(log.level),
@@ -434,7 +434,7 @@ const WaterfallRowLog: React.FC<{
       )}
       href={`#${log.id}`}
     >
-    {/* <> */}
+      {/* <> */}
       <div className={cn(icon ? "mr-2" : "mr-0")}>{icon}</div>
       <div className="flex flex-col w-20 overflow-hidden">
         <div className="font-mono font-normal text-xs truncate text-gray-200">
@@ -452,7 +452,7 @@ const WaterfallRowLog: React.FC<{
       </div>
       <div className="ml-auto text-gray-400 text-xs w-12 px-2" />
       {/* </> */}
-      </a>
+    </a>
   );
 };
 

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -390,11 +390,7 @@ const WaterfallRowSpan: React.FC<{
           style={{ width: lineWidth, marginLeft: lineOffset }}
           title={`${span.start_time} - ${span.end_time}`}
         >
-          <div
-            className={cn(
-              "h-0.5 min-w-0.5 bg-blue-500 w-full",
-            )}
-          ></div>
+          <div className={cn("h-0.5 min-w-0.5 bg-blue-500 w-full")}></div>
         </div>
       </div>
       <div className="text-gray-400 text-xs w-12 px-2">

--- a/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
+++ b/frontend/src/pages/RequestDetailsPage/v2/TraceDetailsTimeline.tsx
@@ -408,7 +408,6 @@ const WaterfallRowLog: React.FC<{
 }> = ({ log, duration, startTime, isActive }) => {
   const left =
     ((new Date(log.timestamp).getTime() - startTime) / duration) * 100;
-  // const lineOffset = `calc(${left}% - ${3 * 0.0625}rem)`;
   const lineOffset = `calc(${left.toFixed(4)}% - ${3 * 0.0625}rem)`;
   const icon = useTimelineIcon(log, {
     colorOverride: getColorForLevel(log.level),

--- a/frontend/src/pages/RequestorPage/RoutesPanel.tsx
+++ b/frontend/src/pages/RequestorPage/RoutesPanel.tsx
@@ -268,15 +268,13 @@ function RoutesSection(props: RoutesSectionProps) {
 
   return (
     <>
-      <div 
+      <div
         className="font-medium text-sm flex items-center mb-2 mt-4"
         onClick={() => {
           setShowRoutesSection((current) => !current);
         }}
       >
-        <ShowRoutesSectionIcon
-          className="h-4 w-4 mr-0.5 cursor-pointer"
-        />
+        <ShowRoutesSectionIcon className="h-4 w-4 mr-0.5 cursor-pointer" />
         {title}
       </div>
       {showRoutesSection && (

--- a/frontend/src/pages/RequestorPage/RoutesPanel.tsx
+++ b/frontend/src/pages/RequestorPage/RoutesPanel.tsx
@@ -268,12 +268,14 @@ function RoutesSection(props: RoutesSectionProps) {
 
   return (
     <>
-      <div className="font-medium text-sm flex items-center mb-2 mt-4">
+      <div 
+        className="font-medium text-sm flex items-center mb-2 mt-4"
+        onClick={() => {
+          setShowRoutesSection((current) => !current);
+        }}
+      >
         <ShowRoutesSectionIcon
           className="h-4 w-4 mr-0.5 cursor-pointer"
-          onClick={() => {
-            setShowRoutesSection((current) => !current);
-          }}
         />
         {title}
       </div>

--- a/packages/client-library-otel/sample/index.ts
+++ b/packages/client-library-otel/sample/index.ts
@@ -25,8 +25,9 @@ const loop = measure("loop", (n: number) => {
 app.get("/", async (c) => {
   console.log("Hello Hono!");
   console.error("This message is logged as an error");
+  console.debug("Debug message")
 
-  loop(100);
+  loop(3);
 
   const response = await fetch("https://api.chucknorris.io/jokes/random");
   const result = await response.json();

--- a/packages/client-library-otel/sample/index.ts
+++ b/packages/client-library-otel/sample/index.ts
@@ -25,7 +25,7 @@ const loop = measure("loop", (n: number) => {
 app.get("/", async (c) => {
   console.log("Hello Hono!");
   console.error("This message is logged as an error");
-  console.debug("Debug message")
+  console.debug("Debug message");
 
   loop(3);
 


### PR DESCRIPTION
* changed the icons for several timeline entries
* added colors for log levels
* fixed positioning of the log dots compared to the spans
* fixed an issue in chrome where on smaller screens the timeline would overflow

See (updated) screenshot:
<img width="984" alt="image" src="https://github.com/user-attachments/assets/7f5dbe78-2aee-4156-9c96-5e92f9bf31fc">

p.s. I've brought back the "tie fighter" span (`|-|`)  otherwise the dots for short spans would appear in the wrong place.