### PR TITLE
If setting is not json, fall back to its og value

### DIFF
--- a/api/src/lib/settings/index.ts
+++ b/api/src/lib/settings/index.ts
@@ -7,6 +7,7 @@ import { eq, sql } from "drizzle-orm";
 import type { LibSQLDatabase } from "drizzle-orm/libsql";
 import { settings } from "../../db/schema.js";
 import type * as schema from "../../db/schema.js";
+import { safeParseJson } from "../utils.js";
 
 export async function upsertSettings(
   db: LibSQLDatabase<typeof schema>,
@@ -62,7 +63,7 @@ export async function getSetting<T extends SettingsKey>(
     return;
   }
 
-  return JSON.parse(result.value);
+  return safeParseJson(result.value);
 }
 
 export async function getAllSettings(


### PR DESCRIPTION
things blow up when i try to run the api rn. `getSetting` tries to parse the setting value as json, but sometimes it's just a string

<img width="815" alt="image" src="https://github.com/user-attachments/assets/7c844175-18c1-4f59-b7dc-29557de86c6d">
