### PR TITLE
Search registered routes first when looking for a single match

### DIFF
--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -57,6 +57,14 @@ jobs:
       - name: Typecheck all workspaces
         run: pnpm --recursive typecheck
 
+      # Testing
+
+      - name: Test Studio API
+        run: pnpm --filter @fiberplane/studio test
+
+      - name: Test Studio Frontend
+        run: pnpm --filter @fiberplane/studio-frontend test
+
       # Building
 
       - name: Build all workspaces

--- a/studio/src/pages/RequestorPage/reducer/reducer.ts
+++ b/studio/src/pages/RequestorPage/reducer/reducer.ts
@@ -891,16 +891,14 @@ function mapPathParamKey(key: string) {
 function extractMatchedPathParams(
   matchedRoute: ReturnType<typeof findMatchedRoute>,
 ) {
-  return Object.entries(matchedRoute?.pathParamValues ?? {}).map(
-    ([key, value]) => {
-      const nextValue = value === `:${key}` ? "" : value;
-      return {
-        ...mapPathParamKey(key),
-        value: nextValue,
-        enabled: !!nextValue,
-      };
-    },
-  );
+  return Object.entries(matchedRoute?.pathParams ?? {}).map(([key, value]) => {
+    const nextValue = value === `:${key}` ? "" : value;
+    return {
+      ...mapPathParamKey(key),
+      value: nextValue,
+      enabled: !!nextValue,
+    };
+  });
 }
 
 /**

--- a/studio/src/pages/RequestorPage/routes/match.test.ts
+++ b/studio/src/pages/RequestorPage/routes/match.test.ts
@@ -61,10 +61,10 @@ describe("findSmartRouterMatch", () => {
 
 describe("findFirstSmartRouterMatch - registered routes precedence", () => {
   const routes: ProbedRoute[] = [
+    // Unregesterd route - should not be matched first
     toRoute("/test/:k", "GET", "http", false, -1),
+    // Registered route - should be matched first
     toRoute("/test/:key", "GET", "http", true, 1),
-    toRoute("/users/:userId", "GET", "http", false, -1),
-    toRoute("/users/:userId", "GET", "http", false, -1),
   ];
 
   it("should return registered route with higher precedence", () => {
@@ -73,7 +73,6 @@ describe("findFirstSmartRouterMatch - registered routes precedence", () => {
     expect(match?.route?.path).toBe("/test/:key");
   });
 });
-
 
 // describe("findMatchedRoute", () => {
 //   const routes: ProbedRoute[] = [

--- a/studio/src/pages/RequestorPage/routes/match.test.ts
+++ b/studio/src/pages/RequestorPage/routes/match.test.ts
@@ -1,6 +1,6 @@
 import type { ProbedRoute } from "../queries";
 import type { RequestMethod, RequestType } from "../types";
-import { findFirstSmartRouterMatch, findMatchedRoute } from "./match";
+import { findFirstSmartRouterMatch } from "./match";
 
 const toRoute = (
   path: string,
@@ -59,7 +59,7 @@ describe("findSmartRouterMatch", () => {
   });
 });
 
-describe("findMatchedRoute - registered routes precedence", () => {
+describe("findFirstSmartRouterMatch - registered routes precedence", () => {
   const routes: ProbedRoute[] = [
     toRoute("/test/:k", "GET", "http", false, -1),
     toRoute("/test/:key", "GET", "http", true, 1),
@@ -68,7 +68,7 @@ describe("findMatchedRoute - registered routes precedence", () => {
   ];
 
   it("should return registered route with higher precedence", () => {
-    const match = findMatchedRoute(routes, "/test/123", "GET", "http");
+    const match = findFirstSmartRouterMatch(routes, "/test/123", "GET", "http");
     expect(match).toBeTruthy();
     expect(match?.route?.path).toBe("/test/:key");
   });

--- a/studio/src/pages/RequestorPage/routes/match.test.ts
+++ b/studio/src/pages/RequestorPage/routes/match.test.ts
@@ -49,10 +49,12 @@ describe("findSmartRouterMatch", () => {
 
   it("should return a match for the given pathname and method", () => {
     const match = findFirstSmartRouterMatch(routes, "/users/1", "GET", "http");
-    expect(match).toMatchObject({
-      path: "/users/:userId",
-      method: "GET",
-      isWs: false,
+    expect(match).toBeTruthy();
+    expect(match?.route).toBeDefined();
+    expect(match?.route?.method).toBe("GET");
+    expect(match?.route?.path).toBe("/users/:userId");
+    expect(match?.pathParams).toMatchObject({
+      userId: "1",
     });
   });
 });

--- a/studio/src/pages/RequestorPage/routes/match.ts
+++ b/studio/src/pages/RequestorPage/routes/match.ts
@@ -16,14 +16,14 @@ type MatchedRouteResult = {
  * Precedence should always occur as follows:
  * - First checks registered routes
  * - Then checks unregistered routes
- * 
+ *
  * As of writing, precedence is enforced via sorting the routes (in a helper function for finding smart router matches)
- * 
+ *
  * If the router throws an error when matching, we return the first route that matches exactly on:
  * - pathname
  * - method
  * - requestType
- * 
+ *
  * @param routes
  * @param pathname
  * @param method
@@ -88,7 +88,7 @@ export function findAllSmartRouterMatches(
   requestType: "http" | "websocket",
 ) {
   // HACK - Sort routes by registration, then registration order so that registered routes match first
-  const routes = [...unsortedRoutes]
+  const routes = [...unsortedRoutes];
   routes.sort((a, b) => {
     const aIsRegistered = a.currentlyRegistered;
     const bIsRegistered = b.currentlyRegistered;

--- a/studio/src/pages/RequestorPage/routes/match.ts
+++ b/studio/src/pages/RequestorPage/routes/match.ts
@@ -88,35 +88,8 @@ export function findAllSmartRouterMatches(
   requestType: "http" | "websocket",
 ) {
   // HACK - Sort with registered routes first, then unregistered routes
-  // - for registered routes:
-  //   - `registrationOrder` (ascending)
-  // - for unregistered routes:
-  //   - `isDraft` status (`false` before `true`)
-  const routes = [...unsortedRoutes];
-  routes.sort((a, b) => {
-    const aIsRegistered = a.currentlyRegistered;
-    const bIsRegistered = b.currentlyRegistered;
-    const aIsDraft = a.isDraft;
-    const bIsDraft = b.isDraft;
-
-    // First, sort by registration status
-    if (aIsRegistered !== bIsRegistered) {
-      return aIsRegistered ? -1 : 1;
-    }
-
-    // Then, If registration status is the same, sort by draft status
-    if (aIsDraft !== bIsDraft) {
-      return aIsDraft ? 1 : -1;
-    }
-
-    // Then, sort by registration order
-    if (aIsRegistered && bIsRegistered) {
-      return a.registrationOrder - b.registrationOrder;
-    }
-
-    // If both registration and draft status are the same, sort by registration order
-    return a.registrationOrder - b.registrationOrder;
-  });
+  //        Look at the sortRoutesForMatching function for more details
+  const routes = sortRoutesForMatching(unsortedRoutes);
 
   // HACK - We need to be able to associate route handlers back to the ProbedRoute definition
   const functionHandlerLookupTable: Map<() => void, ProbedRoute> = new Map();
@@ -186,6 +159,47 @@ const isMatchResultEmpty = <R extends SmartRouter<T>, T>(
     });
   }
 };
+
+/**
+ * Sorts routes for matching, with registered routes first, then unregistered routes
+ *
+ * - for registered routes:
+ *   - `registrationOrder` (ascending)
+ * - for unregistered routes:
+ *   - `isDraft` status (`false` before `true`)
+ *
+ * @NOTE - Creates a new array, does not mutate the input
+ */
+function sortRoutesForMatching(unsortedRoutes: ProbedRoute[]) {
+  const routes = [...unsortedRoutes];
+
+  routes.sort((a, b) => {
+    const aIsRegistered = a.currentlyRegistered;
+    const bIsRegistered = b.currentlyRegistered;
+    const aIsDraft = a.isDraft;
+    const bIsDraft = b.isDraft;
+
+    // First, sort by registration status
+    if (aIsRegistered !== bIsRegistered) {
+      return aIsRegistered ? -1 : 1;
+    }
+
+    // Then, If registration status is the same, sort by draft status
+    if (aIsDraft !== bIsDraft) {
+      return aIsDraft ? 1 : -1;
+    }
+
+    // Then, sort by registration order
+    if (aIsRegistered && bIsRegistered) {
+      return a.registrationOrder - b.registrationOrder;
+    }
+
+    // If both registration and draft status are the same, sort by registration order
+    return a.registrationOrder - b.registrationOrder;
+  });
+
+  return routes;
+}
 
 /**
  * Transforms a route match result into an array of matches with path parameter values

--- a/studio/src/pages/RequestorPage/routes/match.ts
+++ b/studio/src/pages/RequestorPage/routes/match.ts
@@ -87,7 +87,11 @@ export function findAllSmartRouterMatches(
   method: string,
   requestType: "http" | "websocket",
 ) {
-  // HACK - Sort routes by registration, then registration order so that registered routes match first
+  // HACK - Sort with registered routes first, then unregistered routes
+  // - for registered routes:
+  //   - `registrationOrder` (ascending)
+  // - for unregistered routes:
+  //   - `isDraft` status (`false` before `true`)
   const routes = [...unsortedRoutes];
   routes.sort((a, b) => {
     const aIsRegistered = a.currentlyRegistered;


### PR DESCRIPTION
Fixes a problem where sometimes an old unregistered route snuck its way into the context for ai request generation

Adds a test for this case, and then added the tests to CI