### PR TITLE
Allow spans to be deleted

### DIFF
--- a/fpx-lib/src/api.rs
+++ b/fpx-lib/src/api.rs
@@ -54,19 +54,20 @@ impl Builder {
 
         let router = axum::Router::new()
             .route("/v1/traces", post(handlers::otel::trace_collector_handler))
+            .route("/api/traces", get(handlers::traces::traces_list_handler))
             .route(
-                "/api/traces/:trace_id/spans/:span_id",
-                get(handlers::spans::span_get_handler),
+                "/api/traces/:trace_id",
+                get(handlers::traces::traces_get_handler)
+                    .delete(handlers::traces::traces_delete_handler),
             )
             .route(
                 "/api/traces/:trace_id/spans",
                 get(handlers::spans::span_list_handler),
             )
             .route(
-                "/api/traces/:trace_id",
-                get(handlers::traces::traces_get_handler),
+                "/api/traces/:trace_id/spans/:span_id",
+                get(handlers::spans::span_get_handler).delete(handlers::spans::span_delete_handler),
             )
-            .route("/api/traces", get(handlers::traces::traces_list_handler))
             .route(
                 "/ts-compat/v1/traces/:trace_id/spans",
                 get(handlers::spans::ts_compat_span_list_handler),

--- a/fpx-lib/src/api/handlers/spans.rs
+++ b/fpx-lib/src/api/handlers/spans.rs
@@ -114,7 +114,7 @@ pub async fn span_delete_handler(
     hex::decode(&span_id)
         .map_err(|_| ApiServerError::ServiceError(SpanDeleteError::InvalidSpanId))?;
 
-    let _ = store.span_delete(&tx, &trace_id, &span_id).await?;
+    store.span_delete(&tx, &trace_id, &span_id).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/fpx-lib/src/api/handlers/traces.rs
+++ b/fpx-lib/src/api/handlers/traces.rs
@@ -112,7 +112,7 @@ pub async fn traces_delete_handler(
         .map_err(|_| ApiServerError::ServiceError(TraceDeleteError::InvalidTraceId))?;
 
     // Retrieve all the spans that are associated with the trace
-    let _ = store.span_delete_by_trace(&tx, &trace_id).await?;
+    store.span_delete_by_trace(&tx, &trace_id).await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/fpx-lib/src/api/handlers/traces.rs
+++ b/fpx-lib/src/api/handlers/traces.rs
@@ -100,3 +100,35 @@ impl From<DbError> for ApiServerError<TraceGetError> {
         ApiServerError::CommonError(CommonError::InternalServerError)
     }
 }
+
+#[tracing::instrument(skip_all)]
+pub async fn traces_delete_handler(
+    State(store): State<BoxedStore>,
+    Path(trace_id): Path<String>,
+) -> Result<StatusCode, ApiServerError<TraceDeleteError>> {
+    let tx = store.start_readonly_transaction().await?;
+
+    hex::decode(&trace_id)
+        .map_err(|_| ApiServerError::ServiceError(TraceDeleteError::InvalidTraceId))?;
+
+    // Retrieve all the spans that are associated with the trace
+    let _ = store.span_delete_by_trace(&tx, &trace_id).await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Debug, Serialize, Deserialize, Error, ApiError)]
+#[serde(tag = "error", content = "details", rename_all = "camelCase")]
+#[non_exhaustive]
+pub enum TraceDeleteError {
+    #[api_error(status_code = StatusCode::BAD_REQUEST)]
+    #[error("Trace ID is invalid")]
+    InvalidTraceId,
+}
+
+impl From<DbError> for ApiServerError<TraceDeleteError> {
+    fn from(err: DbError) -> Self {
+        error!(?err, "Failed to list trace from database");
+        ApiServerError::CommonError(CommonError::InternalServerError)
+    }
+}

--- a/fpx-lib/src/data.rs
+++ b/fpx-lib/src/data.rs
@@ -69,4 +69,10 @@ pub trait Store: Send + Sync {
         tx: &Transaction,
         // Future improvement could hold sort fields, limits, etc
     ) -> Result<Vec<models::Trace>>;
+
+    /// Delete all spans with a specific trace_id.
+    async fn span_delete_by_trace(&self, tx: &Transaction, trace_id: &str) -> Result<u64>;
+
+    /// Delete a single span.
+    async fn span_delete(&self, tx: &Transaction, trace_id: &str, span_id: &str) -> Result<u64>;
 }

--- a/fpx-lib/src/data.rs
+++ b/fpx-lib/src/data.rs
@@ -71,8 +71,13 @@ pub trait Store: Send + Sync {
     ) -> Result<Vec<models::Trace>>;
 
     /// Delete all spans with a specific trace_id.
-    async fn span_delete_by_trace(&self, tx: &Transaction, trace_id: &str) -> Result<u64>;
+    async fn span_delete_by_trace(&self, tx: &Transaction, trace_id: &str) -> Result<Option<u64>>;
 
     /// Delete a single span.
-    async fn span_delete(&self, tx: &Transaction, trace_id: &str, span_id: &str) -> Result<u64>;
+    async fn span_delete(
+        &self,
+        tx: &Transaction,
+        trace_id: &str,
+        span_id: &str,
+    ) -> Result<Option<u64>>;
 }

--- a/fpx-lib/src/data/sql.rs
+++ b/fpx-lib/src/data/sql.rs
@@ -86,4 +86,21 @@ impl SqlBuilder {
             ",
         )
     }
+
+    /// Delete all spans with a specific trace_id.
+    ///
+    /// Query parameters:
+    /// - $1: trace_id
+    pub fn span_delete_by_trace(&self) -> String {
+        String::from("DELETE FROM spans WHERE trace_id=$1")
+    }
+
+    /// Delete a specific span.
+    ///
+    /// Query parameters:
+    /// - $1: trace_id
+    /// - $2: span_id
+    pub fn span_delete(&self) -> String {
+        String::from("DELETE FROM spans WHERE trace_id=$1 AND span_id=$2")
+    }
 }

--- a/fpx/src/commands/client/spans.rs
+++ b/fpx/src/commands/client/spans.rs
@@ -17,12 +17,16 @@ pub enum Command {
 
     /// List all spans for a single trace
     List(ListArgs),
+
+    /// Delete a single span
+    Delete(DeleteArgs),
 }
 
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
         Command::Get(args) => handle_get(args).await,
         Command::List(args) => handle_list(args).await,
+        Command::Delete(args) => handle_delete(args).await,
     }
 }
 
@@ -65,6 +69,27 @@ async fn handle_list(args: ListArgs) -> Result<()> {
     let result = api_client.span_list(args.trace_id).await?;
 
     serde_json::to_writer_pretty(stdout(), &result)?;
+
+    Ok(())
+}
+
+#[derive(clap::Args, Debug)]
+pub struct DeleteArgs {
+    /// TraceID - hex encoded
+    pub trace_id: String,
+
+    /// SpanID - hex encoded
+    pub span_id: String,
+
+    /// Base url of the fpx dev server.
+    #[arg(from_global)]
+    pub base_url: Url,
+}
+
+async fn handle_delete(args: DeleteArgs) -> Result<()> {
+    let api_client = ApiClient::new(args.base_url.clone());
+
+    let _ = api_client.span_delete(args.trace_id, args.span_id).await?;
 
     Ok(())
 }

--- a/fpx/src/commands/client/spans.rs
+++ b/fpx/src/commands/client/spans.rs
@@ -89,7 +89,7 @@ pub struct DeleteArgs {
 async fn handle_delete(args: DeleteArgs) -> Result<()> {
     let api_client = ApiClient::new(args.base_url.clone());
 
-    let _ = api_client.span_delete(args.trace_id, args.span_id).await?;
+    api_client.span_delete(args.trace_id, args.span_id).await?;
 
     Ok(())
 }

--- a/fpx/src/commands/client/traces.rs
+++ b/fpx/src/commands/client/traces.rs
@@ -17,12 +17,16 @@ pub enum Command {
 
     /// List all traces
     List(ListArgs),
+
+    /// Delete all spans for a single trace
+    Delete(DeleteArgs),
 }
 
 pub async fn handle_command(args: Args) -> Result<()> {
     match args.command {
         Command::Get(args) => handle_get(args).await,
         Command::List(args) => handle_list(args).await,
+        Command::Delete(args) => handle_delete(args).await,
     }
 }
 
@@ -59,6 +63,24 @@ async fn handle_list(args: ListArgs) -> Result<()> {
     let result = api_client.trace_list().await?;
 
     serde_json::to_writer_pretty(stdout(), &result)?;
+
+    Ok(())
+}
+
+#[derive(clap::Args, Debug)]
+pub struct DeleteArgs {
+    /// TraceID - hex encoded
+    pub trace_id: String,
+
+    /// Base url of the fpx dev server.
+    #[arg(from_global)]
+    pub base_url: Url,
+}
+
+async fn handle_delete(args: DeleteArgs) -> Result<()> {
+    let api_client = ApiClient::new(args.base_url.clone());
+
+    let _ = api_client.trace_delete(args.trace_id).await?;
 
     Ok(())
 }

--- a/fpx/src/commands/client/traces.rs
+++ b/fpx/src/commands/client/traces.rs
@@ -80,7 +80,7 @@ pub struct DeleteArgs {
 async fn handle_delete(args: DeleteArgs) -> Result<()> {
     let api_client = ApiClient::new(args.base_url.clone());
 
-    let _ = api_client.trace_delete(args.trace_id).await?;
+    api_client.trace_delete(args.trace_id).await?;
 
     Ok(())
 }

--- a/fpx/src/data.rs
+++ b/fpx/src/data.rs
@@ -180,4 +180,24 @@ impl Store for LibsqlStore {
 
         Ok(traces)
     }
+
+    /// Delete all spans with a specific trace_id.
+    async fn span_delete_by_trace(&self, _tx: &Transaction, trace_id: &str) -> Result<u64> {
+        let rows_affected = self
+            .connection
+            .execute(&self.sql_builder.span_delete_by_trace(), params!(trace_id))
+            .await?;
+
+        Ok(rows_affected)
+    }
+
+    /// Delete a single span.
+    async fn span_delete(&self, _tx: &Transaction, trace_id: &str, span_id: &str) -> Result<u64> {
+        let rows_affected = self
+            .connection
+            .execute(&self.sql_builder.span_delete(), params!(trace_id, span_id))
+            .await?;
+
+        Ok(rows_affected)
+    }
 }

--- a/fpx/src/data.rs
+++ b/fpx/src/data.rs
@@ -182,22 +182,27 @@ impl Store for LibsqlStore {
     }
 
     /// Delete all spans with a specific trace_id.
-    async fn span_delete_by_trace(&self, _tx: &Transaction, trace_id: &str) -> Result<u64> {
+    async fn span_delete_by_trace(&self, _tx: &Transaction, trace_id: &str) -> Result<Option<u64>> {
         let rows_affected = self
             .connection
             .execute(&self.sql_builder.span_delete_by_trace(), params!(trace_id))
             .await?;
 
-        Ok(rows_affected)
+        Ok(Some(rows_affected))
     }
 
     /// Delete a single span.
-    async fn span_delete(&self, _tx: &Transaction, trace_id: &str, span_id: &str) -> Result<u64> {
+    async fn span_delete(
+        &self,
+        _tx: &Transaction,
+        trace_id: &str,
+        span_id: &str,
+    ) -> Result<Option<u64>> {
         let rows_affected = self
             .connection
             .execute(&self.sql_builder.span_delete(), params!(trace_id, span_id))
             .await?;
 
-        Ok(rows_affected)
+        Ok(Some(rows_affected))
     }
 }


### PR DESCRIPTION
Allow deleting a specific span or all spans of a trace

NOTE: Support for deleting a batch of spans or having a cronjob that will delete old spans will be added in another PR.