### PR TITLE
Resolve issue where multiple tabs would compete for saving requestor state in localStorage

### DIFF
--- a/studio/src/pages/RequestorPage/reducer/persistence.ts
+++ b/studio/src/pages/RequestorPage/reducer/persistence.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useBeforeUnload } from "react-router-dom";
+import { addSessionIdToState } from "./session-persistence-key";
 import {
   LOCAL_STORAGE_KEY,
   type SavedRequestorState,
@@ -22,7 +23,9 @@ export function useSaveUiState(state: SavedRequestorState) {
 
   const saveUiState = useCallback(() => {
     try {
-      const state = SavedRequestorStateSchema.parse(stateRef.current);
+      const state =
+        // Fixes issue where having multiple tabs open would disrupt the persisted requestor state of other tabs
+        addSessionIdToState(SavedRequestorStateSchema.parse(stateRef.current));
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
     } catch {
       // Ignore errors

--- a/studio/src/pages/RequestorPage/reducer/session-persistence-key.ts
+++ b/studio/src/pages/RequestorPage/reducer/session-persistence-key.ts
@@ -1,0 +1,30 @@
+import { objectWithKey } from "@/utils";
+import type { SavedRequestorState } from "./state";
+
+// NOTE - This will be unique to the tab/session, and refreshed whenever the page is reloaded.
+//        This allows us to NOT load the UI state saved in local storage when the user has Studio open in another tab.
+const CURRENT_SESSION_ID = crypto.randomUUID();
+
+// We add this key to the persisted session state to determine if the state is from the current session
+const SESSION_ID_KEY = "_persistenceSessionId";
+
+/**
+ * Checks if the state in local storage is from the current tab's session
+ */
+export function isCurrentSessionState(state: unknown) {
+  if (objectWithKey(state, SESSION_ID_KEY)) {
+    return state[SESSION_ID_KEY] === CURRENT_SESSION_ID;
+  }
+  return false;
+}
+
+/**
+ * Adds the session ID to the state to indicate that the persisted state is from the current tab's session
+ */
+export function addSessionIdToState(state: SavedRequestorState) {
+  return {
+    ...state,
+    // Fixes issue where having multiple tabs open would disrupt the persisted requestor state of other tabs
+    [SESSION_ID_KEY]: CURRENT_SESSION_ID,
+  };
+}

--- a/studio/src/pages/RequestorPage/reducer/state.ts
+++ b/studio/src/pages/RequestorPage/reducer/state.ts
@@ -7,6 +7,7 @@ import { ProbedRouteSchema } from "../queries";
 import { RequestMethodSchema, RequestTypeSchema } from "../types";
 import { addContentTypeHeader } from "./reducers";
 import { RequestorBodySchema } from "./request-body";
+import { isCurrentSessionState } from "./session-persistence-key";
 import { RequestsPanelTabSchema, ResponsePanelTabSchema } from "./tabs";
 
 const RequestorResponseBodySchema = z.discriminatedUnion("type", [
@@ -210,7 +211,7 @@ function loadUiStateFromLocalStorage(): SavedRequestorState | null {
 
   try {
     const uiState = JSON.parse(possibleUiState);
-    if (isSavedRequestorState(uiState)) {
+    if (isSavedRequestorState(uiState) && isCurrentSessionState(uiState)) {
       return uiState;
     }
     return null;


### PR DESCRIPTION
Creates a small module for adding a "session id" to the UI state we save in localStorage.

This guarantees that tabs will not accidentally save UI state to local storage, and then affect the UI of other tabs.

There are ways to improve this, but this is kind of edge-casey, so don't feel like optimizing any further