### PR TITLE
Implement basic client library debug logging mode

### DIFF
--- a/examples/goose-quotes/src/index.ts
+++ b/examples/goose-quotes/src/index.ts
@@ -510,6 +510,7 @@ app.get(
 );
 
 export default instrument(app, {
+  libraryDebugMode: true,
   monitor: {
     fetch: true,
     logging: true,

--- a/examples/goosify/src/index.ts
+++ b/examples/goosify/src/index.ts
@@ -94,6 +94,7 @@ app.get("/api/cyberpunk-goose", async (c) => {
 });
 
 export default instrument(app, {
+  // libraryDebugMode: true,
   monitor: {
     fetch: true,
     logging: true,

--- a/packages/client-library-otel/README.md
+++ b/packages/client-library-otel/README.md
@@ -138,6 +138,16 @@ export default instrument(app, {
 });
 ```
 
+#### The `FPX_LOG_LEVEL` Environment Variable
+
+The `FPX_LOG_LEVEL` environment variable controls the verbosity of the library's logging.
+
+The possible values are: `debug`, `info`, `warn`, and `error`.
+
+The default value is `warn`.
+
+The `libraryDebugMode` option (documented in the previous section), takes precedence over this environment variable.
+
 ### Advanced Usage: Custom Spans with `measure`
 
 The library also allows you to create custom spans for any function in your app.

--- a/packages/client-library-otel/README.md
+++ b/packages/client-library-otel/README.md
@@ -111,6 +111,8 @@ The options are:
 
 - `monitor.fetch`: Whether to create traces for all fetch requests. (Default: `true`)
 - `monitor.logging`: Whether to proxy `console.*` functions to send logging data to a local Fiberplane Studio server. (Default: `true`)
+- `monitor.cfBindings`: Whether to proxy Cloudflare bindings (D1, R2, KV, AI) to add instrumentation to them. (Default: `false`)
+- `libraryDebugMode`: Whether to enable debug logging in the library. (Default: `false`)
 
 Here is an example:
 
@@ -123,11 +125,15 @@ const app = new Hono();
 app.get("/", (c) => c.text("Hello, Hono!"));
 
 export default instrument(app, {
+  // Enable debug logging in the library
+  libraryDebugMode: true,
   monitor: {
     // Don't create traces for fetch requests
     fetch: false,
     // Don't proxy `console.*` functions to send logging data to a local FPX server
     logging: false,
+    // Proxy Cloudflare bindings (D1, R2, KV, AI) to add instrumentation to them
+    cfBindings: true,
   },
 });
 ```

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -83,7 +83,7 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
           rawEnv: HonoLikeEnv,
           executionContext: ExecutionContext | undefined,
         ) {
-          // Patch the related functions to monitor
+          // Merge the default config with the user's config
           const {
             libraryDebugMode,
             monitor: {
@@ -125,6 +125,7 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
 
           const serviceName = env?.FPX_SERVICE_NAME ?? "unknown";
 
+          // Patch all functions we want to monitor in the runtime
           if (monitorCfBindings) {
             patchCloudflareBindings(env);
           }

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -9,6 +9,7 @@ import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import type { ExecutionContext } from "hono";
 // TODO figure out we can use something else
 import { AsyncLocalStorageContextManager } from "./async-hooks";
+import { getLogger } from "./logger";
 import { measure } from "./measure";
 import {
   patchCloudflareBindings,
@@ -93,12 +94,16 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
             typeof env === "object" && env !== null ? env.FPX_ENDPOINT : null;
           const isEnabled = !!endpoint && typeof endpoint === "string";
 
+          const logger = getLogger(rawEnv);
+
           if (!isEnabled) {
+            logger.debug("Fiberplane is not enabled, skipping instrumentation");
             return await originalFetch(request, rawEnv, executionContext);
           }
 
           // If the request is from the route inspector, respond with the routes
           if (isRouteInspectorRequest(request)) {
+            logger.debug("Fiberplane: Responding to route inspector request");
             return respondWithRoutes(webStandardFetch, endpoint, app);
           }
 

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -212,6 +212,7 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
                   throw new Error(r.statusText);
                 }
               },
+              logger,
             },
             originalFetch,
           );

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -107,10 +107,8 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
 
           const FPX_LOG_LEVEL = libraryDebugMode ? "debug" : env?.FPX_LOG_LEVEL;
           const logger = getLogger(FPX_LOG_LEVEL);
-
-          if (libraryDebugMode) {
-            logger.debug("Library debug mode is enabled");
-          }
+          // NOTE - This should only log if the FPX_LOG_LEVEL is debug
+          logger.debug("Library debug mode is enabled");
 
           if (!isEnabled) {
             logger.debug(

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -105,26 +105,23 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
             typeof env === "object" && env !== null ? env.FPX_ENDPOINT : null;
           const isEnabled = !!endpoint && typeof endpoint === "string";
 
-          const logger = getLogger(
-            libraryDebugMode
-              ? {
-                  FPX_LOG_LEVEL: "debug",
-                }
-              : rawEnv,
-          );
+          const FPX_LOG_LEVEL = libraryDebugMode ? "debug" : env?.FPX_LOG_LEVEL;
+          const logger = getLogger(FPX_LOG_LEVEL);
 
           if (libraryDebugMode) {
-            logger.debug("Fiberplane: Library debug mode is enabled");
+            logger.debug("Library debug mode is enabled");
           }
 
           if (!isEnabled) {
-            logger.debug("Fiberplane is not enabled, skipping instrumentation");
+            logger.debug(
+              "@fiberplane/hono-otel is missing FPX_ENDPOINT. Skipping instrumentation",
+            );
             return await originalFetch(request, rawEnv, executionContext);
           }
 
           // If the request is from the route inspector, respond with the routes
           if (isRouteInspectorRequest(request)) {
-            logger.debug("Fiberplane: Responding to route inspector request");
+            logger.debug("Responding to route inspector request");
             return respondWithRoutes(webStandardFetch, endpoint, app);
           }
 

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -1,5 +1,6 @@
 import { SpanKind, context } from "@opentelemetry/api";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import type { OTLPExporterError } from "@opentelemetry/otlp-exporter-base";
 import { Resource } from "@opentelemetry/resources";
 import {
   BasicTracerProvider,
@@ -9,7 +10,7 @@ import { SEMRESATTRS_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import type { ExecutionContext } from "hono";
 // TODO figure out we can use something else
 import { AsyncLocalStorageContextManager } from "./async-hooks";
-import { getLogger } from "./logger";
+import { type FpxLogger, getLogger, logExporterSendError } from "./logger";
 import { measure } from "./measure";
 import {
   patchCloudflareBindings,
@@ -140,6 +141,7 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
           const provider = setupTracerProvider({
             serviceName,
             endpoint,
+            logger
           });
 
           // Enable tracing for waitUntil
@@ -250,6 +252,7 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
 function setupTracerProvider(options: {
   serviceName: string;
   endpoint: string;
+  logger: FpxLogger;
 }) {
   // We need to use async hooks to be able to propagate context
   const asyncHooksContextManager = new AsyncLocalStorageContextManager();
@@ -264,9 +267,42 @@ function setupTracerProvider(options: {
   const exporter = new OTLPTraceExporter({
     url: options.endpoint,
   });
+
+  proxySendWithErrorLogging(exporter, options.logger);
+
   provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
   provider.register();
   return provider;
+}
+
+/**
+ * NOTE - This was my first attempt to be able to hook into errors that happen when
+ *        OTEL tries to send the trace to Fiberplane Studio, but there's a network error.
+ *        There is likely a more elegant way to do this.
+ */
+function proxySendWithErrorLogging(
+  exporter: OTLPTraceExporter,
+  logger: FpxLogger,
+) {
+  const originalSend = exporter.send.bind(exporter);
+  exporter.send = (...args) => {
+    console.log('hi from send')
+    const modOnError = (e: OTLPExporterError) => {
+      console.log('hi')
+      if (logger) {
+        logExporterSendError(logger, e);
+      }
+      if (typeof args?.[2] === "function") {
+        args[2](e);
+      }
+    };
+    const modArgs: Parameters<typeof originalSend> = [
+      args[0],
+      args[1],
+      modOnError,
+    ];
+    return originalSend(...modArgs);
+  };
 }
 
 /**

--- a/packages/client-library-otel/src/logger.ts
+++ b/packages/client-library-otel/src/logger.ts
@@ -79,12 +79,3 @@ export function getLogger(level: unknown) {
 function isLogLevel(level: unknown): level is LogLevel {
   return logLevels.includes(level as LogLevel);
 }
-
-export function logExporterSendError(logger: FpxLogger, error: unknown) {
-  const errorMessage =
-    error instanceof Error ? error.message : "<Unknown error>";
-  logger.error(
-    "Error sending span. Is Fiberplane Studio running?",
-    errorMessage,
-  );
-}

--- a/packages/client-library-otel/src/logger.ts
+++ b/packages/client-library-otel/src/logger.ts
@@ -79,3 +79,12 @@ export function getLogger(level: unknown) {
 function isLogLevel(level: unknown): level is LogLevel {
   return logLevels.includes(level as LogLevel);
 }
+
+export function logExporterSendError(logger: FpxLogger, error: unknown) {
+  const errorMessage =
+    error instanceof Error ? error.message : "<Unknown error>";
+  logger.error(
+    "Error sending span. Is Fiberplane Studio running?",
+    errorMessage,
+  );
+}

--- a/packages/client-library-otel/src/logger.ts
+++ b/packages/client-library-otel/src/logger.ts
@@ -1,0 +1,86 @@
+import type { HonoLikeEnv } from "./types";
+
+// Define the possible log levels
+const logLevels = ["debug", "info", "warn", "error"] as const;
+type LogLevel = (typeof logLevels)[number];
+
+const debugLog = console.debug.bind(console);
+const infoLog = console.info.bind(console);
+const warnLog = console.warn.bind(console);
+const errorLog = console.error.bind(console);
+
+const ourConsole = {
+  debug: debugLog,
+  info: infoLog,
+  warn: warnLog,
+  error: errorLog,
+};
+
+/**
+ * Get a logger that can be used to log messages to the console.
+ * - Optionally log depending on the FPX_LOG_LEVEL environment variable.
+ * - By default, log everything when in development mode, and log "warn" and above otherwise.
+ *
+ * @OPTIMIZE - This creates a new logger every time it's called.
+ *             (But this is somewhat necessary, because the logger needs to be able to access the environment variables.
+ *              In CF Workers, the environment variables are only available at runtime,
+ *              and a single worker's env might get reused across requests.)
+ *
+ * @param honoEnv - The environment variables from the Hono app.
+ * @returns A logger object with methods for each log level
+ */
+export function getLogger(honoEnv: HonoLikeEnv) {
+  // TODO - Update with Node.js env utilties after https://github.com/fiberplane/fpx/pull/208 is merged
+
+  // @ts-expect-error - We know the env might be a record with string keys
+  const FPX_LOG_LEVEL = honoEnv?.FPX_LOG_LEVEL;
+
+  // Determine the current log level from the environment variable or default to "warn"
+  const defaultLogLevel: LogLevel = "warn";
+  const currentLogLevel: LogLevel = isLogLevel(FPX_LOG_LEVEL)
+    ? FPX_LOG_LEVEL
+    : defaultLogLevel;
+
+  /**
+   * Determines if a message at a given log level should be logged based on the current log level.
+   * @param level - The log level of the message.
+   * @returns True if the message should be logged, false otherwise.
+   */
+  function shouldLog(level: LogLevel): boolean {
+    const currentLevelIndex = logLevels.indexOf(currentLogLevel);
+    const messageLevelIndex = logLevels.indexOf(level);
+    return messageLevelIndex >= currentLevelIndex;
+  }
+
+  // Create a logger object with methods for each log level
+  const logger = logLevels.reduce(
+    (acc, level) => {
+      /**
+       * Logs a message if the current log level allows it.
+       * @param message - The message to log.
+       * @param optionalParams - Additional parameters to log.
+       */
+      acc[level] = (message?: unknown, ...optionalParams: unknown[]) => {
+        if (shouldLog(level)) {
+          ourConsole[level](message, ...optionalParams);
+        }
+      };
+      return acc;
+    },
+    {} as Record<
+      LogLevel,
+      (message?: unknown, ...optionalParams: unknown[]) => void
+    >,
+  );
+
+  return logger;
+}
+
+/**
+ * Checks if a given level is a valid log level.
+ * @param level - The level to check.
+ * @returns True if the level is a valid LogLevel, false otherwise.
+ */
+function isLogLevel(level: unknown): level is LogLevel {
+  return logLevels.includes(level as LogLevel);
+}


### PR DESCRIPTION
To help debug issues, we should be able to give people some clearer instructions on how to produce better debug logs from the client library.

This adds configuration to enable debug logging, as well as some limited debug logs, to the client library.

<img width="446" alt="image" src="https://github.com/user-attachments/assets/bb957231-47ab-4041-8868-2ee2bcbaaf1b">


PR also updates the README.