### PR TITLE
Client library: Use integers in span attributes again

### DIFF
--- a/packages/client-library-otel/src/utils/request.ts
+++ b/packages/client-library-otel/src/utils/request.ts
@@ -271,7 +271,7 @@ export async function getResponseAttributes(
   response: GlobalResponse | HonoResponse,
 ) {
   const attributes: Attributes = {
-    [EXTRA_SEMATTRS_HTTP_RESPONSE_STATUS_CODE]: String(response.status),
+    [EXTRA_SEMATTRS_HTTP_RESPONSE_STATUS_CODE]: response.status,
     [SEMATTRS_HTTP_SCHEME]: response.url.split(":")[0],
   };
 
@@ -283,7 +283,14 @@ export async function getResponseAttributes(
 
   const contentLength = response.headers.get("content-length");
   if (contentLength) {
-    attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH] = contentLength;
+    try {
+      attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH] = Number.parseInt(
+        contentLength,
+        10,
+      );
+    } catch {
+      // ignore errors
+    }
   }
 
   const headers = response.headers;


### PR DESCRIPTION
Revert changes from https://github.com/fiberplane/fpx/pull/137/files

Background: The otel rust collector was rejecting certain spans that had integer-values for attributes. We coerced these values to strings to make things work, but it turns out this was a bug in the rust lib.

We need to wait until that bug is resolved and released before updating. Ergo:

**DO NOT MERGE UNTIL OTEL-RS HAS THE FOLLOWING PR MERGED AND RELEASED: https://github.com/open-telemetry/opentelemetry-rust/pull/1906**