### PR TITLE
RequestorPage: on small screen also render bg

### DIFF
--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -389,8 +389,28 @@ export const RequestorPage = () => {
             />
             {isSmallScreen ? (
               <>
-                {requestContent}
-                {responseContent}
+                <div
+                  className={
+                    cn(
+                      // Needs "relative" to constrain absolute position of bottom toolbar
+                      "relative",
+                      BACKGROUND_LAYER,
+                      "rounded-md",
+                      "border",
+
+                    )
+                  }>
+                  {requestContent}</div>
+                <div
+                  className={
+                    cn(
+                      BACKGROUND_LAYER,
+                      "rounded-md",
+                      "border",
+
+                    )
+                  }>{responseContent}
+                </div>
               </>
             ) : (
               <ResizablePanelGroup

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -390,26 +390,25 @@ export const RequestorPage = () => {
             {isSmallScreen ? (
               <>
                 <div
-                  className={
-                    cn(
-                      // Needs "relative" to constrain absolute position of bottom toolbar
-                      "relative",
-                      BACKGROUND_LAYER,
-                      "rounded-md",
-                      "border",
-
-                    )
-                  }>
-                  {requestContent}</div>
+                  className={cn(
+                    // Needs "relative" to constrain absolute position of bottom toolbar
+                    "relative",
+                    BACKGROUND_LAYER,
+                    "rounded-md",
+                    "border",
+                  )}
+                >
+                  {requestContent}
+                </div>
                 <div
-                  className={
-                    cn(
-                      BACKGROUND_LAYER,
-                      "rounded-md",
-                      "border",
-                      "flex-1"
-                    )
-                  }>{responseContent}
+                  className={cn(
+                    BACKGROUND_LAYER,
+                    "rounded-md",
+                    "border",
+                    "flex-1",
+                  )}
+                >
+                  {responseContent}
                 </div>
               </>
             ) : (

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -407,7 +407,7 @@ export const RequestorPage = () => {
                       BACKGROUND_LAYER,
                       "rounded-md",
                       "border",
-
+                      "flex-1"
                     )
                   }>{responseContent}
                 </div>


### PR DESCRIPTION
For the request/response panels

I noticed that on small screens the background was gone and also the selector for content-type was in the wrong place

Before:
![after](https://github.com/user-attachments/assets/61d556a8-c28f-4e5a-b455-26b0ff56836a)

After: 
![after](https://github.com/user-attachments/assets/346c1cc2-d065-478f-ae50-d4b80a82d54f)

