### PR TITLE
Otel Client Lib: Don't delete those precious headers (Bun/Node)

### DIFF
--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -133,20 +133,6 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
             duplex: body2 ? "half" : undefined,
           });
 
-          // Determine the content length of the body2 stream, in order to pass it correctly to the server
-          // let newRequestContentLength = null;
-          // if (body2 && newRequest.headers.has("Content-Length")) {
-          //   const blob = await new Response(body2).blob();
-          //   newRequestContentLength = blob.size;
-          // }
-          // // Update the Content-Length header on the newRequest object
-          // if (newRequestContentLength !== null) {
-          //   newRequest.headers.set(
-          //     "Content-Length",
-          //     newRequestContentLength.toString(),
-          //   );
-          // }
-
           // Parse the body and headers for the root request.
           //
           // NOTE - This will add some latency, and it will serialize the env object.

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -134,18 +134,18 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
           });
 
           // Determine the content length of the body2 stream, in order to pass it correctly to the server
-          let newRequestContentLength = null;
-          if (body2 && newRequest.headers.has("Content-Length")) {
-            const blob = await new Response(body2).blob();
-            newRequestContentLength = blob.size;
-          }
-          // Update the Content-Length header on the newRequest object
-          if (newRequestContentLength !== null) {
-            newRequest.headers.set(
-              "Content-Length",
-              newRequestContentLength.toString(),
-            );
-          }
+          // let newRequestContentLength = null;
+          // if (body2 && newRequest.headers.has("Content-Length")) {
+          //   const blob = await new Response(body2).blob();
+          //   newRequestContentLength = blob.size;
+          // }
+          // // Update the Content-Length header on the newRequest object
+          // if (newRequestContentLength !== null) {
+          //   newRequest.headers.set(
+          //     "Content-Length",
+          //     newRequestContentLength.toString(),
+          //   );
+          // }
 
           // Parse the body and headers for the root request.
           //


### PR DESCRIPTION
For some reason the code I put in here fixes and issue that @oscarvz and @Nlea were having with their sample app. 

Headers were getting fully devoured by our instrumentation library... maybe a node/bun specific bug? (Since they're running on bun)