### PR TITLE
Fix unhandled promise rejection when route reporting is wired up incorrectly

### DIFF
--- a/packages/client-library-otel/src/routes.ts
+++ b/packages/client-library-otel/src/routes.ts
@@ -38,6 +38,11 @@ export function respondWithRoutes(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ routes }),
+    }).catch((_e) => {
+      // NOTE - We're not awaiting this fetch, so we need to catch its errors
+      //        to avoid unhandled promise rejections.
+      // TODO - Use a logger, or only log if library debugging is enabled
+      // console.error("Error sending routes to FPX", e);
     });
   } catch (_e) {
     // TODO - Use a logger, or only log if library debugging is enabled


### PR DESCRIPTION
We have a fetch to report the routes back to the fpx ts api, and if things are wired up incorrectly, then we crash the app (node/bun). Let's not do that!