### PR TITLE
Do not attach content-type or content-length to request headers when  method WS, GET, or HEAD

### DIFF
--- a/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
+++ b/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
@@ -73,7 +73,7 @@ const FormDataFormRow = (props: FormDataRowProps) => {
         placeholder="name"
         readOnly={!onChangeKey}
         onChange={(e) => onChangeKey?.(e.target.value)}
-        className="w-24 h-8 bg-transparent shadow-none px-2 py-0 text-sm border-none"
+        className="w-28 h-8 bg-transparent shadow-none px-2 py-0 text-sm border-none"
       />
       {value.type === "text" && (
         <Input

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -60,7 +60,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
         placeholder="name"
         readOnly={!onChangeKey}
         onChange={(e) => onChangeKey?.(e.target.value)}
-        className="w-24 h-8 bg-transparent shadow-none px-2 py-0 text-sm border-none"
+        className="w-28 h-8 bg-transparent shadow-none px-2 py-0 text-sm border-none"
       />
       <Input
         type="text"

--- a/studio/src/pages/RequestorPage/reducer/reducer.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducer.ts
@@ -412,6 +412,10 @@ function requestorReducer(
           },
         });
       }
+      // When the user adds a file, we want to use the file's type as the content type header
+      if (nextBody.type === "file") {
+        return addContentTypeHeader({ ...state, body: nextBody });
+      }
       return { ...state, body: nextBody };
     }
     case CLEAR_BODY: {

--- a/studio/src/pages/RequestorPage/reducer/reducers/content-type.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducers/content-type.ts
@@ -64,6 +64,8 @@ function removeHeader(
   return currentHeaders.filter((p) => p.id !== header.id);
 }
 
+// NOTE - This logic is partly duplicated in `useRequestorSubmitHandler`
+//        We should refactor to share this logic
 function mapBodyToContentType(body: RequestorBody) {
   if (body.type === "form-data" && body.isMultipart) {
     return "multipart/form-data";
@@ -72,10 +74,9 @@ function mapBodyToContentType(body: RequestorBody) {
     return "application/x-www-form-urlencoded";
   }
 
-  // TODO - Sniff the file extension, this could otherwise be very very annoying
-  //        if we keep resetting their content type header when it's already set to like "application/iamge"
+  // NOTE - Uses the mime type of the file, but falls back to application/octet-stream
   if (body.type === "file") {
-    return "application/octet-stream";
+    return body.value?.type ?? "application/octet-stream";
   }
 
   if (body.type === "json") {
@@ -130,12 +131,6 @@ function getUpdateOperation(
       return null;
     }
 
-    // If the body is a file, we don't want to add the content type header, in order to give the user the ability to set the content type themselves
-    // If the user doesn't define a content type, fetch will just add application/octet-stream
-    if (currentBody.type === "file") {
-      return null;
-    }
-
     // Add the content type header
     return {
       type: "add",
@@ -167,18 +162,6 @@ function getUpdateOperation(
       type: "remove",
       value: currentContentTypeHeader,
     };
-  }
-
-  if (currentBody.type === "file") {
-    if (
-      currentContentTypeHeader.value?.startsWith("text/") ||
-      currentContentTypeHeader.value?.startsWith("application/json")
-    ) {
-      return {
-        type: "remove",
-        value: currentContentTypeHeader,
-      };
-    }
   }
 
   // Update the content type header

--- a/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -131,6 +131,8 @@ export function useRequestorSubmitHandler({
   );
 }
 
+// NOTE - This logic is partly duplicated in `reducer/reducers/content-type.ts`
+//        We should refactor to share this logic
 function getContentTypeHeader(body: RequestorBody): string | null {
   switch (body.type) {
     case "json":
@@ -146,8 +148,11 @@ function getContentTypeHeader(body: RequestorBody): string | null {
       }
       return "application/x-www-form-urlencoded";
     }
-    case "file":
-      return "application/octet-stream";
+    case "file": {
+      const file = body.value;
+      // TODO - What if file is undefined?
+      return file?.type ?? "application/octet-stream";
+    }
     default:
       return "text/plain";
   }

--- a/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -49,8 +49,10 @@ export function useRequestorSubmitHandler({
       }
 
       // TODO - Make it clear in the UI that we're auto-adding this header
-      const contentTypeHeader = getContentTypeHeader(body);
-      const contentLength = getContentLength(body);
+      const canHaveBody =
+        !isWsRequest(requestType) && !["GET", "DELETE"].includes(method);
+      const contentTypeHeader = canHaveBody ? getContentTypeHeader(body) : null;
+      const contentLength = canHaveBody ? getContentLength(body) : null;
       const modifiedHeaders = [
         contentTypeHeader
           ? {


### PR DESCRIPTION
Requestor fix - very simple. Prevents bugs! And we don't like bugs.

Extra goodie!

- Add the mime type of an attached file as the content-type, when working with files