### PR TITLE
Modify OtelSpan schema to handle null attributes

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,7 @@
   },
   "types": "./src/lib/types.ts",
   "scripts": {
-    "dev": "tsx watch src/index.node.ts",
+    "dev": "pnpm run db:migrate && tsx watch src/index.node.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx migrate.ts",
     "db:drop": "drizzle-kit drop",

--- a/api/src/lib/settings/index.ts
+++ b/api/src/lib/settings/index.ts
@@ -73,7 +73,9 @@ export async function getAllSettings(
 
   const mappedToSchema = results.reduce<Record<string, string>>(
     (acc, setting) => {
-      acc[setting.key] = setting.value ? JSON.parse(setting.value) : undefined;
+      acc[setting.key] = setting.value
+        ? safeParseJson(setting.value)
+        : undefined;
       return acc;
     },
     {},

--- a/frontend/src/queries/traces-otel.ts
+++ b/frontend/src/queries/traces-otel.ts
@@ -13,8 +13,13 @@ const OtelAttributesSchema = z.record(
       Int: z.number(),
     }),
     z.number(),
+
+    // NOTE - It's possible the middleware is setting null for some attributes
+    //        We need this null case here defensively
+    //        FP-4019
+    z.null(),
+
     // z.boolean(),
-    // z.null(),
     // z.undefined(),
     // z.record(
     //   z.string(),


### PR DESCRIPTION
It's possible an attribute on an event could end up being null, and we don't want to break the UI because of it.

This happened with [FP-4019](https://linear.app/fiberplane/issue/FP-4019/otel-middleware-passing-a-function-to-console-serializes-message)

At a certain point we have to be defensive for this case in the UI. So I added `null` as a possible attribute value in the OtelSpanSchema

## Other changes

- Safely parse json when getting all settings from the database
- Always run `db:migrate` when running the ts api in dev