### PR TITLE
Fix issue where 204 no content could not be proxied

### DIFF
--- a/api/src/lib/proxy-request/index.ts
+++ b/api/src/lib/proxy-request/index.ts
@@ -140,7 +140,7 @@ export async function handleSuccessfulRequest(
       .extend({
         headers: z.instanceof(Headers),
         status: z.number(),
-        body: z.instanceof(ReadableStream),
+        body: z.instanceof(ReadableStream).nullable(),
         traceId: z.string().optional(),
       })
       .transform(async ({ headers, status }) => {


### PR DESCRIPTION
One line fix.

We needed a better zod schema that understood the response body might be null!