### PR TITLE
CLI Fix: Fall back to `cwd` when no project root is found

### DIFF
--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -44,7 +44,7 @@ const WRANGLER_TOML_PATH = findInParentDirs("wrangler.toml");
 const PACKAGE_JSON_PATH = findInParentDirs("package.json");
 // NOTE - Deno projects might also not necessarily have a deno.json
 const DENO_CONFIG_PATH = findInParentDirs(["deno.json", "deno.jsonc"]);
-const PROJECT_ROOT_DIR = findProjectRoot();
+const PROJECT_ROOT_DIR = findProjectRoot() ?? process.cwd();
 
 // Loading some possible configuration from the environment
 const WRANGLER_TOML = safeParseTomlFile(WRANGLER_TOML_PATH);


### PR DESCRIPTION
title says it all

to test:


**this should cause an error**

```sh
cd ~
mkdir meh
cd meh
npx @fiberplane/studio@latest
```

repeat the process with the pkg from this PR, and it should not error 

```sh
pnpx https://pkg.pr.new/fiberplane/fpx/@fiberplane/studio@207
```