### PR TITLE
Densifying UI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,9 @@ importers:
       '@darkobits/vite-plugin-favicons':
         specifier: ^0.3.2
         version: 0.3.2(typescript@5.5.4)(vite@5.4.0(@types/node@20.14.15))
+      '@iconify/react':
+        specifier: ^5.0.2
+        version: 5.0.2(react@18.3.1)
       '@types/node':
         specifier: ^20.12.12
         version: 20.14.15
@@ -1710,6 +1713,11 @@ packages:
 
   '@iconify-json/lucide@1.1.208':
     resolution: {integrity: sha512-wdlljQKeoqmIw3YcYMCObPvuB3Gc0vbb0tocULrb0isl7wqINlHmcCAbL2mtLbHmwbldtW25AsplB6H56njPoA==}
+
+  '@iconify/react@5.0.2':
+    resolution: {integrity: sha512-wtmstbYlEbo4NDxFxBJkhkf9gJBDqMGr7FaqLrAUMneRV3Z+fVHLJjOhWbkAF8xDQNFC/wcTYdrWo1lnRhmagQ==}
+    peerDependencies:
+      react: '>=16'
 
   '@iconify/tools@4.0.5':
     resolution: {integrity: sha512-l8KoA1lxlN/FFjlMd3vjfD7BtcX/QnFWtlBapILMlJSBgM5zhDYak/ldw/LkKG3258q/0YmXa48sO/QpxX7ptg==}
@@ -5097,6 +5105,7 @@ packages:
 
   libsql@0.3.19:
     resolution: {integrity: sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@2.1.0:
@@ -8389,6 +8398,11 @@ snapshots:
   '@iconify-json/lucide@1.1.208':
     dependencies:
       '@iconify/types': 2.0.0
+
+  '@iconify/react@5.0.2(react@18.3.1)':
+    dependencies:
+      '@iconify/types': 2.0.0
+      react: 18.3.1
 
   '@iconify/tools@4.0.5':
     dependencies:

--- a/studio/package.json
+++ b/studio/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@darkobits/vite-plugin-favicons": "^0.3.2",
+    "@iconify/react": "^5.0.2",
     "@types/node": "^20.12.12",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",

--- a/studio/src/Layout.tsx
+++ b/studio/src/Layout.tsx
@@ -12,7 +12,7 @@ import { cn } from "./utils";
 const Branding = () => {
   return (
     <div>
-      <FpxIcon height="32px" width="32px" />
+      <FpxIcon height="20px" width="20px" />
     </div>
   );
 };
@@ -30,7 +30,7 @@ export const Layout: React.FC<{ children?: React.ReactNode }> = ({
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-muted/30 max-w-128 overflow-hidden">
-      <nav className="flex gap-4 sm:gap-4 py-4 sm:py-0 justify-between items-center h-[64px] border-b">
+      <nav className="flex gap-4 sm:gap-4 py-4 sm:py-0 justify-between items-center h-[38px] border-b">
         <div className="sticky top-0 flex items-center gap-2 px-4 sm:static sm:h-auto border-0 bg-transparent md:px-6 py-2 text-sm">
           <Branding />
           <div className="ml-2">
@@ -47,30 +47,30 @@ export const Layout: React.FC<{ children?: React.ReactNode }> = ({
               <WebhoncBadge />
             </div>
           )}
-          <div className="flex items-center gap-0 border-l px-1">
-            <Button variant="ghost" size="icon">
+          <div className="flex items-center border-l gap-1 px-1">
+            <Button variant="ghost" size="icon" className="p-0.5 w-6 h-6">
               <a
                 href="https://github.com/fiberplane/fpx"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <GitHubLogoIcon className="w-4 h-4" />
+                <GitHubLogoIcon className="w-3.5 h-3.5" />
               </a>
             </Button>
-            <Button variant="ghost" size="icon">
+            <Button variant="ghost" size="icon" className="p-0.5 w-6 h-6">
               <a
                 href="https://discord.com/invite/cqdY6SpfVR"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <DiscordLogoIcon className="w-4 h-4" />
+                <DiscordLogoIcon className="w-3.5 h-3.5" />
               </a>
             </Button>
           </div>
         </div>
       </nav>
       <main
-        className={cn("md:gap-8", "overflow-hidden", "h-[calc(100vh-64px)]")}
+        className={cn("md:gap-8", "overflow-hidden", "h-[calc(100vh-40px)]")}
       >
         {children}
       </main>
@@ -83,7 +83,7 @@ const HeaderNavLink = (props: ComponentProps<typeof NavLink>) => {
     <NavLink
       {...props}
       className={({ isActive }) =>
-        `rounded ${isActive ? "bg-muted" : ""} inline-block py-2 px-4 hover:underline`
+        `rounded ${isActive ? "bg-muted" : ""} inline-block py-1 px-2 hover:underline text-xs`
       }
     />
   );

--- a/studio/src/Layout.tsx
+++ b/studio/src/Layout.tsx
@@ -30,8 +30,8 @@ export const Layout: React.FC<{ children?: React.ReactNode }> = ({
 
   return (
     <div className="flex min-h-screen w-full flex-col bg-muted/30 max-w-128 overflow-hidden">
-      <nav className="flex gap-4 sm:gap-4 py-4 sm:py-0 justify-between items-center h-[38px] border-b">
-        <div className="sticky top-0 flex items-center gap-2 px-4 sm:static sm:h-auto border-0 bg-transparent md:px-6 py-2 text-sm">
+      <nav className="flex gap-4 sm:gap-4 py-2 sm:py-2 justify-between items-center border-b">
+        <div className="sticky top-0 flex items-center gap-2 px-4 sm:static sm:h-auto border-0 bg-transparent md:px-6 text-sm">
           <Branding />
           <div className="ml-2">
             <div className="flex items-center gap-2 text-sm">

--- a/studio/src/components/Timeline/DetailsList/TextJsonViewer.tsx
+++ b/studio/src/components/Timeline/DetailsList/TextJsonViewer.tsx
@@ -4,7 +4,7 @@ import { nordTheme } from "@uiw/react-json-view/nord";
 
 export function TextOrJsonViewer({
   text,
-  collapsed,
+  collapsed = true,
   textMaxPreviewLength,
   textMaxPreviewLines,
 }: {

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -67,7 +67,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
         value={value}
         placeholder="value"
         onChange={(e) => onChangeValue(e.target.value)}
-        className="h-8 flex-grow bg-transparent shadow-none px-2 py-0 text-sm border-none"
+        className="h-8 min-width-28 w-auto bg-transparent shadow-none px-2 py-0 text-sm border-none"
       />
       <div
         className={cn("ml-1 flex invisible", {

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -67,7 +67,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
         value={value}
         placeholder="value"
         onChange={(e) => onChangeValue(e.target.value)}
-        className="h-8 min-width-28 w-auto bg-transparent shadow-none px-2 py-0 text-sm border-none"
+        className="h-8 w-full bg-transparent shadow-none px-2 py-0 text-sm border-none"
       />
       <div
         className={cn("ml-1 flex invisible", {

--- a/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/BottomToolbar.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/BottomToolbar.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/utils";
 import { CopyAsCurl, type CopyAsCurlProps } from "./CopyAsCurl";
 import {
   RequestBodyTypeDropdown,
@@ -18,7 +19,12 @@ export function BottomToolbar({
   const isDropdownDisabled = method === "GET" || method === "HEAD";
 
   return (
-    <div className="flex justify-between gap-2 absolute bottom-0 w-full p-2 backdrop-blur-sm border-t">
+    <div
+      className={cn(
+        "bg-muted",
+        "flex justify-between absolute bottom-0 w-full border-t",
+      )}
+    >
       <RequestBodyTypeDropdown
         requestBody={body}
         handleRequestBodyTypeChange={handleRequestBodyTypeChange}

--- a/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/CopyAsCurl.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/CopyAsCurl.tsx
@@ -70,13 +70,13 @@ export function CopyAsCurl({
           variant="secondary"
           size="icon"
           type="button"
-          className="disabled:pointer-events-auto"
+          className="disabled:pointer-events-auto h-auto"
           disabled={isUnsupportedBodyType}
         >
           {isCopied ? (
-            <CheckIcon className="w-5 h-5" />
+            <CheckIcon className="w-4 h-4" />
           ) : (
-            <CopyIcon className="w-4 h-4" />
+            <CopyIcon className="w-3 h-3" />
           )}
         </Button>
       </TooltipTrigger>

--- a/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/RequestBodyCombobox.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/BottomToolbar/RequestBodyCombobox.tsx
@@ -64,10 +64,10 @@ export function RequestBodyTypeDropdown({
                 variant="secondary"
                 role="combobox"
                 aria-expanded={open}
-                className="pl-3 disabled:pointer-events-auto"
+                className="pl-3 disabled:pointer-events-auto text-xs h-6"
                 disabled={isDisabled}
               >
-                <CaretSortIcon className="w-4 h-4 mr-1" />
+                <CaretSortIcon className="w-3 h-3 mr-1" />
                 {bodyTypeLabel}
               </Button>
             </PopoverTrigger>
@@ -101,6 +101,7 @@ export function RequestBodyTypeDropdown({
                 <CommandItem
                   key={type.value}
                   value={type.value}
+                  className="text-xs"
                   onSelect={(currentValue) => {
                     handleRequestBodyTypeChange(
                       currentValue as RequestBodyType,

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -328,7 +328,7 @@ export function PanelSectionHeader({
   return (
     <div
       className={cn(
-        "uppercase text-gray-400 text-xs mb-2 flex items-center gap-2",
+        "uppercase justify-between text-gray-400 text-xs mb-2 flex items-center",
         className,
       )}
     >

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -162,7 +162,7 @@ export const RequestPanel = memo(function RequestPanel(
           setIgnoreAiInputsBanner={setIgnoreAiInputsBanner}
         />
         <PanelSectionHeader
-          title="Query parameters"
+          title="Query"
           handleClearData={() => {
             setQueryParams([]);
           }}
@@ -176,7 +176,7 @@ export const RequestPanel = memo(function RequestPanel(
         {pathParams.length > 0 ? (
           <>
             <PanelSectionHeader
-              title="Path parameters"
+              title="Path"
               handleClearData={clearPathParams}
               className="mt-4"
             />
@@ -328,7 +328,7 @@ export function PanelSectionHeader({
   return (
     <div
       className={cn(
-        "uppercase text-gray-400 text-sm mb-2 flex items-center justify-between",
+        "uppercase text-gray-400 text-xs mb-2 flex items-center gap-2",
         className,
       )}
     >

--- a/studio/src/pages/RequestorPage/RequestorHistory.tsx
+++ b/studio/src/pages/RequestorPage/RequestorHistory.tsx
@@ -149,6 +149,7 @@ export function StatusCode({
         "rounded-md",
         "px-2",
         "py-1",
+        "text-xs",
         "bg-opacity-30",
         "font-sans",
         isGreen && ["text-green-400", "bg-green-800"],

--- a/studio/src/pages/RequestorPage/RequestorInput.tsx
+++ b/studio/src/pages/RequestorPage/RequestorInput.tsx
@@ -102,7 +102,7 @@ export function RequestorInput({
           onChange={(e) => {
             handlePathInputChange(e.target.value);
           }}
-          className="flex-grow w-full bg-transparent font-mono border-none shadow-none focus:ring-0 ml-0"
+          className="flex-grow text-xs w-full bg-transparent font-mono border-none shadow-none focus:ring-0 ml-0"
         />
       </div>
       <div className="flex items-center space-x-2 px-2 py-0">

--- a/studio/src/pages/RequestorPage/RequestorInput.tsx
+++ b/studio/src/pages/RequestorPage/RequestorInput.tsx
@@ -105,7 +105,7 @@ export function RequestorInput({
           className="flex-grow w-full bg-transparent font-mono border-none shadow-none focus:ring-0 ml-0"
         />
       </div>
-      <div className="flex items-center space-x-2 p-2">
+      <div className="flex items-center space-x-2 px-2 py-0">
         {canSaveDraftRoute && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -155,7 +155,7 @@ export function RequestorInput({
               }}
               disabled={isRequestorRequesting}
               variant={isWsConnected ? "destructive" : "default"}
-              className={cn("p-2 md:p-2.5")}
+              className={cn("p-2 md:px-2.5 py-1 h-auto")}
             >
               <span className="hidden md:inline">
                 {isWsRequest(requestType)

--- a/studio/src/pages/RequestorPage/RequestorInput.tsx
+++ b/studio/src/pages/RequestorPage/RequestorInput.tsx
@@ -10,11 +10,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { cn, isMac } from "@/utils";
 import { useHandler } from "@fiberplane/hooks";
 import { Icon } from "@iconify/react";
-import {
-  FilePlusIcon,
-  MixerHorizontalIcon,
-  TriangleRightIcon,
-} from "@radix-ui/react-icons";
+import { FilePlusIcon, MixerHorizontalIcon } from "@radix-ui/react-icons";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useShallow } from "zustand/react/shallow";
 import { RequestMethodCombobox } from "./RequestMethodCombobox";

--- a/studio/src/pages/RequestorPage/RequestorInput.tsx
+++ b/studio/src/pages/RequestorPage/RequestorInput.tsx
@@ -9,12 +9,12 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import { cn, isMac } from "@/utils";
 import { useHandler } from "@fiberplane/hooks";
+import { Icon } from "@iconify/react";
 import {
   FilePlusIcon,
   MixerHorizontalIcon,
   TriangleRightIcon,
 } from "@radix-ui/react-icons";
-import { Icon } from "@iconify/react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useShallow } from "zustand/react/shallow";
 import { RequestMethodCombobox } from "./RequestMethodCombobox";

--- a/studio/src/pages/RequestorPage/RequestorInput.tsx
+++ b/studio/src/pages/RequestorPage/RequestorInput.tsx
@@ -14,6 +14,7 @@ import {
   MixerHorizontalIcon,
   TriangleRightIcon,
 } from "@radix-ui/react-icons";
+import { Icon } from "@iconify/react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useShallow } from "zustand/react/shallow";
 import { RequestMethodCombobox } from "./RequestMethodCombobox";
@@ -167,7 +168,10 @@ export function RequestorInput({
               {isWsRequest(requestType) ? (
                 <MixerHorizontalIcon className="md:hidden w-6 h-6" />
               ) : (
-                <TriangleRightIcon className="md:hidden w-6 h-6" />
+                <Icon
+                  icon="lucide:send-horizontal"
+                  className="w-4 h-4 md:hidden"
+                />
               )}
             </Button>
           </TooltipTrigger>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -254,9 +254,7 @@ export const RequestorPage = () => {
                 id="requestor-page-main-panel"
                 autoSaveId="requestor-page-main-panel"
                 className={cn(
-                  BACKGROUND_LAYER,
                   "rounded-md",
-                  "border",
                   // HACK - This defensively prevents overflow from getting too excessive,
                   //        In the case where the inner content expands beyond the parent
                   "max-w-screen",
@@ -265,15 +263,23 @@ export const RequestorPage = () => {
               >
                 <ResizablePanel
                   order={1}
-                  className="relative"
+                  className={cn(BACKGROUND_LAYER, "relative", "rounded-md")}
                   id="request-panel"
                   minSize={requestPanelMinSize}
                   maxSize={requestPanelMaxSize}
                 >
                   {requestContent}
                 </ResizablePanel>
-                <ResizableHandle hitAreaMargins={{ coarse: 20, fine: 10 }} />
-                <ResizablePanel id="response-panel" order={4} minSize={10}>
+                <ResizableHandle
+                  hitAreaMargins={{ coarse: 20, fine: 10 }}
+                  className="bg-transparent m-1 rounded-md"
+                />
+                <ResizablePanel
+                  id="response-panel"
+                  order={4}
+                  minSize={10}
+                  className={cn(BACKGROUND_LAYER, "rounded-md", "border")}
+                >
                   {responseContent}
                 </ResizablePanel>
                 {isAiTestGenerationPanelOpen && !isSmallScreen && (

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -131,7 +131,6 @@ export const RequestorPage = () => {
   );
 
   const width = getMainSectionWidth();
-  const isSmallScreen = useIsSmScreen();
   const isLgScreen = useIsLgScreen();
 
   const { minSize, maxSize } = usePanelConstraints({
@@ -232,8 +231,8 @@ export const RequestorPage = () => {
               "h-[calc(100%-0.6rem)]",
               "lg:h-full",
               "relative",
-              "overflow-scroll",
-              "sm:overflow-hidden",
+              // "overflow-scroll",
+              "overflow-hidden",
             )}
           >
             <RequestorInput
@@ -243,12 +242,6 @@ export const RequestorPage = () => {
               formRef={formRef}
               websocketState={websocketState}
             />
-            {isSmallScreen ? (
-              <>
-                {requestContent}
-                {responseContent}
-              </>
-            ) : (
               <ResizablePanelGroup
                 direction="vertical"
                 id="requestor-page-main-panel"
@@ -289,19 +282,12 @@ export const RequestorPage = () => {
                       minSize={10}
                       className={cn(BACKGROUND_LAYER)}
                     >
-                      <AiTestGenerationPanel
-                        // TODO - Only use history for recent matching route
-                        history={history}
-                        toggleAiTestGenerationPanel={
-                          toggleAiTestGenerationPanel
-                        }
-                      />
                       {responseContent}
                     </ResizablePanel>
                   </ResizablePanelGroup>
                 </ResizablePanel>
                 <ResizablePanel>
-                  {isAiTestGenerationPanelOpen && !isSmallScreen && (
+                  {isAiTestGenerationPanelOpen && (
                     <>
                       <ResizableHandle
                         hitAreaMargins={{ coarse: 20, fine: 10 }}
@@ -324,15 +310,12 @@ export const RequestorPage = () => {
                           toggleAiTestGenerationPanel={
                             toggleAiTestGenerationPanel
                           }
-                          getActiveRoute={getActiveRoute}
-                          removeServiceUrlFromPath={removeServiceUrlFromPath}
                         />
                       </ResizablePanel>
                     </>
                   )}
                 </ResizablePanel>
               </ResizablePanelGroup>
-            )}
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
@@ -399,8 +382,8 @@ pace-x-6 h-12"
     <h1
       className="inline-flex items-center justify-center whitespace-nowrap rounded-md ring-offset-background transition-
 all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-ev
-ents-none disabled:opacity-50 py-2 px-0 text-left h-12 ml-2 text-sm font-normal border-b border-transparent font-medium tex
-t-gray-100 shadow-none bg-inherit rounded-none border-blue-500"
+ents-none disabled:opacity-50 py-2 px-0 text-left h-12 ml-2 text-sm border-b border-transparent font-medium tex
+t-gray-100 shadow-none bg-inherit border-blue-500"
     >
       {props.children}
     </h1>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -259,6 +259,7 @@ export const RequestorPage = () => {
                   //        In the case where the inner content expands beyond the parent
                   "max-w-screen",
                   "max-h-full",
+                  "gap-1",
                 )}
               >
                 <ResizablePanel
@@ -277,7 +278,7 @@ export const RequestorPage = () => {
                 </ResizablePanel>
                 <ResizableHandle
                   hitAreaMargins={{ coarse: 20, fine: 10 }}
-                  className="bg-transparent m-1 rounded-md"
+                  className="bg-transparent"
                 />
                 <ResizablePanel
                   id="response-panel"
@@ -291,8 +292,13 @@ export const RequestorPage = () => {
                   <>
                     <ResizableHandle
                       hitAreaMargins={{ coarse: 20, fine: 10 }}
+                      className="bg-transparent"
                     />
-                    <ResizablePanel order={3} id="ai-panel">
+                    <ResizablePanel
+                      order={3}
+                      id="ai-panel"
+                      className={cn(BACKGROUND_LAYER, "rounded-md", "border")}
+                    >
                       <AiTestGenerationPanel
                         // TODO - Only use history for recent matching route
                         history={history}

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -180,7 +180,7 @@ export const RequestorPage = () => {
     <div
       className={cn(
         // It's critical the parent has a fixed height for our grid layout to work
-        "h-[calc(100vh-64px)]",
+        "h-[calc(100vh-40px)]",
         "flex",
         "flex-col",
         "gap-2",

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -250,49 +250,44 @@ export const RequestorPage = () => {
               </>
             ) : (
               <ResizablePanelGroup
-                direction={isLgScreen ? "horizontal" : "vertical"}
+                direction="vertical"
                 id="requestor-page-main-panel"
                 autoSaveId="requestor-page-main-panel"
-                className={cn(
-                  "rounded-md",
-                  // HACK - This defensively prevents overflow from getting too excessive,
-                  //        In the case where the inner content expands beyond the parent
-                  "max-w-screen",
-                  "max-h-full",
-                  // "gap-1",
-                )}
               >
                 <ResizablePanel
-                  order={1}
-                  className={cn(BACKGROUND_LAYER, "relative")}
-                  id="request-panel"
-                  minSize={requestPanelMinSize}
-                  maxSize={requestPanelMaxSize}
+                  defaultSize={isAiTestGenerationPanelOpen ? 50 : 100}
                 >
-                  {requestContent}
-                </ResizablePanel>
-                <ResizableHandle
-                  hitAreaMargins={{ coarse: 20, fine: 10 }}
-                  className="bg-transparent"
-                />
-                <ResizablePanel
-                  id="response-panel"
-                  order={4}
-                  minSize={10}
-                  className={cn(BACKGROUND_LAYER)}
-                >
-                  {responseContent}
-                </ResizablePanel>
-                {isAiTestGenerationPanelOpen && !isSmallScreen && (
-                  <>
+                  <ResizablePanelGroup
+                    direction={isLgScreen ? "horizontal" : "vertical"}
+                    id="requestor-page-request-panel-group"
+                    autoSaveId="requestor-page-request-panel-group"
+                    className={cn(
+                      "rounded-md",
+                      // HACK - This defensively prevents overflow from getting too excessive,
+                      //        In the case where the inner content expands beyond the parent
+                      "max-w-screen",
+                      "max-h-full",
+                      // "gap-1",
+                    )}
+                  >
+                    <ResizablePanel
+                      order={1}
+                      className={cn(BACKGROUND_LAYER, "relative")}
+                      id="request-panel"
+                      minSize={requestPanelMinSize}
+                      maxSize={requestPanelMaxSize}
+                    >
+                      {requestContent}
+                    </ResizablePanel>
                     <ResizableHandle
                       hitAreaMargins={{ coarse: 20, fine: 10 }}
                       className="bg-transparent"
                     />
                     <ResizablePanel
-                      order={3}
-                      id="ai-panel"
-                      className={cn(BACKGROUND_LAYER, "rounded-md", "border")}
+                      id="response-panel"
+                      order={4}
+                      minSize={10}
+                      className={cn(BACKGROUND_LAYER)}
                     >
                       <AiTestGenerationPanel
                         // TODO - Only use history for recent matching route
@@ -301,9 +296,41 @@ export const RequestorPage = () => {
                           toggleAiTestGenerationPanel
                         }
                       />
+                      {responseContent}
                     </ResizablePanel>
-                  </>
-                )}
+                  </ResizablePanelGroup>
+                </ResizablePanel>
+                <ResizablePanel>
+                  {isAiTestGenerationPanelOpen && !isSmallScreen && (
+                    <>
+                      <ResizableHandle
+                        hitAreaMargins={{ coarse: 20, fine: 10 }}
+                        className="bg-transparent"
+                      />
+                      <ResizablePanel
+                        order={3}
+                        id="ai-panel"
+                        className={cn(
+                          BACKGROUND_LAYER,
+                          "rounded-md",
+                          "border",
+                          "h-full",
+                          "mt-2",
+                        )}
+                      >
+                        <AiTestGenerationPanel
+                          // TODO - Only use history for recent matching route
+                          history={history}
+                          toggleAiTestGenerationPanel={
+                            toggleAiTestGenerationPanel
+                          }
+                          getActiveRoute={getActiveRoute}
+                          removeServiceUrlFromPath={removeServiceUrlFromPath}
+                        />
+                      </ResizablePanel>
+                    </>
+                  )}
+                </ResizablePanel>
               </ResizablePanelGroup>
             )}
           </div>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -263,7 +263,12 @@ export const RequestorPage = () => {
               >
                 <ResizablePanel
                   order={1}
-                  className={cn(BACKGROUND_LAYER, "relative", "rounded-md")}
+                  className={cn(
+                    BACKGROUND_LAYER,
+                    "relative",
+                    "rounded-md",
+                    "border",
+                  )}
                   id="request-panel"
                   minSize={requestPanelMinSize}
                   maxSize={requestPanelMaxSize}

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -250,7 +250,7 @@ export const RequestorPage = () => {
               </>
             ) : (
               <ResizablePanelGroup
-                direction={"vertical"}
+                direction={isLgScreen ? "horizontal" : "vertical"}
                 id="requestor-page-main-panel"
                 autoSaveId="requestor-page-main-panel"
                 className={cn(
@@ -259,12 +259,12 @@ export const RequestorPage = () => {
                   //        In the case where the inner content expands beyond the parent
                   "max-w-screen",
                   "max-h-full",
-                  "gap-1",
+                  // "gap-1",
                 )}
               >
                 <ResizablePanel
                   order={1}
-                  className={cn(BACKGROUND_LAYER, "relative", "rounded-md")}
+                  className={cn(BACKGROUND_LAYER, "relative")}
                   id="request-panel"
                   minSize={requestPanelMinSize}
                   maxSize={requestPanelMaxSize}
@@ -279,7 +279,7 @@ export const RequestorPage = () => {
                   id="response-panel"
                   order={4}
                   minSize={10}
-                  className={cn(BACKGROUND_LAYER, "rounded-md", "border")}
+                  className={cn(BACKGROUND_LAYER)}
                 >
                   {responseContent}
                 </ResizablePanel>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -264,12 +264,7 @@ export const RequestorPage = () => {
               >
                 <ResizablePanel
                   order={1}
-                  className={cn(
-                    BACKGROUND_LAYER,
-                    "relative",
-                    "rounded-md",
-                    "border",
-                  )}
+                  className={cn(BACKGROUND_LAYER, "relative", "rounded-md")}
                   id="request-panel"
                   minSize={requestPanelMinSize}
                   maxSize={requestPanelMaxSize}

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -242,80 +242,80 @@ export const RequestorPage = () => {
               formRef={formRef}
               websocketState={websocketState}
             />
-              <ResizablePanelGroup
-                direction="vertical"
-                id="requestor-page-main-panel"
-                autoSaveId="requestor-page-main-panel"
+            <ResizablePanelGroup
+              direction="vertical"
+              id="requestor-page-main-panel"
+              autoSaveId="requestor-page-main-panel"
+            >
+              <ResizablePanel
+                defaultSize={isAiTestGenerationPanelOpen ? 50 : 100}
               >
-                <ResizablePanel
-                  defaultSize={isAiTestGenerationPanelOpen ? 50 : 100}
+                <ResizablePanelGroup
+                  direction={isLgScreen ? "horizontal" : "vertical"}
+                  id="requestor-page-request-panel-group"
+                  autoSaveId="requestor-page-request-panel-group"
+                  className={cn(
+                    "rounded-md",
+                    // HACK - This defensively prevents overflow from getting too excessive,
+                    //        In the case where the inner content expands beyond the parent
+                    "max-w-screen",
+                    "max-h-full",
+                    // "gap-1",
+                  )}
                 >
-                  <ResizablePanelGroup
-                    direction={isLgScreen ? "horizontal" : "vertical"}
-                    id="requestor-page-request-panel-group"
-                    autoSaveId="requestor-page-request-panel-group"
-                    className={cn(
-                      "rounded-md",
-                      // HACK - This defensively prevents overflow from getting too excessive,
-                      //        In the case where the inner content expands beyond the parent
-                      "max-w-screen",
-                      "max-h-full",
-                      // "gap-1",
-                    )}
+                  <ResizablePanel
+                    order={1}
+                    className={cn(BACKGROUND_LAYER, "relative")}
+                    id="request-panel"
+                    minSize={requestPanelMinSize}
+                    maxSize={requestPanelMaxSize}
                   >
-                    <ResizablePanel
-                      order={1}
-                      className={cn(BACKGROUND_LAYER, "relative")}
-                      id="request-panel"
-                      minSize={requestPanelMinSize}
-                      maxSize={requestPanelMaxSize}
-                    >
-                      {requestContent}
-                    </ResizablePanel>
+                    {requestContent}
+                  </ResizablePanel>
+                  <ResizableHandle
+                    hitAreaMargins={{ coarse: 20, fine: 10 }}
+                    className="bg-transparent"
+                  />
+                  <ResizablePanel
+                    id="response-panel"
+                    order={4}
+                    minSize={10}
+                    className={cn(BACKGROUND_LAYER)}
+                  >
+                    {responseContent}
+                  </ResizablePanel>
+                </ResizablePanelGroup>
+              </ResizablePanel>
+              <ResizablePanel>
+                {isAiTestGenerationPanelOpen && (
+                  <>
                     <ResizableHandle
                       hitAreaMargins={{ coarse: 20, fine: 10 }}
                       className="bg-transparent"
                     />
                     <ResizablePanel
-                      id="response-panel"
-                      order={4}
-                      minSize={10}
-                      className={cn(BACKGROUND_LAYER)}
+                      order={3}
+                      id="ai-panel"
+                      className={cn(
+                        BACKGROUND_LAYER,
+                        "rounded-md",
+                        "border",
+                        "h-full",
+                        "mt-2",
+                      )}
                     >
-                      {responseContent}
-                    </ResizablePanel>
-                  </ResizablePanelGroup>
-                </ResizablePanel>
-                <ResizablePanel>
-                  {isAiTestGenerationPanelOpen && (
-                    <>
-                      <ResizableHandle
-                        hitAreaMargins={{ coarse: 20, fine: 10 }}
-                        className="bg-transparent"
+                      <AiTestGenerationPanel
+                        // TODO - Only use history for recent matching route
+                        history={history}
+                        toggleAiTestGenerationPanel={
+                          toggleAiTestGenerationPanel
+                        }
                       />
-                      <ResizablePanel
-                        order={3}
-                        id="ai-panel"
-                        className={cn(
-                          BACKGROUND_LAYER,
-                          "rounded-md",
-                          "border",
-                          "h-full",
-                          "mt-2",
-                        )}
-                      >
-                        <AiTestGenerationPanel
-                          // TODO - Only use history for recent matching route
-                          history={history}
-                          toggleAiTestGenerationPanel={
-                            toggleAiTestGenerationPanel
-                          }
-                        />
-                      </ResizablePanel>
-                    </>
-                  )}
-                </ResizablePanel>
-              </ResizablePanelGroup>
+                    </ResizablePanel>
+                  </>
+                )}
+              </ResizablePanel>
+            </ResizablePanelGroup>
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -8,7 +8,7 @@ import {
   usePanelConstraints,
 } from "@/components/ui/resizable";
 import { useToast } from "@/components/ui/use-toast";
-import { useIsLgScreen, useIsSmScreen } from "@/hooks";
+import { useIsLgScreen } from "@/hooks";
 import { cn } from "@/utils";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
@@ -1,4 +1,5 @@
 import { CodeMirrorJsonEditor, SubSectionHeading } from "@/components/Timeline";
+import { TextOrJsonViewer } from "@/components/Timeline/DetailsList/TextJsonViewer";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -19,7 +20,6 @@ import {
   isRequestorActiveResponse,
 } from "../store/types";
 } from "../reducer/state";
-import { TextOrJsonViewer } from "@/components/Timeline/DetailsList/TextJsonViewer";
 
 export function ResponseBody({
   headersSlot,

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
@@ -18,6 +18,8 @@ import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../store/types";
+} from "../reducer/state";
+import { TextOrJsonViewer } from "@/components/Timeline/DetailsList/TextJsonViewer";
 
 export function ResponseBody({
   headersSlot,
@@ -65,12 +67,7 @@ export function ResponseBody({
         >
           {headersSlot}
           <CollapsibleBodyContainer>
-            <CodeMirrorJsonEditor
-              value={prettyBody}
-              readOnly
-              onChange={noop}
-              minHeight="0"
-            />
+            <TextOrJsonViewer text={prettyBody} collapsed={false} />
           </CollapsibleBodyContainer>
         </div>
       );

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
@@ -19,7 +19,6 @@ import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../store/types";
-} from "../reducer/state";
 
 export function ResponseBody({
   headersSlot,

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -86,123 +86,121 @@ export const ResponsePanel = memo(function ResponsePanel({
 
   return (
     <div className="overflow-x-hidden overflow-y-auto h-full relative">
-      <div className="h-full">
-        <Tabs
-          value={activeResponsePanelTab}
-          onValueChange={setActiveResponsePanelTab}
-          className="grid grid-rows-[auto_1fr] overflow-hidden h-full"
-        >
-          <CustomTabsList>
-            <CustomTabTrigger value="response" className="flex items-center">
-              {responseToRender ? (
-                <ResponseSummary
-                  response={responseToRender}
-                  transformUrl={removeServiceUrlFromPath}
-                />
-              ) : (
-                "Response"
-              )}
-            </CustomTabTrigger>
-            {shouldShowMessages && (
-              <CustomTabTrigger value="messages">Messages</CustomTabTrigger>
+      <Tabs
+        value={activeResponsePanelTab}
+        onValueChange={setActiveResponsePanelTab}
+        className="grid grid-rows-[auto_1fr] overflow-hidden h-full"
+      >
+        <CustomTabsList>
+          <CustomTabTrigger value="response" className="flex items-center">
+            {responseToRender ? (
+              <ResponseSummary
+                response={responseToRender}
+                transformUrl={removeServiceUrlFromPath}
+              />
+            ) : (
+              "Response"
             )}
-            <div
+          </CustomTabTrigger>
+          {shouldShowMessages && (
+            <CustomTabTrigger value="messages">Messages</CustomTabTrigger>
+          )}
+          <div
+            className={cn(
+              // Hide this button on mobile, and rely on the button + drawer pattern instead
+              "max-sm:hidden",
+              "flex-grow sm:flex justify-end",
+            )}
+          >
+            <Button
+              variant={isAiTestGenerationPanelOpen ? "outline" : "ghost"}
+              size="icon"
+              onClick={openAiTestGenerationPanel}
               className={cn(
-                // Hide this button on mobile, and rely on the button + drawer pattern instead
-                "max-sm:hidden",
-                "flex-grow sm:flex justify-end",
+                isAiTestGenerationPanelOpen && "opacity-50 bg-slate-900",
+                "h-6 w-6",
               )}
             >
-              <Button
-                variant={isAiTestGenerationPanelOpen ? "outline" : "ghost"}
-                size="icon"
-                onClick={openAiTestGenerationPanel}
-                className={cn(
-                  isAiTestGenerationPanelOpen && "opacity-50 bg-slate-900",
-                  "h-6 w-6",
-                )}
-              >
-                <RobotIcon className="h-3 w-3 cursor-pointer" />
-              </Button>
+              <RobotIcon className="h-3 w-3 cursor-pointer" />
+            </Button>
+          </div>
+        </CustomTabsList>
+        <CustomTabsContent value="messages">
+          <TabContentInner
+            isLoading={websocketState.isConnecting}
+            isEmpty={
+              !websocketState.isConnected && !websocketState.isConnecting
+            }
+            isFailure={websocketState.hasError}
+            LoadingState={<LoadingResponseBody />}
+            FailState={<FailedWebsocket />}
+            EmptyState={<NoWebsocketConnection />}
+          >
+            <WebsocketMessages websocketState={websocketState} />
+          </TabContentInner>
+        </CustomTabsContent>
+        <CustomTabsContent value="response" className="h-full">
+          <TabContentInner
+            isLoading={isLoading}
+            isEmpty={!responseToRender}
+            isFailure={
+              isWsRequest(requestType) ? websocketState.hasError : !!isFailure
+            }
+            LoadingState={<LoadingResponseBody />}
+            FailState={
+              isWsRequest(requestType) ? (
+                <FailedWebsocket />
+              ) : (
+                <FailedRequest response={tracedResponse} />
+              )
+            }
+            EmptyState={
+              isWsRequest(requestType) ? (
+                <NoWebsocketConnection />
+              ) : (
+                <NoResponse />
+              )
+            }
+          >
+            <div className={cn("grid grid-rows-[auto_1fr]")}>
+              <ResponseBody
+                headersSlot={
+                  <CollapsibleKeyValueTableV2
+                    sensitiveKeys={SENSITIVE_HEADERS}
+                    title="Headers"
+                    keyValue={responseHeaders ?? {}}
+                    className="mb-0.5 pb-2"
+                  />
+                }
+                response={responseToRender}
+                // HACK - To support absolutely positioned bottom toolbar
+                className={cn(showBottomToolbar && "pb-2")}
+              />
+              {traceId && (
+                <Collapsible
+                  open={isOpen}
+                  onOpenChange={setIsOpen}
+                  className="pl-0 border-t pt-2.5 mt-0.5"
+                >
+                  <CollapsibleTrigger asChild className="mb-2">
+                    <SubSectionHeading className="flex items-center gap-2 cursor-pointer">
+                      {isOpen ? (
+                        <CaretDownIcon className="w-4 h-4 cursor-pointer" />
+                      ) : (
+                        <CaretRightIcon className="w-4 h-4 cursor-pointer" />
+                      )}
+                      Logs & Events
+                    </SubSectionHeading>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <RequestorTimeline traceId={traceId} />
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
             </div>
-          </CustomTabsList>
-          <CustomTabsContent value="messages">
-            <TabContentInner
-              isLoading={websocketState.isConnecting}
-              isEmpty={
-                !websocketState.isConnected && !websocketState.isConnecting
-              }
-              isFailure={websocketState.hasError}
-              LoadingState={<LoadingResponseBody />}
-              FailState={<FailedWebsocket />}
-              EmptyState={<NoWebsocketConnection />}
-            >
-              <WebsocketMessages websocketState={websocketState} />
-            </TabContentInner>
-          </CustomTabsContent>
-          <CustomTabsContent value="response" className="h-full">
-            <TabContentInner
-              isLoading={isLoading}
-              isEmpty={!responseToRender}
-              isFailure={
-                isWsRequest(requestType) ? websocketState.hasError : !!isFailure
-              }
-              LoadingState={<LoadingResponseBody />}
-              FailState={
-                isWsRequest(requestType) ? (
-                  <FailedWebsocket />
-                ) : (
-                  <FailedRequest response={tracedResponse} />
-                )
-              }
-              EmptyState={
-                isWsRequest(requestType) ? (
-                  <NoWebsocketConnection />
-                ) : (
-                  <NoResponse />
-                )
-              }
-            >
-              <div className={cn("grid grid-rows-[auto_1fr]")}>
-                <ResponseBody
-                  headersSlot={
-                    <CollapsibleKeyValueTableV2
-                      sensitiveKeys={SENSITIVE_HEADERS}
-                      title="Headers"
-                      keyValue={responseHeaders ?? {}}
-                      className="mb-0.5 pb-2"
-                    />
-                  }
-                  response={responseToRender}
-                  // HACK - To support absolutely positioned bottom toolbar
-                  className={cn(showBottomToolbar && "pb-2")}
-                />
-                {traceId && (
-                  <Collapsible
-                    open={isOpen}
-                    onOpenChange={setIsOpen}
-                    className="pl-0 border-t pt-2.5 mt-0.5"
-                  >
-                    <CollapsibleTrigger asChild className="mb-2">
-                      <SubSectionHeading className="flex items-center gap-2 cursor-pointer">
-                        {isOpen ? (
-                          <CaretDownIcon className="w-4 h-4 cursor-pointer" />
-                        ) : (
-                          <CaretRightIcon className="w-4 h-4 cursor-pointer" />
-                        )}
-                        Logs & Events
-                      </SubSectionHeading>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                      <RequestorTimeline traceId={traceId} />
-                    </CollapsibleContent>
-                  </Collapsible>
-                )}
-              </div>
-            </TabContentInner>
-          </CustomTabsContent>
-        </Tabs>
-      </div>
+          </TabContentInner>
+        </CustomTabsContent>
+      </Tabs>
     </div>
   );
 });

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -105,13 +105,7 @@ export const ResponsePanel = memo(function ResponsePanel({
           {shouldShowMessages && (
             <CustomTabTrigger value="messages">Messages</CustomTabTrigger>
           )}
-          <div
-            className={cn(
-              // Hide this button on mobile, and rely on the button + drawer pattern instead
-              "max-sm:hidden",
-              "flex-grow sm:flex justify-end",
-            )}
-          >
+          <div className="flex-grow flex justify-end">
             <Button
               variant={isAiTestGenerationPanelOpen ? "outline" : "ghost"}
               size="icon"

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -266,6 +266,7 @@ function ResponseSummary({
             "font-mono",
             "whitespace-nowrap",
             "overflow-ellipsis",
+            "text-xs",
             "ml-2",
             "pt-0.5", // HACK - to adjust baseline of mono font to look good next to sans
           )}

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -119,9 +119,10 @@ export const ResponsePanel = memo(function ResponsePanel({
                 onClick={openAiTestGenerationPanel}
                 className={cn(
                   isAiTestGenerationPanelOpen && "opacity-50 bg-slate-900",
+                  "h-6 w-6",
                 )}
               >
-                <RobotIcon className="h-4 w-4 cursor-pointer" />
+                <RobotIcon className="h-3 w-3 cursor-pointer" />
               </Button>
             </div>
           </CustomTabsList>

--- a/studio/src/pages/RequestorPage/Tabs.tsx
+++ b/studio/src/pages/RequestorPage/Tabs.tsx
@@ -4,7 +4,7 @@ import type * as TabsPrimitive from "@radix-ui/react-tabs";
 import * as React from "react";
 import type { ComponentProps } from "react";
 
-const TAB_HEIGHT = "h-12";
+const TAB_HEIGHT = "h-8";
 
 export const CustomTabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -31,7 +31,7 @@ export function CustomTabTrigger(props: ComponentProps<typeof TabsTrigger>) {
         "text-left",
         TAB_HEIGHT,
         "ml-2",
-        "text-sm",
+        "text-xs",
         "font-normal",
         "border-b",
         "border-transparent",

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -72,8 +72,9 @@ export function AiTestGenerationPanel({
               variant="ghost"
               size="icon"
               onClick={toggleAiTestGenerationPanel}
+              className="h-6 w-6"
             >
-              <Cross1Icon className="h-3.5 w-3.5 cursor-pointer" />
+              <Cross1Icon className="h-3 w-3 cursor-pointer" />
             </Button>
           </div>
         </CustomTabsList>
@@ -112,10 +113,7 @@ export function AiTestGenerationPanel({
               </div>
             </div>
             <div className="mt-4 flex flex-row justify-end px-2">
-              <Button
-                className="text-white"
-                onClick={() => copyToClipboard(prompt)}
-              >
+              <Button onClick={() => copyToClipboard(prompt)}>
                 <CopyIcon className="h-4 w-4 mr-2" />{" "}
                 {isCopied ? "Copied!" : "Copy Prompt"}
               </Button>

--- a/studio/vite.config.ts
+++ b/studio/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       include: "**/*.svg",
     }),
     faviconsPlugin({
-      icons: { favicons: { source: "src/assets/fpx.svg" } },
+      icons: { favicons: { source: "src/assets/fp.svg" } },
     }),
   ],
   resolve: {

--- a/studio/vite.config.ts
+++ b/studio/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       include: "**/*.svg",
     }),
     faviconsPlugin({
-      icons: { favicons: { source: "src/assets/fp.svg" } },
+      icons: { favicons: { source: "src/assets/fpx.svg" } },
     }),
   ],
   resolve: {


### PR DESCRIPTION
This is a mostly aesthetic overhaul of some of our design language in terms of layouts and spacing.

We've noticed that our UI often struggles to fit the vital information that we want to convey from requests/responses and traces. This is an experiment that adopts the following guidelines:
- `text-xs` on nearly all clickable elements;
- reduce the (vertical) padding on buttons and input elements (this will not be used on touch screens);
- collapse JSON tree view *always* to preserve vertical space

Some other notable changes:
- revert the vertical request-response stacking introduced in #221 in favor of grouped request-response side-by-side
- introduce a parent resizable grid  over the request panels that would house all auxiliary panels (AI test prompt creator, eventually: extracted timeline component, and upcoming logs comp)
