### PR TITLE
Make ai test prompt clearer that we are only notifying error logs and exceptions

### DIFF
--- a/frontend/src/pages/RequestorPage/ai/ai-test-generation.ts
+++ b/frontend/src/pages/RequestorPage/ai/ai-test-generation.ts
@@ -73,7 +73,7 @@ And I got the following response:
 
 ${responseDescription}
 
-My app produced these logs:
+My app produced the following error logs and exceptions:
 
 <app-logs>
 ${appLogs}


### PR DESCRIPTION
The context for the AI Test Prompt mentions it will include all application logs, but in actuality, we're only including exceptions and error logs. This makes the prompt clearer