### PR TITLE
Use matching middleware as context in ai req generation

### DIFF
--- a/api/drizzle/0012_deep_junta.sql
+++ b/api/drizzle/0012_deep_junta.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `app_routes` ADD `registration_order` integer DEFAULT -1;

--- a/api/drizzle/0013_futuristic_snowbird.sql
+++ b/api/drizzle/0013_futuristic_snowbird.sql
@@ -9,7 +9,7 @@ We can do it in 3 steps with drizzle orm:
 ALTER TABLE `app_routes` RENAME TO `old_app_routes`;
 --> statement-breakpoint
 CREATE TABLE `app_routes` (
-	`id` integer PRIMARY KEY AUTOINCREMENT,
+  `id` integer PRIMARY KEY AUTOINCREMENT,
   `path` TEXT,
   `method` TEXT,
   `handler` TEXT,

--- a/api/drizzle/0013_futuristic_snowbird.sql
+++ b/api/drizzle/0013_futuristic_snowbird.sql
@@ -1,0 +1,28 @@
+/*
+We want to delete PRIMARY KEY(handler_type,method,path,route_origin) from 'app_routes' table
+SQLite does not supportprimary key deletion from existing table
+We can do it in 3 steps with drizzle orm:
+ - create new mirror table table without pk, rename current table to old_table, generate SQL
+ - migrate old data from one table to another
+ - delete old_table in schema, generate sql
+*/
+ALTER TABLE `app_routes` RENAME TO `old_app_routes`;
+--> statement-breakpoint
+CREATE TABLE `app_routes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT,
+  `path` TEXT,
+  `method` TEXT,
+  `handler` TEXT,
+  `handler_type` TEXT,
+  `currentlyRegistered` INTEGER DEFAULT false,
+  `registration_order` INTEGER DEFAULT -1,
+  `route_origin` TEXT DEFAULT 'discovered',
+  `openapi_spec` TEXT,
+  `request_type` TEXT DEFAULT 'http'
+);
+--> statement-breakpoint
+INSERT INTO `app_routes` (`path`, `method`, `handler`, `handler_type`, `currentlyRegistered`, `registration_order`, `route_origin`, `openapi_spec`, `request_type`)
+SELECT `path`, `method`, `handler`, `handler_type`, `currentlyRegistered`, `registration_order`, `route_origin`, `openapi_spec`, `request_type`
+FROM `old_app_routes`;
+--> statement-breakpoint
+DROP TABLE `old_app_routes`;

--- a/api/drizzle/meta/0012_snapshot.json
+++ b/api/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,488 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cd5bd8ef-be05-4fd5-a1b5-f5b9769b882a",
+  "prevId": "cee1e0f6-1736-488e-8d3e-6243c83d5ae1",
+  "tables": {
+    "app_requests": {
+      "name": "app_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_method": {
+          "name": "request_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_url": {
+          "name": "request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_query_params": {
+          "name": "request_query_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_path_params": {
+          "name": "request_path_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_route": {
+          "name": "request_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_responses": {
+      "name": "app_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_status_code": {
+          "name": "response_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_failure": {
+          "name": "is_failure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_responses_request_id_app_requests_id_fk": {
+          "name": "app_responses_request_id_app_requests_id_fk",
+          "tableFrom": "app_responses",
+          "tableTo": "app_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_routes": {
+      "name": "app_routes",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handler": {
+          "name": "handler",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handler_type": {
+          "name": "handler_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentlyRegistered": {
+          "name": "currentlyRegistered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "registration_order": {
+          "name": "registration_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        },
+        "route_origin": {
+          "name": "route_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovered'"
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'http'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "id": {
+          "columns": [
+            "handler_type",
+            "method",
+            "path",
+            "route_origin"
+          ],
+          "name": "id"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "mizu_logs": {
+      "name": "mizu_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caller_location": {
+          "name": "caller_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "matching_issues": {
+          "name": "matching_issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "otel_spans": {
+      "name": "otel_spans",
+      "columns": {
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/api/drizzle/meta/0013_snapshot.json
+++ b/api/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,485 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cf7990f9-0720-4897-b0c5-449511f37c63",
+  "prevId": "cd5bd8ef-be05-4fd5-a1b5-f5b9769b882a",
+  "tables": {
+    "app_requests": {
+      "name": "app_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_method": {
+          "name": "request_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_url": {
+          "name": "request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_headers": {
+          "name": "request_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_query_params": {
+          "name": "request_query_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_path_params": {
+          "name": "request_path_params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_route": {
+          "name": "request_route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_responses": {
+      "name": "app_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_status_code": {
+          "name": "response_status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_headers": {
+          "name": "response_headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_details": {
+          "name": "failure_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_failure": {
+          "name": "is_failure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_responses_request_id_app_requests_id_fk": {
+          "name": "app_responses_request_id_app_requests_id_fk",
+          "tableFrom": "app_responses",
+          "tableTo": "app_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_routes": {
+      "name": "app_routes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handler": {
+          "name": "handler",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "handler_type": {
+          "name": "handler_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currentlyRegistered": {
+          "name": "currentlyRegistered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "registration_order": {
+          "name": "registration_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": -1
+        },
+        "route_origin": {
+          "name": "route_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'discovered'"
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'http'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "mizu_logs": {
+      "name": "mizu_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "caller_location": {
+          "name": "caller_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "matching_issues": {
+          "name": "matching_issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "otel_spans": {
+      "name": "otel_spans",
+      "columns": {
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parsed_payload": {
+          "name": "parsed_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {
+        "settings_key_unique": {
+          "name": "settings_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1724163077731,
       "tag": "0011_aspiring_triathlon",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1725009049745,
+      "tag": "0012_deep_junta",
+      "breakpoints": true
     }
   ]
 }

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1725009049745,
       "tag": "0012_deep_junta",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1725009596194,
+      "tag": "0013_futuristic_snowbird",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -21,6 +21,9 @@ export const appRoutes = sqliteTable(
     currentlyRegistered: integer("currentlyRegistered", {
       mode: "boolean",
     }).default(false),
+    registrationOrder: integer("registration_order", {
+      mode: "number",
+    }).default(-1),
     // A flag for route type that indicated if the route was added manually by user or by probe
     routeOrigin: text("route_origin", {
       mode: "text",

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -1,55 +1,35 @@
 import { relations, sql } from "drizzle-orm";
-import {
-  integer,
-  primaryKey,
-  sqliteTable,
-  text,
-} from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 
-export const appRoutes = sqliteTable(
-  "app_routes",
-  {
-    path: text("path", { mode: "text" }),
-    method: text("method", { mode: "text" }),
-    // The text of the function serving the request
-    handler: text("handler", { mode: "text" }),
-    // In practice, handler_type is either "route" or "middleware" - I didn't feel like defining an enum
-    handlerType: text("handler_type", { mode: "text" }),
-    // A flag that indicates if this route is currently registered or the result of an old probe
-    currentlyRegistered: integer("currentlyRegistered", {
-      mode: "boolean",
-    }).default(false),
-    registrationOrder: integer("registration_order", {
-      mode: "number",
-    }).default(-1),
-    // A flag for route type that indicated if the route was added manually by user or by probe
-    routeOrigin: text("route_origin", {
-      mode: "text",
-      enum: ["discovered", "custom", "open_api"],
-    }).default("discovered"),
-    // serialized OpenAPI spec for AI prompting
-    openApiSpec: text("openapi_spec", { mode: "text" }),
-    requestType: text("request_type", {
-      mode: "text",
-      enum: ["http", "websocket"],
-    }).default("http"),
-  },
-  (table) => {
-    return {
-      id: primaryKey({
-        name: "id",
-        columns: [
-          table.method,
-          table.path,
-          table.handlerType,
-          table.routeOrigin,
-        ],
-      }),
-    };
-  },
-);
+export const appRoutes = sqliteTable("app_routes", {
+  id: integer("id", { mode: "number" }).primaryKey(),
+  path: text("path", { mode: "text" }),
+  method: text("method", { mode: "text" }),
+  // The text of the function serving the request
+  handler: text("handler", { mode: "text" }),
+  // In practice, handler_type is either "route" or "middleware" - I didn't feel like defining an enum
+  handlerType: text("handler_type", { mode: "text" }),
+  // A flag that indicates if this route is currently registered or the result of an old probe
+  currentlyRegistered: integer("currentlyRegistered", {
+    mode: "boolean",
+  }).default(false),
+  registrationOrder: integer("registration_order", {
+    mode: "number",
+  }).default(-1),
+  // A flag for route type that indicated if the route was added manually by user or by probe
+  routeOrigin: text("route_origin", {
+    mode: "text",
+    enum: ["discovered", "custom", "open_api"],
+  }).default("discovered"),
+  // serialized OpenAPI spec for AI prompting
+  openApiSpec: text("openapi_spec", { mode: "text" }),
+  requestType: text("request_type", {
+    mode: "text",
+    enum: ["http", "websocket"],
+  }).default("http"),
+});
 
 export const appRoutesSelectSchema = createSelectSchema(appRoutes);
 export const appRoutesInsertSchema = createInsertSchema(appRoutes);

--- a/api/src/lib/ai/anthropic.ts
+++ b/api/src/lib/ai/anthropic.ts
@@ -20,6 +20,11 @@ type GenerateRequestOptions = {
   baseUrl?: string;
   history?: Array<string>;
   openApiSpec?: string;
+  middleware?: {
+    handler: string;
+    method: string;
+    path: string;
+  }[];
 };
 
 /**
@@ -39,6 +44,7 @@ export async function generateRequestWithAnthropic({
   handler,
   history,
   openApiSpec,
+  middleware,
 }: GenerateRequestOptions) {
   logger.debug(
     "Generating request data with Anthropic",
@@ -49,6 +55,7 @@ export async function generateRequestWithAnthropic({
     `path: ${path}`,
     `handler: ${handler}`,
     `openApiSpec: ${openApiSpec}`,
+    `middleware: ${middleware}`,
   );
   const anthropicClient = new Anthropic({ apiKey, baseURL: baseUrl });
   const userPrompt = await invokeRequestGenerationPrompt({
@@ -58,6 +65,7 @@ export async function generateRequestWithAnthropic({
     handler,
     history,
     openApiSpec,
+    middleware,
   });
 
   const toolChoice: Anthropic.Messages.MessageCreateParams.ToolChoiceTool = {

--- a/api/src/lib/ai/index.ts
+++ b/api/src/lib/ai/index.ts
@@ -10,6 +10,7 @@ export async function generateRequestWithAiProvider({
   handler,
   history,
   openApiSpec,
+  middleware,
 }: {
   inferenceConfig: Settings;
   persona: string;
@@ -18,6 +19,11 @@ export async function generateRequestWithAiProvider({
   handler: string;
   history?: string[];
   openApiSpec?: string;
+  middleware?: {
+    handler: string;
+    method: string;
+    path: string;
+  }[];
 }) {
   const {
     openaiApiKey,
@@ -39,6 +45,7 @@ export async function generateRequestWithAiProvider({
       handler,
       history,
       openApiSpec,
+      middleware,
     }).then(
       (parsedArgs) => {
         return { data: parsedArgs, error: null };
@@ -62,6 +69,7 @@ export async function generateRequestWithAiProvider({
       handler,
       history,
       openApiSpec,
+      middleware,
     }).then(
       (parsedArgs) => {
         return { data: parsedArgs, error: null };

--- a/api/src/lib/ai/openai.ts
+++ b/api/src/lib/ai/openai.ts
@@ -13,6 +13,11 @@ type GenerateRequestOptions = {
   handler: string;
   history?: Array<string>;
   openApiSpec?: string;
+  middleware?: {
+    handler: string;
+    method: string;
+    path: string;
+  }[];
 };
 
 /**
@@ -32,6 +37,7 @@ export async function generateRequestWithOpenAI({
   handler,
   history,
   openApiSpec,
+  middleware,
 }: GenerateRequestOptions) {
   logger.debug(
     "Generating request data with OpenAI",
@@ -42,6 +48,7 @@ export async function generateRequestWithOpenAI({
     `path: ${path}`,
     `handler: ${handler}`,
     `openApiSpec: ${openApiSpec}`,
+    `middleware: ${middleware}`,
   );
   const openaiClient = new OpenAI({ apiKey, baseURL: baseUrl });
   const userPrompt = await invokeRequestGenerationPrompt({
@@ -51,6 +58,7 @@ export async function generateRequestWithOpenAI({
     handler,
     history,
     openApiSpec,
+    middleware,
   });
 
   const response = await openaiClient.chat.completions.create({

--- a/api/src/lib/app-routes.ts
+++ b/api/src/lib/app-routes.ts
@@ -16,58 +16,69 @@ export const schemaProbedRoutes = z.object({
   ),
 });
 
-export function unregisterRoutes(db: LibSQLDatabase<typeof schema>) {
-  return db
-    .update(appRoutes)
-    .set({ currentlyRegistered: false, registrationOrder: -1 });
-}
-
-export function deleteMiddleware(db: LibSQLDatabase<typeof schema>) {
-  return db.delete(appRoutes).where(eq(appRoutes.handlerType, "middleware"));
-}
-
 /**
+ * Re-registers all app routes in a database transaction
  *
+ * This is used to update the app routes when the client library reports new routes
+ *
+ * The logic is:
+ * - Unregister all routes (including middleware), by setting currentlyRegistered to false
+ * - Delete all old middleware, since we don't want stale middleware in the database
+ * - Insert all new routes and middleware
+ * - Update all routes that changed
+ *
+ * A route is considered "changed" if there's already a record in the database with
+ * the same path and method, with `handlerType === "route"` and `routeOrigin === "discovered"`,
+ * but the handler or other information is different
  */
 export async function reregisterRoutes(
   db: LibSQLDatabase<typeof schema>,
   { routes }: z.infer<typeof schemaProbedRoutes>,
 ) {
-  const currentDiscoveredRoutes = await db
-    .select()
-    .from(appRoutes)
-    .where(
-      and(
-        eq(appRoutes.handlerType, "route"),
-        eq(appRoutes.routeOrigin, "discovered"),
-      ),
-    );
+  return db.transaction(async (tx) => {
+    // Unregister all routes
+    await tx
+      .update(appRoutes)
+      .set({ currentlyRegistered: false, registrationOrder: -1 });
 
-  // HACK - N+1 query because we should never have too many routes...
-  // TODO - Use a transaction
-  // TODO - Investigate "update many" logic: https://orm.drizzle.team/learn/guides/update-many-with-different-value
-  // TODO - Could just delete all old routes we're going to update then do one big insert
-  for (const [index, route] of routes.entries()) {
-    const routeToUpdate =
-      route.handlerType === "route" &&
-      currentDiscoveredRoutes.find(
-        (r) => r.path === route.path && r.method === route.method,
+    // Delete all old middleware
+    await tx.delete(appRoutes).where(eq(appRoutes.handlerType, "middleware"));
+
+    const currentDiscoveredRoutes = await tx
+      .select()
+      .from(appRoutes)
+      .where(
+        and(
+          eq(appRoutes.handlerType, "route"),
+          eq(appRoutes.routeOrigin, "discovered"),
+        ),
       );
-    if (routeToUpdate) {
-      await db
-        .update(appRoutes)
-        .set({
-          handler: route.handler,
+
+    // HACK - This is an N+1 query, but we should never have too many routes
+    // TODO - Investigate "update many" logic: https://orm.drizzle.team/learn/guides/update-many-with-different-value
+    // TODO - Could just delete all old routes we're going to update, then do one big insert
+    for (const [index, route] of routes.entries()) {
+      const routeToUpdate =
+        route.handlerType === "route" &&
+        currentDiscoveredRoutes.find(
+          (r) => r.path === route.path && r.method === route.method,
+        );
+      if (routeToUpdate) {
+        await tx
+          .update(appRoutes)
+          .set({
+            handler: route.handler,
+            currentlyRegistered: true,
+            registrationOrder: index,
+          })
+          .where(eq(appRoutes.id, routeToUpdate.id));
+      } else {
+        await tx.insert(appRoutes).values({
+          ...route,
           currentlyRegistered: true,
           registrationOrder: index,
-        })
-        .where(eq(appRoutes.id, routeToUpdate.id));
-    } else {
-      await db.insert(appRoutes).values({
-        ...route,
-        currentlyRegistered: true,
-        registrationOrder: index,
-      });
+        });
+      }
     }
-  }
+  });
 }

--- a/api/src/lib/app-routes.ts
+++ b/api/src/lib/app-routes.ts
@@ -27,7 +27,7 @@ export function deleteMiddleware(db: LibSQLDatabase<typeof schema>) {
 }
 
 /**
- * 
+ *
  */
 export async function reregisterRoutes(
   db: LibSQLDatabase<typeof schema>,
@@ -51,9 +51,7 @@ export async function reregisterRoutes(
     const routeToUpdate =
       route.handlerType === "route" &&
       currentDiscoveredRoutes.find(
-        (r) =>
-          r.path === route.path &&
-          r.method === route.method
+        (r) => r.path === route.path && r.method === route.method,
       );
     if (routeToUpdate) {
       await db

--- a/api/src/lib/app-routes.ts
+++ b/api/src/lib/app-routes.ts
@@ -1,0 +1,68 @@
+import { and, eq } from "drizzle-orm";
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
+import { z } from "zod";
+import * as schema from "../db/schema.js";
+
+const { appRoutes } = schema;
+
+export const schemaProbedRoutes = z.object({
+  routes: z.array(
+    z.object({
+      method: z.string(),
+      path: z.string(),
+      handler: z.string(),
+      handlerType: z.string(),
+    }),
+  ),
+});
+
+export function unregisterRoutes(db: LibSQLDatabase<typeof schema>) {
+  return db
+    .update(appRoutes)
+    .set({ currentlyRegistered: false, registrationOrder: -1 });
+}
+
+export function deleteMiddleware(db: LibSQLDatabase<typeof schema>) {
+  return db.delete(appRoutes).where(eq(appRoutes.handlerType, "middleware"));
+}
+
+export async function reregisterRoutes(
+  db: LibSQLDatabase<typeof schema>,
+  { routes }: z.infer<typeof schemaProbedRoutes>,
+) {
+  const currentRoutes = await db
+    .select()
+    .from(appRoutes)
+    .where(
+      and(
+        eq(appRoutes.handlerType, "route"),
+        eq(appRoutes.routeOrigin, "discovered"),
+      ),
+    );
+  for (const [index, route] of routes.entries()) {
+    const routeToUpdate =
+      route.handlerType === "route" &&
+      currentRoutes.find(
+        (r) =>
+          r.path === route.path &&
+          r.method === route.method &&
+          r.routeOrigin === "discovered",
+      );
+    if (routeToUpdate) {
+      await db
+        .update(appRoutes)
+        .set({
+          handler: route.handler,
+          currentlyRegistered: true,
+          registrationOrder: index,
+        })
+        .where(eq(appRoutes.id, routeToUpdate.id));
+    } else {
+      await db.insert(appRoutes).values({
+        ...route,
+        currentlyRegistered: true,
+        registrationOrder: index,
+      });
+    }
+  }
+}

--- a/api/src/routes/app-routes.ts
+++ b/api/src/routes/app-routes.ts
@@ -11,6 +11,12 @@ import {
   appRoutesInsertSchema,
 } from "../db/schema.js";
 import {
+  deleteMiddleware,
+  reregisterRoutes,
+  schemaProbedRoutes,
+  unregisterRoutes,
+} from "../lib/app-routes.js";
+import {
   OTEL_TRACE_ID_REGEX,
   generateOtelTraceId,
   isValidOtelTraceId,
@@ -77,17 +83,6 @@ app.post(
   },
 );
 
-const schemaProbedRoutes = z.object({
-  routes: z.array(
-    z.object({
-      method: z.string(),
-      path: z.string(),
-      handler: z.string(),
-      handlerType: z.string(),
-    }),
-  ),
-});
-
 app.post(
   "/v0/probed-routes",
   zValidator("json", schemaProbedRoutes),
@@ -98,36 +93,11 @@ app.post(
     try {
       if (routes.length > 0) {
         // "Unregister" all app routes (including middleware)
-        await db
-          .update(appRoutes)
-          .set({ currentlyRegistered: false, registrationOrder: -1 });
+        await unregisterRoutes(db);
         // Delete all old middleware
-        await db
-          .delete(appRoutes)
-          .where(eq(appRoutes.handlerType, "middleware"));
+        await deleteMiddleware(db);
         // "Re-register" all current app routes
-        for (const [index, route] of routes.entries()) {
-          await db
-            .insert(appRoutes)
-            .values({
-              ...route,
-              currentlyRegistered: true,
-              registrationOrder: index,
-            })
-            .onConflictDoUpdate({
-              target: [
-                appRoutes.path,
-                appRoutes.method,
-                appRoutes.handlerType,
-                appRoutes.routeOrigin,
-              ],
-              set: {
-                handler: route.handler,
-                currentlyRegistered: true,
-                registrationOrder: index,
-              },
-            });
-        }
+        await reregisterRoutes(db, { routes });
 
         // TODO - Detect if anything actually changed before invalidating the query on the frontend
         //        This would be more of an optimization, but is friendlier to the frontend

--- a/api/src/routes/app-routes.ts
+++ b/api/src/routes/app-routes.ts
@@ -10,12 +10,7 @@ import {
   appRoutes,
   appRoutesInsertSchema,
 } from "../db/schema.js";
-import {
-  deleteMiddleware,
-  reregisterRoutes,
-  schemaProbedRoutes,
-  unregisterRoutes,
-} from "../lib/app-routes.js";
+import { reregisterRoutes, schemaProbedRoutes } from "../lib/app-routes.js";
 import {
   OTEL_TRACE_ID_REGEX,
   generateOtelTraceId,
@@ -92,11 +87,7 @@ app.post(
 
     try {
       if (routes.length > 0) {
-        // "Unregister" all app routes (including middleware)
-        await unregisterRoutes(db);
-        // Delete all old middleware
-        await deleteMiddleware(db);
-        // "Re-register" all current app routes
+        // "Re-register" all current app routes in a database transaction
         await reregisterRoutes(db, { routes });
 
         // TODO - Detect if anything actually changed before invalidating the query on the frontend

--- a/api/src/routes/inference.ts
+++ b/api/src/routes/inference.ts
@@ -55,8 +55,8 @@ app.post(
         method,
         path,
         handler,
-        history,
-        openApiSpec,
+        history: history ?? undefined,
+        openApiSpec: openApiSpec ?? undefined,
         middleware: middleware ? middleware : undefined,
       });
 

--- a/api/src/routes/inference.ts
+++ b/api/src/routes/inference.ts
@@ -11,7 +11,7 @@ import type { Bindings, Variables } from "../lib/types.js";
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 app.post("/v0/generate-request", cors(), async (ctx) => {
-  const { handler, method, path, history, persona, openApiSpec } =
+  const { handler, method, path, history, persona, openApiSpec, middleware } =
     await ctx.req.json();
 
   const db = ctx.get("db");
@@ -35,6 +35,7 @@ app.post("/v0/generate-request", cors(), async (ctx) => {
       handler,
       history,
       openApiSpec,
+      middleware,
     });
 
   if (generateError) {

--- a/studio/src/components/WebhoncBadge/WebhoncBadge.tsx
+++ b/studio/src/components/WebhoncBadge/WebhoncBadge.tsx
@@ -14,7 +14,7 @@ export function WebhoncBadge() {
 
   return (
     <Tooltip>
-      <TooltipTrigger>
+      <TooltipTrigger asChild>
         <Button
           className={cn(
             "rounded-xl flex items-center text-sm gap-2 cursor-pointer h-7",

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -95,7 +95,7 @@ export const RequestorPage = () => {
     getMatchingMiddleware,
   } = requestorState;
 
-  getMatchingMiddleware();
+  const matchingMiddleware = getMatchingMiddleware();
 
   const selectedRoute = getActiveRoute();
 
@@ -191,6 +191,7 @@ export const RequestorPage = () => {
     setIgnoreAiInputsBanner,
   } = useAi(
     selectedRoute,
+    matchingMiddleware,
     history,
     {
       setBody,

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -49,6 +49,10 @@ export const RequestorPage = () => {
     selectRoute: handleSelectRoute, // TODO - Rename, just not sure to what
     getActiveRoute,
 
+    // NOTE - This returns middleware that might fire for the current route
+    //        It's used to inject additional context to the ai request generation feature
+    getMatchingMiddleware,
+
     // Requestor input
     // NOTE - `requestType` is an internal property used to determine if we're making a websocket request or not
     state: { path, method, requestType },
@@ -90,12 +94,7 @@ export const RequestorPage = () => {
     state: { activeHistoryResponseTraceId },
     showResponseBodyFromHistory,
     clearResponseBodyFromHistory,
-
-    // TODO
-    getMatchingMiddleware,
   } = requestorState;
-
-  const matchingMiddleware = getMatchingMiddleware();
 
   const selectedRoute = getActiveRoute();
 
@@ -191,7 +190,7 @@ export const RequestorPage = () => {
     setIgnoreAiInputsBanner,
   } = useAi(
     selectedRoute,
-    matchingMiddleware,
+    getMatchingMiddleware(),
     history,
     {
       setBody,

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -44,6 +44,7 @@ export const RequestorPage = () => {
     // Routes panel
     state: { routes },
     setRoutes,
+    setMiddleware,
     setServiceBaseUrl,
     selectRoute: handleSelectRoute, // TODO - Rename, just not sure to what
     getActiveRoute,
@@ -89,13 +90,19 @@ export const RequestorPage = () => {
     state: { activeHistoryResponseTraceId },
     showResponseBodyFromHistory,
     clearResponseBodyFromHistory,
+
+    // TODO
+    getMatchingMiddleware,
   } = requestorState;
+
+  getMatchingMiddleware();
 
   const selectedRoute = getActiveRoute();
 
   // NOTE - This sets the `routes` and `serviceBaseUrl` in the reducer
   useRoutes({
     setRoutes,
+    setMiddleware,
     setServiceBaseUrl,
   });
 

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -44,7 +44,7 @@ export const RequestorPage = () => {
     // Routes panel
     state: { routes },
     setRoutes,
-    setMiddleware,
+    setRoutesAndMiddleware,
     setServiceBaseUrl,
     selectRoute: handleSelectRoute, // TODO - Rename, just not sure to what
     getActiveRoute,
@@ -102,7 +102,7 @@ export const RequestorPage = () => {
   // NOTE - This sets the `routes` and `serviceBaseUrl` in the reducer
   useRoutes({
     setRoutes,
-    setMiddleware,
+    setRoutesAndMiddleware,
     setServiceBaseUrl,
   });
 

--- a/studio/src/pages/RequestorPage/RoutesPanel.tsx
+++ b/studio/src/pages/RequestorPage/RoutesPanel.tsx
@@ -72,11 +72,13 @@ export function RoutesPanel({
   }, [filteredRoutes]);
 
   const detectedRoutes = useMemo(() => {
-    return (
+    const detected =
       filteredRoutes?.filter(
         (r) => r.routeOrigin === "discovered" && r.currentlyRegistered,
-      ) ?? []
-    );
+      ) ?? [];
+    // NOTE - This preserves the order the routes were registered in the Hono api
+    detected.sort((a, b) => a.registrationOrder - b.registrationOrder);
+    return detected;
   }, [filteredRoutes]);
 
   const openApiRoutes = useMemo(() => {

--- a/studio/src/pages/RequestorPage/ai/ai.ts
+++ b/studio/src/pages/RequestorPage/ai/ai.ts
@@ -29,6 +29,7 @@ type FormSetters = {
 
 export function useAi(
   selectedRoute: ProbedRoute | null,
+  matchingMiddleware: ProbedRoute[] | null,
   requestHistory: Array<Requestornator>,
   formSetters: FormSetters,
   body: RequestorBody,
@@ -63,7 +64,13 @@ export function useAi(
   }, [requestHistory]);
 
   const { isFetching: isLoadingParameters, refetch: generateRequestData } =
-    useAiRequestData(selectedRoute, bodyType, recentHistory, testingPersona);
+    useAiRequestData(
+      selectedRoute,
+      matchingMiddleware,
+      bodyType,
+      recentHistory,
+      testingPersona,
+    );
 
   const fillInRequest = useCallback(() => {
     generateRequestData().then(({ data, isError, error }) => {

--- a/studio/src/pages/RequestorPage/ai/generate-request-data.ts
+++ b/studio/src/pages/RequestorPage/ai/generate-request-data.ts
@@ -5,6 +5,7 @@ import { simplifyHistoryEntry } from "./utils";
 
 const fetchAiRequestData = (
   route: ProbedRoute | null,
+  middleware: ProbedRoute[] | null,
   bodyType: RequestBodyType,
   history: Array<Requestornator>,
   persona: string,
@@ -25,6 +26,7 @@ const fetchAiRequestData = (
       history: simplifiedHistory,
       persona,
       openApiSpec,
+      middleware,
     }),
   }).then(async (r) => {
     if (!r.ok) {
@@ -37,13 +39,15 @@ const fetchAiRequestData = (
 
 export function useAiRequestData(
   route: ProbedRoute | null,
+  matchingMiddleware: ProbedRoute[] | null,
   bodyType: RequestBodyType,
   history: Array<Requestornator>,
   persona = "Friendly",
 ) {
   return useQuery({
     queryKey: ["generateRequest"],
-    queryFn: () => fetchAiRequestData(route, bodyType, history, persona),
+    queryFn: () =>
+      fetchAiRequestData(route, matchingMiddleware, bodyType, history, persona),
     enabled: false,
     retry: false,
   });

--- a/studio/src/pages/RequestorPage/queries.ts
+++ b/studio/src/pages/RequestorPage/queries.ts
@@ -20,6 +20,7 @@ export const ProbedRouteSchema = z.object({
   handler: z.string(),
   handlerType: z.enum(["route", "middleware"]),
   currentlyRegistered: z.boolean(),
+  registrationOrder: z.number().default(-1),
   routeOrigin: z.enum(["discovered", "custom", "open_api"]),
   openApiSpec: z.string().optional(),
   requestType: RequestTypeSchema,

--- a/studio/src/pages/RequestorPage/reducer/reducer.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducer.ts
@@ -3,11 +3,7 @@ import { enforceFormDataTerminalDraftParameter } from "../FormDataForm";
 import type { KeyValueParameter } from "../KeyValueForm";
 import { enforceTerminalDraftParameter } from "../KeyValueForm/hooks";
 import type { ProbedRoute } from "../queries";
-import { findMatchedRoute } from "../routes";
-import {
-  findAllMiddlewareMatches,
-  findSmartRouterMatches,
-} from "../routes/match";
+import { findAllSmartRouterMatches, findMatchedRoute } from "../routes";
 import {
   type RequestMethod,
   type RequestMethodInputValue,
@@ -42,6 +38,7 @@ const _getActiveRoute = (state: RequestorState): ProbedRoute => {
       handler: "",
       handlerType: "route",
       currentlyRegistered: false,
+      registrationOrder: -1,
       routeOrigin: "custom",
       isDraft: true,
     }
@@ -712,10 +709,10 @@ export function useRequestor() {
    * ...
    */
   const getMatchingMiddleware = useCallback(() => {
-    // TODO
     const path = state.path;
     const method = state.method;
     const requestType = state.requestType;
+
     const matchedRoute = findMatchedRoute(
       state.routes,
       removeBaseUrl(state.serviceBaseUrl, path),
@@ -736,7 +733,7 @@ export function useRequestor() {
       (r) => r.handlerType === "middleware",
     );
 
-    const middlewareMatches = findAllMiddlewareMatches(
+    const middlewareMatches = findAllSmartRouterMatches(
       filteredMiddleware,
       removeBaseUrl(state.serviceBaseUrl, path),
       method,

--- a/studio/src/pages/RequestorPage/reducer/reducer.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducer.ts
@@ -706,7 +706,7 @@ export function useRequestor() {
   );
 
   /**
-   * ...
+   * Looks for any middleware that will match the current request
    */
   const getMatchingMiddleware = useCallback(() => {
     const path = state.path;
@@ -743,7 +743,13 @@ export function useRequestor() {
     console.log("all routes and middleware", state.routesAndMiddleware);
     console.log("filtered middleware (before route)", filteredMiddleware);
     console.log("middlewareMatches", middlewareMatches ?? "NOOOOO MATCHES YO");
-    return middlewareMatches;
+    const middleware = [];
+    for (const m of middlewareMatches ?? []) {
+      if (m?.route && m.route?.handlerType === "middleware") {
+        middleware.push(m.route);
+      }
+    }
+    return middleware;
   }, [
     state.routes,
     state.routesAndMiddleware,

--- a/studio/src/pages/RequestorPage/reducer/reducer.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducer.ts
@@ -754,7 +754,6 @@ export function useRequestor() {
       requestType,
     );
 
-    // console.log("matched route", matchedRoute);
     // console.log("all routes and middleware", state.routesAndMiddleware);
     // console.log("filtered middleware (before route)", filteredMiddleware);
     // console.log("middlewareMatches", middlewareMatches ?? "NOOOOO MATCHES YO");

--- a/studio/src/pages/RequestorPage/reducer/state.ts
+++ b/studio/src/pages/RequestorPage/reducer/state.ts
@@ -73,7 +73,9 @@ export type RequestorActiveResponse = z.infer<
 
 export const RequestorStateSchema = z.object({
   routes: z.array(ProbedRouteSchema).describe("All routes"),
-  middleware: z.array(ProbedRouteSchema).describe("All middleware"),
+  routesAndMiddleware: z
+    .array(ProbedRouteSchema)
+    .describe("All routes and middleware"),
   selectedRoute: ProbedRouteSchema.nullable().describe(
     "Indicates which route to highlight in the routes panel",
   ),
@@ -131,7 +133,7 @@ export type RequestBodyType = RequestorBody["type"];
 
 export const initialState: RequestorState = addContentTypeHeader({
   routes: [],
-  middleware: [],
+  routesAndMiddleware: [],
   selectedRoute: null,
   path: "/",
   serviceBaseUrl: "http://localhost:8787",

--- a/studio/src/pages/RequestorPage/reducer/state.ts
+++ b/studio/src/pages/RequestorPage/reducer/state.ts
@@ -73,6 +73,7 @@ export type RequestorActiveResponse = z.infer<
 
 export const RequestorStateSchema = z.object({
   routes: z.array(ProbedRouteSchema).describe("All routes"),
+  middleware: z.array(ProbedRouteSchema).describe("All middleware"),
   selectedRoute: ProbedRouteSchema.nullable().describe(
     "Indicates which route to highlight in the routes panel",
   ),
@@ -130,6 +131,7 @@ export type RequestBodyType = RequestorBody["type"];
 
 export const initialState: RequestorState = addContentTypeHeader({
   routes: [],
+  middleware: [],
   selectedRoute: null,
   path: "/",
   serviceBaseUrl: "http://localhost:8787",

--- a/studio/src/pages/RequestorPage/routes/hooks.ts
+++ b/studio/src/pages/RequestorPage/routes/hooks.ts
@@ -72,7 +72,9 @@ export function useRoutes({
   }, [routesAndMiddleware]);
 
   const activeRoutesAndMiddleware = useMemo(() => {
-    return filterActive(routesAndMiddleware?.routes ?? []);
+    const activeRoutes = filterActive(routesAndMiddleware?.routes ?? []);
+    activeRoutes.sort((a, b) => b.registrationOrder - a.registrationOrder);
+    return activeRoutes;
   }, [routesAndMiddleware]);
 
   // HACK - Antipattern, add serviceBaseUrl to the reducer based off of external changes

--- a/studio/src/pages/RequestorPage/routes/index.ts
+++ b/studio/src/pages/RequestorPage/routes/index.ts
@@ -1,3 +1,3 @@
 export { useRoutes } from "./hooks";
-export { findMatchedRoute } from "./match";
+export { findMatchedRoute, findAllSmartRouterMatches } from "./match";
 export { AddRouteButton } from "./AddRouteButton";

--- a/studio/src/pages/RequestorPage/routes/match.test.ts
+++ b/studio/src/pages/RequestorPage/routes/match.test.ts
@@ -1,6 +1,6 @@
 import type { ProbedRoute } from "../queries";
 import type { RequestMethod, RequestType } from "../types";
-import { findSmartRouterMatches } from "./match";
+import { findFirstSmartRouterMatch } from "./match";
 
 const toRoute = (
   path: string,
@@ -29,24 +29,24 @@ describe("findSmartRouterMatch", () => {
   ];
 
   it("should return a match for the given pathname and method", () => {
-    const match = findSmartRouterMatches(routes, "/test", "GET", "http");
+    const match = findFirstSmartRouterMatch(routes, "/test", "GET", "http");
     console.log("/test match", match);
     expect(match).toBeTruthy();
   });
 
   it("should return a match for the given pathname and method", () => {
-    const match = findSmartRouterMatches(routes, "/test", "POST", "http");
+    const match = findFirstSmartRouterMatch(routes, "/test", "POST", "http");
     expect(match).toBeTruthy();
   });
 
   // NOTE - Basically just testing router behavior but this is a sanity check for me
   it("should return null if no match is found (params in route)", () => {
-    const match = findSmartRouterMatches(routes, "/users", "GET", "http");
+    const match = findFirstSmartRouterMatch(routes, "/users", "GET", "http");
     expect(match).toBeNull();
   });
 
   it("should return a match for the given pathname and method", () => {
-    const match = findSmartRouterMatches(routes, "/users/1", "GET", "http");
+    const match = findFirstSmartRouterMatch(routes, "/users/1", "GET", "http");
     expect(match).toMatchObject({
       path: "/users/:userId",
       method: "GET",

--- a/studio/src/pages/RequestorPage/routes/match.test.ts
+++ b/studio/src/pages/RequestorPage/routes/match.test.ts
@@ -13,6 +13,7 @@ const toRoute = (
   handler: "",
   handlerType: "route" as const,
   currentlyRegistered: false,
+  registrationOrder: -1,
   routeOrigin: "custom" as const,
   isDraft: false,
 });

--- a/studio/src/pages/RequestorPage/routes/match.ts
+++ b/studio/src/pages/RequestorPage/routes/match.ts
@@ -61,9 +61,7 @@ export function findFirstSmartRouterMatch(
 }
 
 /**
- * Prototype of doing middleware matching in the browser with Hono itself
- *
- * NOTE - This is only different from the above insofar as it returns ALL matches
+ * Returns all matching routes (or middleware!) from the smart router
  */
 export function findAllSmartRouterMatches(
   routes: ProbedRoute[],


### PR DESCRIPTION
## Overview

This PR adds the ability to inject, as context for AI Request Generation:tm:, the stringified function code of all middleware that matches a given route.

The result is smarter request generation. If certain middleware expects a specific header, or query param, the AI will be able to auto-populate it. For example, the AI will now try to populate the "x-interesting-header" in the following api:

```ts
app.use(async (c, next) => {
  const interestingHeader = c.req.header("x-interesting-header");
  // do something with interestingHeader
  await next();
})

app.get("/", c => c.text("Hello Hono!");
```

Because the frontend only sends along _matching_ middleware as context, the following middleware would not be sent along as context for `GET /`, since the middleware would not fire for the route:

```ts
app.get("/", c => c.text("Hello Hono!");

app.use(async (c, next) => {
  const interestingHeader = c.req.header("x-interesting-header");
  // do something with interestingHeader
  await next();
})
```

### Extra Goodie

When you update your routes with a new route, the order is now reflected in the routes sidebar.

So, if you had:

- `app.get("/", ...)`
- `app.get("/api/stuff", ...)`
- `app.get("/api/things", ...)`

And you updated your routes to

- `app.get("/", ...)`
- `app.get("/api/stuff", ...)`
- `app.post("/api/stuff", ...)`
- `app.get("/api/things", ...)`

Then the routes sidebar will now have the ordering:

- `GET /`
- `GET /api/stuff`
- `POST /api/stuff`
- `GET /api/things`

Instead of

- `GET /`
- `GET /api/stuff`
- `GET /api/things`
- `POST /api/stuff`

## Database Changes

The `app_routes` table needed to be modified as follows:

1. Add the column `registration_order`, which should be the index in the array of routes returned by the app
2. Use an auto-incrementing primary key on the table, in lieu of a computed primary key

### `registration_order`
The `registration_order` column is necessary for understanding which middleware will match for a given path. 
Its default value is `-1`, meaning unregistered.

### Primary Key changes

> **SQLite doesn't allow altering primary keys** so I had to use the trick of creating a shadow copy of the table in order to define a new, identical, table with a different primary key.

We needed a new primary key for the table because the table computed its primary key from the columns:

- method
- path
- handler_type
- route_origin

However, it's possible for multiple middleware to be registered with the same method and path. For example:

```ts
app.use(async (c, next) => {
  console.log("middleware 1");
  await next();
});

app.use(async (c, next) => {
  console.log("middleware 2");
  await next();
});
```

In such a case, both of these middleware will have the column value:

- method: "ALL"
- path: "/*"
- handler_type: "middleware"
- route_origin: "discovered"

So, I opted to ditch the old computed primary key, and handle "collision" logic on the application side (see: API Changes).

This way, we can record all the app's middleware accurately when we receive a route probe.

## API Changes

### `/v0/probed-routes`

Database logic for the `POST /v0/probed-routes` route now lives in `lib/app-routes.ts`.

When we receive a route probe, the logic is now:

1. Mark all current routes in the database as "unregistered"
2. Delete all middleware (we don't want crufty middleware)
3. Re-register all middleware, insert new routes, and upsert any existing (matching) routes

All of this is done in a transaction, but it still suffers from N+1 query problem... which isn't too much of a problem since we're operating locally.

### `inference`

The prompt invocation helper now will format an array of middleware and inject it as context in the prompt.

There is a hack here: We remove `reactRenderer` middleware if we see any.

## Frontend Changes

The `useAi` hook now accepts an array of `matchingMiddleware`.

The matched middleware is computed from the list of routes and middleware. This matching logic is a little involved, but there are comments.