### PR TITLE
Brett Presents: 2x The Fun! Cf binding errors, and a fix to RegExp router path parameter parsing

### DIFF
--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareAISpan.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareAISpan.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/components/ui/badge";
-import { CF_BINDING_RESULT } from "@/constants";
+import { CF_BINDING_ERROR, CF_BINDING_RESULT } from "@/constants";
 import type { OtelSpan } from "@/queries";
 import { getString } from "@/utils";
 import { useMemo } from "react";
 import { CollapsibleSubSection } from "../../../shared";
 import { TextOrJsonViewer } from "../../TextJsonViewer";
-import { CfBindingOverview } from "./shared";
+import { CfBindingOverview, CfResultAndError } from "./shared";
 
 /**
  * The AI binding, as of writing, only has a `run` method.
@@ -16,6 +16,7 @@ export function CloudflareAISpan({ span }: { span: OtelSpan }) {
   const args = getString(span.attributes.args);
   const runAiArgs = useCloudflareAiArgs(args);
   const result = getString(span.attributes[CF_BINDING_RESULT]);
+  const error = getString(span.attributes[CF_BINDING_ERROR]);
 
   return (
     <div className="text-xs py-2">
@@ -39,9 +40,7 @@ export function CloudflareAISpan({ span }: { span: OtelSpan }) {
             <CloudflareAiArgs args={runAiArgs.options} />
           </CollapsibleSubSection>
         )}
-        <CollapsibleSubSection heading="Result" defaultCollapsed={true}>
-          <TextOrJsonViewer text={result} collapsed={true} />
-        </CollapsibleSubSection>
+        <CfResultAndError result={result} error={error} />
       </div>
     </div>
   );

--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareD1Span.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareD1Span.tsx
@@ -5,7 +5,6 @@ import { useMemo } from "react";
 import { format } from "sql-formatter";
 import { CollapsibleSubSection } from "../../../shared";
 import { CodeMirrorSqlEditor } from "../../CodeMirrorEditor";
-import { TextOrJsonViewer } from "../../TextJsonViewer";
 import { CfResultAndError } from "./shared";
 
 /**

--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareD1Span.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareD1Span.tsx
@@ -1,4 +1,4 @@
-import { CF_BINDING_RESULT } from "@/constants";
+import { CF_BINDING_ERROR, CF_BINDING_RESULT } from "@/constants";
 import type { OtelSpan } from "@/queries";
 import { type CloudflareD1VendorInfo, getString, noop } from "@/utils";
 import { useMemo } from "react";
@@ -6,6 +6,7 @@ import { format } from "sql-formatter";
 import { CollapsibleSubSection } from "../../../shared";
 import { CodeMirrorSqlEditor } from "../../CodeMirrorEditor";
 import { TextOrJsonViewer } from "../../TextJsonViewer";
+import { CfResultAndError } from "./shared";
 
 /**
  * The D1 span is rendered a little differently.
@@ -29,6 +30,7 @@ export function CloudflareD1Span({
   }, [vendorInfo]);
 
   const result = getString(span.attributes[CF_BINDING_RESULT]);
+  const error = getString(span.attributes[CF_BINDING_ERROR]);
 
   return (
     <div className="text-xs py-2 space-y-2">
@@ -39,9 +41,7 @@ export function CloudflareD1Span({
           readOnly={true}
         />
       </CollapsibleSubSection>
-      <CollapsibleSubSection heading="Result" defaultCollapsed={true}>
-        <TextOrJsonViewer text={result} collapsed={true} />
-      </CollapsibleSubSection>
+      <CfResultAndError result={result} error={error} />
     </div>
   );
 }

--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareKVSpan.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareKVSpan.tsx
@@ -1,4 +1,8 @@
-import { CF_BINDING_METHOD, CF_BINDING_RESULT } from "@/constants";
+import {
+  CF_BINDING_ERROR,
+  CF_BINDING_METHOD,
+  CF_BINDING_RESULT,
+} from "@/constants";
 import type { OtelSpan } from "@/queries";
 import { getString } from "@/utils";
 import { useMemo } from "react";
@@ -20,6 +24,7 @@ export function CloudflareKVSpan({ span }: { span: OtelSpan }) {
   const args = getString(span.attributes.args);
   const kvArgs = useCloudflareKVArgs(args, method);
   const result = getString(span.attributes[CF_BINDING_RESULT]);
+  const error = getString(span.attributes[CF_BINDING_ERROR]);
   return (
     <div className="text-xs py-2">
       <CfBindingOverview span={span}>
@@ -33,11 +38,22 @@ export function CloudflareKVSpan({ span }: { span: OtelSpan }) {
             </div>
           </CollapsibleSubSection>
         ) : null}
+        {/*
+         * NOTE - The result looks bad if we don't add some additional padding.
+         *        That's why we're not using the CfResultAndError component here.
+         */}
         <CollapsibleSubSection heading="Result" defaultCollapsed={true}>
           <div className="pl-6 mt-1">
-            <TextOrJsonViewer text={result} collapsed={true} />
+            <TextOrJsonViewer text={result} collapsed={false} />
           </div>
         </CollapsibleSubSection>
+        {error && (
+          <CollapsibleSubSection heading="Error" defaultCollapsed={true}>
+            <div className="pl-6 mt-1">
+              <TextOrJsonViewer text={error} collapsed={false} />
+            </div>
+          </CollapsibleSubSection>
+        )}
       </div>
     </div>
   );

--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareR2Span.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/CloudflareR2Span.tsx
@@ -1,10 +1,14 @@
-import { CF_BINDING_METHOD, CF_BINDING_RESULT } from "@/constants";
+import {
+  CF_BINDING_ERROR,
+  CF_BINDING_METHOD,
+  CF_BINDING_RESULT,
+} from "@/constants";
 import type { OtelSpan } from "@/queries";
 import { getString } from "@/utils";
 import { useMemo } from "react";
 import { CollapsibleSubSection } from "../../../shared";
 import { TextOrJsonViewer } from "../../TextJsonViewer";
-import { CfBindingOverview, KeyBadge } from "./shared";
+import { CfBindingOverview, CfResultAndError, KeyBadge } from "./shared";
 
 /**
  * Cloudflare R2 has the following methods:
@@ -24,6 +28,7 @@ export function CloudflareR2Span({ span }: { span: OtelSpan }) {
   const args = getString(span.attributes.args);
   const r2Args = useCloudflareR2Args(args, method);
   const result = getString(span.attributes[CF_BINDING_RESULT]);
+  const error = getString(span.attributes[CF_BINDING_ERROR]);
   return (
     <div className="text-xs py-2">
       <CfBindingOverview span={span}>
@@ -35,9 +40,7 @@ export function CloudflareR2Span({ span }: { span: OtelSpan }) {
             <CloudflareR2Args args={r2Args.options} />
           </CollapsibleSubSection>
         )}
-        <CollapsibleSubSection heading="Result">
-          <TextOrJsonViewer text={result} collapsed={true} />
-        </CollapsibleSubSection>
+        <CfResultAndError result={result} error={error} />
       </div>
     </div>
   );

--- a/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/shared.tsx
+++ b/studio/src/components/Timeline/DetailsList/spans/CloudflareSpan/shared.tsx
@@ -1,7 +1,9 @@
+import { CollapsibleSubSection } from "@/components/Timeline/shared";
 import { Badge } from "@/components/ui/badge";
 import { CF_BINDING_METHOD, CF_BINDING_NAME } from "@/constants";
 import type { OtelSpan } from "@/queries";
 import { cn, getString } from "@/utils";
+import { TextOrJsonViewer } from "../../TextJsonViewer";
 
 export function CfBindingOverview({
   span,
@@ -18,6 +20,29 @@ export function CfBindingOverview({
       </Badge>
       {children}
     </div>
+  );
+}
+
+export function CfResultAndError({
+  result,
+  error,
+}: {
+  result: string;
+  error: string;
+}) {
+  return (
+    <>
+      {result && (
+        <CollapsibleSubSection heading="Result" defaultCollapsed={true}>
+          <TextOrJsonViewer text={result} collapsed={false} />
+        </CollapsibleSubSection>
+      )}
+      {error && (
+        <CollapsibleSubSection heading="Error" defaultCollapsed={true}>
+          <TextOrJsonViewer text={error} collapsed={false} />
+        </CollapsibleSubSection>
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
Found an unrelated bug while working on rendering Error results from CF bindings and it rolled into this PR bc the fix was kind of involved.

This PR does two very separate things:

1. Will render an `Error` section for CF bindings when the call to a binding resulted in an error 

<img width="980" alt="image" src="https://github.com/user-attachments/assets/e72f35b0-29b2-446b-9c0c-641bbe18d44a">

2. (Not screen-shottable) Fixes an issue where the `SmartRouter` returned a match object that mapped path parameters to their _indices in a regexp match object_ instead of their actual values. Turns out we weren't handling that case well because we hadn't actually bumped into it yet. 