### PR TITLE
Client Library Canary Publish Action: Add registry-url to gh action

### DIFF
--- a/.github/workflows/publish_hono_otel_library.yml
+++ b/.github/workflows/publish_hono_otel_library.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
           cache: "pnpm"
 
       - name: Check if version is already published


### PR DESCRIPTION
The github action does not configure auth unless you define a `registry-url` field:

https://github.com/actions/setup-node/blob/26961cf329f22f6837d5f54c3efd76b480300ace/src/main.ts#L56