### PR TITLE
Fix loading an app.all request from history

### DIFF
--- a/examples/goose-quotes/src/index.ts
+++ b/examples/goose-quotes/src/index.ts
@@ -430,6 +430,15 @@ app.get("/api/geese/:id/avatar", async (c) => {
   });
 });
 
+/**
+ * `app.all` test
+ *
+ * For all methods, print "Honk honk!"
+ */
+app.all("/always-honk/:echo?", (c) => {
+  return c.text(`Honk honk! ${c.req.param("echo") ?? ""}`);
+});
+
 app.get(
   "/ws",
   upgradeWebSocket((c) => {

--- a/studio/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/studio/src/pages/RequestorPage/useRequestorHistory.ts
@@ -90,6 +90,14 @@ export function useRequestorHistory({
         // NOTE - Helps us set path parameters correctly
         handleSelectRoute(matchedRoute.route, pathParams);
 
+        // @ts-expect-error - We don't handle ALL methods well yet
+        if (matchedRoute.route.method === "ALL") {
+          // TODO - Add based off of method of trace...
+          if (isRequestMethod(match.app_requests.requestMethod)) {
+            setMethod(match.app_requests.requestMethod);
+          }
+        }
+
         // Reset the path to the *exact* path of the request, instead of the route pattern
         const queryParams = match.app_requests.requestQueryParams ?? {};
         // NOTE - We remove the query parameters that are explicitly in the `queryParams`


### PR DESCRIPTION
The UI can handle routes defined with `app.all` _somewhat_ gracefully, but loading such a request from history did not set the correct method. This PR fixes the issue!

https://github.com/user-attachments/assets/830e04cb-c166-47d1-9e31-b3b23bfa8e1b



