### PR TITLE
Timeline tweaks

### DIFF
--- a/studio/src/components/Timeline/DetailsList/spans/FetchSpan.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/FetchSpan.tsx
@@ -64,7 +64,7 @@ export function FetchSpan({
   const url = getRequestUrl(span);
 
   const { component, title } = useVendorSpecificSection(vendorInfo) ?? {};
-  const icon = useTimelineIcon(span);
+  const icon = useTimelineIcon(span, { vendorInfo });
   return (
     <GenericFetchSpan
       icon={icon}

--- a/studio/src/components/Timeline/graph/TimelineGraphLog.tsx
+++ b/studio/src/components/Timeline/graph/TimelineGraphLog.tsx
@@ -54,7 +54,6 @@ export const TimelineGraphLog: React.FC<{
           <div className="h-1.5 w-1.5 bg-blue-500 rounded-full" />
         </div>
       </div>
-      <div className="ml-auto text-gray-400 text-xs w-12 px-2" />
     </a>
   );
 };

--- a/studio/src/components/Timeline/graph/TimelineGraphSpan.tsx
+++ b/studio/src/components/Timeline/graph/TimelineGraphSpan.tsx
@@ -56,13 +56,11 @@ export const TimelineGraphSpan: React.FC<{
             "h-2.5 border-l-2 border-r-2 border-blue-500 flex items-center min-w-0 absolute",
           )}
           style={{ width: lineWidth, marginLeft: lineOffset }}
-          title={`${span.start_time} - ${span.end_time}`}
+          title={`duration: ${formatDuration(span.start_time, span.end_time)}`}
+
         >
           <div className={"h-0.5 min-w-0.5 bg-blue-500 w-full"} />
         </div>
-      </div>
-      <div className="text-gray-400 text-xs w-12 px-2">
-        {formatDuration(span.start_time, span.end_time)}
       </div>
     </a>
   );

--- a/studio/src/components/Timeline/graph/TimelineGraphSpan.tsx
+++ b/studio/src/components/Timeline/graph/TimelineGraphSpan.tsx
@@ -57,7 +57,6 @@ export const TimelineGraphSpan: React.FC<{
           )}
           style={{ width: lineWidth, marginLeft: lineOffset }}
           title={`duration: ${formatDuration(span.start_time, span.end_time)}`}
-
         >
           <div className={"h-0.5 min-w-0.5 bg-blue-500 w-full"} />
         </div>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -252,7 +252,7 @@ export const RequestorPage = () => {
       groupId: "requestor-page-main-panel",
       initialGroupSize: getMainSectionHeight(),
       minPixelSize: 200,
-      dimension: "height"
+      dimension: "height",
     });
 
   const requestContent = (

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -34,6 +34,10 @@ function getMainSectionWidth() {
   return window.innerWidth - 400;
 }
 
+function getMainSectionHeight() {
+  return window.innerHeight - 150;
+}
+
 export const RequestorPage = () => {
   const { toast } = useToast();
 
@@ -245,9 +249,10 @@ export const RequestorPage = () => {
     usePanelConstraints({
       // Change the groupId to `""` on small screens because we're not rendering
       // the resizable panel group
-      groupId: isSmallScreen ? "" : "requestor-page-main-panel",
-      initialGroupSize: width,
-      minPixelSize: 300,
+      groupId: "requestor-page-main-panel",
+      initialGroupSize: getMainSectionHeight(),
+      minPixelSize: 200,
+      dimension: "height"
     });
 
   const requestContent = (
@@ -389,7 +394,7 @@ export const RequestorPage = () => {
               </>
             ) : (
               <ResizablePanelGroup
-                direction={isSmallScreen ? "vertical" : "horizontal"}
+                direction={"vertical"}
                 id="requestor-page-main-panel"
                 autoSaveId="requestor-page-main-panel"
                 className={cn(
@@ -406,11 +411,6 @@ export const RequestorPage = () => {
                   order={1}
                   className="relative"
                   id="request-panel"
-                  defaultSize={
-                    width < 624 || requestPanelMinSize === undefined
-                      ? undefined
-                      : Math.max(requestPanelMinSize, 33)
-                  }
                   minSize={requestPanelMinSize}
                   maxSize={requestPanelMaxSize}
                 >

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -246,9 +246,9 @@ function ResponseSummary({
   const url = isRequestorActiveResponse(response)
     ? response?.requestUrl
     : parsePathFromRequestUrl(
-      response?.app_requests?.requestUrl ?? "",
-      response?.app_requests?.requestQueryParams ?? undefined,
-    );
+        response?.app_requests?.requestUrl ?? "",
+        response?.app_requests?.requestQueryParams ?? undefined,
+      );
   return (
     <div className="flex items-center space-x-2 text-sm">
       <StatusCode status={status ?? "—"} isFailure={!status} />

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -182,7 +182,7 @@ export function ResponsePanel({
                         ) : (
                           <CaretRightIcon className="w-4 h-4 cursor-pointer" />
                         )}
-                        Timeline
+                        Logs & events
                       </SubSectionHeading>
                     </CollapsibleTrigger>
                     <CollapsibleContent>
@@ -246,9 +246,9 @@ function ResponseSummary({
   const url = isRequestorActiveResponse(response)
     ? response?.requestUrl
     : parsePathFromRequestUrl(
-        response?.app_requests?.requestUrl ?? "",
-        response?.app_requests?.requestQueryParams ?? undefined,
-      );
+      response?.app_requests?.requestUrl ?? "",
+      response?.app_requests?.requestQueryParams ?? undefined,
+    );
   return (
     <div className="flex items-center space-x-2 text-sm">
       <StatusCode status={status ?? "—"} isFailure={!status} />

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -182,7 +182,7 @@ export function ResponsePanel({
                         ) : (
                           <CaretRightIcon className="w-4 h-4 cursor-pointer" />
                         )}
-                        Logs & events
+                        Logs & Events
                       </SubSectionHeading>
                     </CollapsibleTrigger>
                     <CollapsibleContent>


### PR DESCRIPTION
Included:
* change layout (use vertical stacking instead of horizontal for request/response panels)
* rename timeline to `logs & events`
* remove duration column in the graph (spans show their duration on hover as well as in the list)
![image](https://github.com/user-attachments/assets/da39d334-0d03-482a-bf4d-9d7d9499e7db)

