### PR TITLE
Create working directory if it wasn't found

### DIFF
--- a/.fpx/.gitignore
+++ b/.fpx/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory, except for this file and a README.md
+*
+
+!.gitignore
+!README.md

--- a/.fpx/README.md
+++ b/.fpx/README.md
@@ -1,0 +1,4 @@
+# .fpx
+
+This directory is a working directory for [fpx](../fpx/). It is used to store
+files such as the database.

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ shared/dist
 .envrc
 
 # Fpx
-.fpx
 .fpxconfig
 
 # Rust targets

--- a/fpx-lib/src/api/models.rs
+++ b/fpx-lib/src/api/models.rs
@@ -151,14 +151,14 @@ pub struct TypeScriptCompatSpan {
     pub parsed_payload: Span,
 }
 
-impl Into<TypeScriptCompatSpan> for crate::data::models::Span {
-    fn into(self) -> TypeScriptCompatSpan {
-        TypeScriptCompatSpan {
-            span_id: Some(self.span_id.clone()),
-            trace_id: Some(self.trace_id.clone()),
-            created_at: self.end_time.into(),
-            updated_at: self.end_time.into(),
-            parsed_payload: self.clone().into(),
+impl From<crate::data::models::Span> for TypeScriptCompatSpan {
+    fn from(span: crate::data::models::Span) -> Self {
+        Self {
+            span_id: Some(span.span_id.clone()),
+            trace_id: Some(span.trace_id.clone()),
+            created_at: span.end_time.into(),
+            updated_at: span.end_time.into(),
+            parsed_payload: span.clone().into(),
         }
     }
 }

--- a/fpx/src/commands.rs
+++ b/fpx/src/commands.rs
@@ -8,8 +8,6 @@ pub mod debug;
 pub mod dev;
 pub mod system;
 
-static DEFAULT_FPX_DIRECTORY: &str = ".fpx";
-
 /// FPX - Super-charge your local development.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -26,8 +24,8 @@ pub struct Args {
     pub otlp_endpoint: Url,
 
     /// fpx directory
-    #[arg(global = true, short, long, env, default_value = DEFAULT_FPX_DIRECTORY)]
-    pub fpx_directory: PathBuf,
+    #[arg(global = true, short, long, env)]
+    pub fpx_directory: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]

--- a/fpx/src/commands.rs
+++ b/fpx/src/commands.rs
@@ -23,7 +23,11 @@ pub struct Args {
     #[clap(long, env, default_value = "http://localhost:4317")]
     pub otlp_endpoint: Url,
 
-    /// fpx directory
+    /// Change the fpx directory.
+    ///
+    /// By default fpx will search for a `.fpx` directory in the current
+    /// directory or its ancestors. If it wasn't found it will create a `.fpx`
+    /// directory in the current directory.
     #[arg(global = true, short, long, env)]
     pub fpx_directory: Option<PathBuf>,
 }

--- a/fpx/src/commands/debug.rs
+++ b/fpx/src/commands/debug.rs
@@ -1,3 +1,4 @@
+use crate::find_fpx_dir;
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -11,6 +12,9 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
+    /// Print the path to the FPX directory.
+    FpxDirectory,
+
     /// Start a WebSocket connection to the server. This will dump any message
     /// it receives to the console.
     #[clap(alias = "ws")]
@@ -18,6 +22,16 @@ pub enum Command {
 }
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
+        Command::FpxDirectory => handle_fpx_directory_command().await,
         Command::WebSocket(args) => ws::handle_command(args).await,
     }
+}
+
+pub async fn handle_fpx_directory_command() -> Result<()> {
+    let fpx_directory = find_fpx_dir()?;
+    match fpx_directory {
+        Some(path) => eprintln!("Fpx directory found: {}", path.display()),
+        None => eprintln!("Fpx directory not found"),
+    }
+    Ok(())
 }

--- a/fpx/src/commands/debug.rs
+++ b/fpx/src/commands/debug.rs
@@ -1,4 +1,3 @@
-use crate::find_fpx_dir;
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -12,9 +11,6 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Print the path to the FPX directory.
-    FpxDirectory,
-
     /// Start a WebSocket connection to the server. This will dump any message
     /// it receives to the console.
     #[clap(alias = "ws")]
@@ -22,16 +18,6 @@ pub enum Command {
 }
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
-        Command::FpxDirectory => handle_fpx_directory_command().await,
         Command::WebSocket(args) => ws::handle_command(args).await,
     }
-}
-
-pub async fn handle_fpx_directory_command() -> Result<()> {
-    let fpx_directory = find_fpx_dir()?;
-    match fpx_directory {
-        Some(path) => eprintln!("Fpx directory found: {}", path.display()),
-        None => eprintln!("Fpx directory not found"),
-    }
-    Ok(())
 }

--- a/fpx/src/commands/system.rs
+++ b/fpx/src/commands/system.rs
@@ -1,3 +1,4 @@
+use crate::find_fpx_dir;
 use anyhow::Result;
 use clap::Subcommand;
 
@@ -11,13 +12,25 @@ pub struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Inspector related endpoints
-    #[clap(hide = true)] // Not released yet
+    /// Low level interaction with the database.
     Database(database::Args),
+
+    /// Print the path to the FPX directory.
+    FpxDirectory,
 }
 
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
         Command::Database(args) => database::handle_command(args).await,
+        Command::FpxDirectory => handle_fpx_directory_command().await,
     }
+}
+
+pub async fn handle_fpx_directory_command() -> Result<()> {
+    let fpx_directory = find_fpx_dir()?;
+    match fpx_directory {
+        Some(path) => eprintln!("Fpx directory found: {}", path.display()),
+        None => eprintln!("Fpx directory not found"),
+    }
+    Ok(())
 }

--- a/fpx/src/commands/system.rs
+++ b/fpx/src/commands/system.rs
@@ -27,7 +27,7 @@ pub async fn handle_command(args: Args) -> Result<()> {
 }
 
 pub async fn handle_fpx_directory_command() -> Result<()> {
-    let fpx_directory = find_fpx_dir()?;
+    let fpx_directory = find_fpx_dir();
     match fpx_directory {
         Some(path) => eprintln!("Fpx directory found: {}", path.display()),
         None => eprintln!("Fpx directory not found"),

--- a/fpx/src/commands/system/database.rs
+++ b/fpx/src/commands/system/database.rs
@@ -1,3 +1,4 @@
+use crate::initialize_fpx_dir;
 use anyhow::Result;
 use clap::Subcommand;
 use std::path::PathBuf;
@@ -10,7 +11,7 @@ pub struct Args {
 
     /// fpx directory
     #[arg(from_global)]
-    pub fpx_directory: PathBuf,
+    pub fpx_directory: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -26,7 +27,9 @@ pub async fn handle_command(args: Args) -> Result<()> {
 }
 
 pub async fn handle_delete_database(args: Args) -> Result<()> {
-    match tokio::fs::remove_file(args.fpx_directory.join("fpx.db")).await {
+    let fpx_directory = initialize_fpx_dir(&args.fpx_directory).await?;
+
+    match tokio::fs::remove_file(fpx_directory.join("fpx.db")).await {
         Ok(_) => info!("Database deleted"),
         Err(err) => error!(?err, "Failed to delete database"),
     };

--- a/fpx/src/commands/system/database.rs
+++ b/fpx/src/commands/system/database.rs
@@ -27,7 +27,7 @@ pub async fn handle_command(args: Args) -> Result<()> {
 }
 
 pub async fn handle_delete_database(args: Args) -> Result<()> {
-    let Some(fpx_directory) = args.fpx_directory.or_else(|| find_fpx_dir()) else {
+    let Some(fpx_directory) = args.fpx_directory.or_else(find_fpx_dir) else {
         warn!("Unable to find fpx directory, skipped deleting database");
         return Ok(());
     };

--- a/fpx/src/data.rs
+++ b/fpx/src/data.rs
@@ -5,7 +5,7 @@ use fpx_lib::data::sql::SqlBuilder;
 use fpx_lib::data::{DbError, Result, Store, Transaction};
 use libsql::{params, Builder, Connection};
 use std::fmt::Display;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use tracing::trace;
 use util::RowsExt;

--- a/fpx/src/data.rs
+++ b/fpx/src/data.rs
@@ -4,7 +4,10 @@ use fpx_lib::data::models::Span;
 use fpx_lib::data::sql::SqlBuilder;
 use fpx_lib::data::{DbError, Result, Store, Transaction};
 use libsql::{params, Builder, Connection};
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use tracing::trace;
 use util::RowsExt;
 
 mod migrations;
@@ -13,6 +16,29 @@ mod util;
 #[cfg(test)]
 mod tests;
 
+pub enum DataPath<'a> {
+    InMemory,
+    File(&'a Path),
+}
+
+impl<'a> DataPath<'a> {
+    pub fn as_path(&self) -> &'a Path {
+        match self {
+            DataPath::InMemory => Path::new(":memory:"),
+            DataPath::File(path) => path,
+        }
+    }
+}
+
+impl<'a> Display for DataPath<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DataPath::InMemory => write!(f, ":memory:"),
+            DataPath::File(path) => f.write_fmt(format_args!("{}", path.display())),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct LibsqlStore {
     connection: Connection,
@@ -20,10 +46,12 @@ pub struct LibsqlStore {
 }
 
 impl LibsqlStore {
-    pub async fn in_memory() -> Result<Self, anyhow::Error> {
+    pub async fn open(path: DataPath<'_>) -> Result<Self, anyhow::Error> {
+        trace!(%path, "Opening Libsql database");
+
         // Not sure if we need this database object, but for now we just drop
         // it.
-        let database = Builder::new_local(":memory:")
+        let database = Builder::new_local(path.as_path())
             .build()
             .await
             .context("failed to build libSQL database object")?;
@@ -40,6 +68,14 @@ impl LibsqlStore {
             connection,
             sql_builder,
         })
+    }
+
+    pub async fn in_memory() -> Result<Self, anyhow::Error> {
+        Self::open(DataPath::InMemory).await
+    }
+
+    pub async fn file(db_path: &Path) -> Result<Self, anyhow::Error> {
+        Self::open(DataPath::File(db_path)).await
     }
 
     /// This function will execute a few PRAGMA statements to set the database


### PR DESCRIPTION
Look for .fpx directory in the current working directory ancestors, if it wasn't found, then create a .fpx directory in the current directory

Store libsql data in the fpx directory again.

Create a .fpx directory in the current repository as a placeholder, making it easier to develop for fpx

Resolves: FP-4017, FP-4018
