### PR TITLE
Extract timeline as its own panel component

### DIFF
--- a/examples/goose-quotes/src/db/client.ts
+++ b/examples/goose-quotes/src/db/client.ts
@@ -1,0 +1,133 @@
+import { neon } from "@neondatabase/serverless";
+import { asc, eq, ilike } from "drizzle-orm";
+import type { drizzle } from "drizzle-orm/neon-http";
+import { geese } from "./schema";
+
+export const getAllGeese = async (db: ReturnType<typeof drizzle>) => {
+  console.log("Fetching all geese");
+  return await db.select().from(geese);
+};
+
+export const searchGeese = async (
+  db: ReturnType<typeof drizzle>,
+  name: string,
+) => {
+  console.log({ action: "searchGeese", name });
+  return await db
+    .select()
+    .from(geese)
+    .where(ilike(geese.name, `%${name}%`))
+    .orderBy(asc(geese.name));
+};
+
+export const createGoose = async (
+  db: ReturnType<typeof drizzle>,
+  gooseData: Partial<typeof geese.$inferInsert>,
+) => {
+  const { name, isFlockLeader, programmingLanguage, motivations, location } =
+    gooseData;
+  const description = `A person named ${name} who talks like a Goose`;
+
+  console.log({
+    action: "createGoose",
+    name,
+    isFlockLeader,
+    programmingLanguage,
+  });
+
+  return await db
+    .insert(geese)
+    .values({
+      name,
+      description,
+      isFlockLeader,
+      programmingLanguage,
+      motivations,
+      location,
+    })
+    .returning({
+      id: geese.id,
+      name: geese.name,
+      description: geese.description,
+      isFlockLeader: geese.isFlockLeader,
+      programmingLanguage: geese.programmingLanguage,
+      motivations: geese.motivations,
+      location: geese.location,
+    });
+};
+
+export const getGooseById = async (
+  db: ReturnType<typeof drizzle>,
+  id: number,
+) => {
+  console.log(`Fetching goose with id: ${id}`);
+  return (await db.select().from(geese).where(eq(geese.id, id)))?.[0];
+};
+
+export const getFlockLeaders = async (db: ReturnType<typeof drizzle>) => {
+  console.log("Fetching flock leaders");
+  return await db.select().from(geese).where(eq(geese.isFlockLeader, true));
+};
+
+export const updateGooseName = async (
+  db: ReturnType<typeof drizzle>,
+  id: number,
+  name: string,
+) => {
+  console.log({ action: "updateGooseName", id, name });
+  return (
+    await db.update(geese).set({ name }).where(eq(geese.id, id)).returning()
+  )?.[0];
+};
+
+export const getGeeseByLanguage = async (
+  db: ReturnType<typeof drizzle>,
+  language: string,
+) => {
+  console.log(`Fetching geese with programming language: ${language}`);
+  return await db
+    .select()
+    .from(geese)
+    .where(ilike(geese.programmingLanguage, `%${language}%`));
+};
+
+export const updateGooseMotivations = async (
+  db: ReturnType<typeof drizzle>,
+  id: number,
+  motivations: string,
+) => {
+  console.log({ action: "updateGooseMotivations", id, motivations });
+  return (
+    await db
+      .update(geese)
+      .set({ motivations })
+      .where(eq(geese.id, id))
+      .returning()
+  )?.[0];
+};
+
+export const updateGooseAvatar = async (
+  db: ReturnType<typeof drizzle>,
+  id: number,
+  avatarKey: string,
+) => {
+  console.log(`Updating avatar for goose with id: ${id}`);
+  return (
+    await db
+      .update(geese)
+      .set({ avatar: avatarKey })
+      .where(eq(geese.id, id))
+      .returning()
+  )[0];
+};
+
+export const updateGoose = async (
+  db: ReturnType<typeof drizzle>,
+  id: number,
+  updateData: Partial<typeof geese.$inferInsert>,
+) => {
+  console.log({ action: "updateGoose", id, updateData });
+  return (
+    await db.update(geese).set(updateData).where(eq(geese.id, id)).returning()
+  )[0];
+};

--- a/examples/goose-quotes/src/index.ts
+++ b/examples/goose-quotes/src/index.ts
@@ -1,10 +1,17 @@
 import { Hono } from "hono";
 
-import { instrument } from "@fiberplane/hono-otel";
+import { instrument, measure } from "@fiberplane/hono-otel";
 import { neon } from "@neondatabase/serverless";
 import { asc, eq, ilike } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/neon-http";
 
+import {
+  createGoose,
+  getAllGeese,
+  getGeeseByLanguage,
+  getGooseById,
+  updateGoose,
+} from "./db/client";
 import { geese } from "./db/schema";
 
 import { upgradeWebSocket } from "hono/cloudflare-workers";
@@ -26,6 +33,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 app.get("/", (c) => {
   const { shouldHonk } = c.req.query();
   const honk = typeof shouldHonk !== "undefined" ? "Honk honk!" : "";
+  console.log(`Home page accessed. Honk: ${honk}`);
   return c.text(`Hello Goose Quotes! ${honk}`.trim());
 });
 
@@ -39,22 +47,27 @@ app.get("/api/geese", async (c) => {
   const db = drizzle(sql);
 
   const name = c.req.query("name");
-
-  console.log("not searching");
+  console.log({ action: "search_geese", name });
 
   if (!name) {
-    return c.json(await db.select().from(geese));
+    const allGeese = await measure("getAllGeese", () => getAllGeese(db))();
+    console.log({ action: "get_all_geese", count: allGeese.length });
+    return c.json(allGeese);
   }
 
-  console.log("searching for", name);
+  const searchResults = await measure("searchGeese", () =>
+    db
+      .select()
+      .from(geese)
+      .where(ilike(geese.name, `%${name}%`))
+      .orderBy(asc(geese.name)),
+  )();
 
-  const searchResults = await db
-    .select()
-    .from(geese)
-    .where(ilike(geese.name, `%${name}%`))
-    .orderBy(asc(geese.name));
-
-  console.log("found", searchResults.length, "results");
+  console.log({
+    action: "search_geese_results",
+    count: searchResults.length,
+    name,
+  });
 
   return c.json(searchResults);
 });
@@ -72,26 +85,20 @@ app.post("/api/geese", async (c) => {
     await c.req.json();
   const description = `A person named ${name} who talks like a Goose`;
 
-  const created = await db
-    .insert(geese)
-    .values({
+  console.log(`Creating new goose: ${name}`);
+
+  const created = await measure("createGoose", () =>
+    createGoose(db, {
       name,
       description,
       isFlockLeader,
       programmingLanguage,
       motivations,
       location,
-    })
-    .returning({
-      id: geese.id,
-      name: geese.name,
-      description: geese.description,
-      isFlockLeader: geese.isFlockLeader,
-      programmingLanguage: geese.programmingLanguage,
-      motivations: geese.motivations,
-      location: geese.location,
-    });
-  return c.json(created?.[0]);
+    }),
+  )();
+  console.log({ action: "create_goose", id: created[0].id, name });
+  return c.json(created);
 });
 
 /**
@@ -103,9 +110,10 @@ app.post("/api/geese/:id/generate", async (c) => {
 
   const id = c.req.param("id");
 
-  const goose = (await db.select().from(geese).where(eq(geese.id, +id)))?.[0];
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
@@ -117,35 +125,44 @@ app.post("/api/geese/:id/generate", async (c) => {
     fetch: globalThis.fetch,
   });
 
-  const response = await openaiClient.chat.completions.create({
-    model: "gpt-4o-mini",
-    messages: [
-      {
-        role: "system",
-        content: trimPrompt(`
-            You are a goose. You are a very smart goose. You are part goose, part AI. You are a GooseAI.
-            You are also influenced heavily by the work of ${gooseName}.
+  console.log(`Generating quotes for goose: ${gooseName}`);
 
-            Always respond without preamble. If I ask for a list, give me a newline-separated list. That's it.
-            Don't number it. Don't bullet it. Just newline it.
+  const response = await measure("generateQuotes", () =>
+    openaiClient.chat.completions.create({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: trimPrompt(`
+              You are a goose. You are a very smart goose. You are part goose, part AI. You are a GooseAI.
+              You are also influenced heavily by the work of ${gooseName}.
 
-            Never forget to Honk. A lot.
-        `),
-      },
-      {
-        role: "user",
-        content: trimPrompt(`
-            Reimagine five famous quotes by ${gooseName}, except with significant goose influence.
-        `),
-      },
-    ],
-    temperature: 0.7,
-    max_tokens: 2048,
-  });
+              Always respond without preamble. If I ask for a list, give me a newline-separated list. That's it.
+              Don't number it. Don't bullet it. Just newline it.
+
+              Never forget to Honk. A lot.
+          `),
+        },
+        {
+          role: "user",
+          content: trimPrompt(`
+              Reimagine five famous quotes by ${gooseName}, except with significant goose influence.
+          `),
+        },
+      ],
+      temperature: 0.7,
+      max_tokens: 2048,
+    }),
+  )();
 
   const quotes = response.choices[0].message.content
     ?.split("\n")
     .filter((quote) => quote.length > 0);
+  console.log({
+    action: "generate_quotes",
+    gooseName,
+    quoteCount: quotes?.length,
+  });
   return c.json({ name: goose.name, quotes });
 });
 
@@ -157,10 +174,13 @@ app.get("/api/geese/flock-leaders", async (c) => {
   const sql = neon(c.env.DATABASE_URL);
   const db = drizzle(sql);
 
-  const flockLeaders = await db
-    .select()
-    .from(geese)
-    .where(eq(geese.isFlockLeader, true));
+  console.log("Fetching flock leaders");
+
+  const flockLeaders = await measure("getFlockLeaders", () =>
+    db.select().from(geese).where(eq(geese.isFlockLeader, true)),
+  )();
+
+  console.log(`Found ${flockLeaders.length} flock leaders`);
 
   return c.json(flockLeaders);
 });
@@ -174,12 +194,16 @@ app.get("/api/geese/:id", async (c) => {
 
   const id = c.req.param("id");
 
-  const goose = (await db.select().from(geese).where(eq(geese.id, +id)))?.[0];
+  console.log(`Fetching goose with id: ${id}`);
+
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
+  console.log(`Found goose: ${goose.name}`);
   return c.json(goose);
 });
 
@@ -192,9 +216,10 @@ app.post("/api/geese/:id/bio", async (c) => {
 
   const id = c.req.param("id");
 
-  const goose = (await db.select().from(geese).where(eq(geese.id, +id)))?.[0];
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
@@ -206,45 +231,48 @@ app.post("/api/geese/:id/bio", async (c) => {
     location,
   } = goose;
 
+  console.log(`Generating bio for goose: ${gooseName}`);
+
   const openaiClient = new OpenAI({
     apiKey: c.env.OPENAI_API_KEY,
     fetch: globalThis.fetch,
   });
 
-  const response = await openaiClient.chat.completions.create({
-    model: "gpt-4o",
-    messages: [
-      {
-        role: "system",
-        content: trimPrompt(`
-            You are a professional bio writer. Your task is to generate a compelling and engaging bio for a goose.
-        `),
-      },
-      {
-        role: "user",
-        content: trimPrompt(`
-            Generate a bio for a goose named ${gooseName} with the following details:
-            Description: ${description}
-            Programming Language: ${programmingLanguage}
-            Motivations: ${motivations}
-            Location: ${location}
-        `),
-      },
-    ],
-    temperature: 0.7,
-    max_tokens: 2048,
-  });
+  const response = await measure("generateBio", () =>
+    openaiClient.chat.completions.create({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "system",
+          content: trimPrompt(`
+              You are a professional bio writer. Your task is to generate a compelling and engaging bio for a goose.
+          `),
+        },
+        {
+          role: "user",
+          content: trimPrompt(`
+              Generate a bio for a goose named ${gooseName} with the following details:
+              Description: ${description}
+              Programming Language: ${programmingLanguage}
+              Motivations: ${motivations}
+              Location: ${location}
+          `),
+        },
+      ],
+      temperature: 0.7,
+      max_tokens: 2048,
+    }),
+  )();
 
   const bio = response.choices[0].message.content;
 
   // Update the goose with the generated bio
-  const updatedGoose = await db
-    .update(geese)
-    .set({ bio })
-    .where(eq(geese.id, +id))
-    .returning();
+  const updatedGoose = await measure("updateGoose", () =>
+    updateGoose(db, +id, { bio }),
+  )();
 
-  return c.json(updatedGoose[0]);
+  console.log(`Bio generated and updated for goose: ${gooseName}`);
+  return c.json(updatedGoose);
 });
 
 /**
@@ -255,12 +283,14 @@ app.post("/api/geese/:id/honk", async (c) => {
   const db = drizzle(sql);
 
   const id = c.req.param("id");
-  const goose = (await db.select().from(geese).where(eq(geese.id, +id)))?.[0];
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
+  console.log(`Honk received for goose: ${goose.name}`);
   return c.json({ message: `Honk honk! ${goose.name} honks back at you!` });
 });
 
@@ -274,14 +304,18 @@ app.patch("/api/geese/:id", async (c) => {
   const id = c.req.param("id");
   const { name } = await c.req.json();
 
-  const goose = (
-    await db.update(geese).set({ name }).where(eq(geese.id, +id)).returning()
-  )?.[0];
+  console.log(`Updating goose ${id} with new name: ${name}`);
+
+  const goose = await measure("updateGoose", () =>
+    updateGoose(db, +id, { name }),
+  )();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
+  console.log(`Goose ${id} updated successfully`);
   return c.json(goose);
 });
 
@@ -294,11 +328,15 @@ app.get("/api/geese/language/:language", async (c) => {
 
   const language = c.req.param("language");
 
-  const geeseByLanguage = await db
-    .select()
-    .from(geese)
-    .where(ilike(geese.programmingLanguage, `%${language}%`));
+  console.log(`Fetching geese with programming language: ${language}`);
 
+  const geeseByLanguage = await measure("getGeeseByLanguage", () =>
+    getGeeseByLanguage(db, language),
+  )();
+
+  console.log(
+    `Found ${geeseByLanguage.length} geese for language: ${language}`,
+  );
   return c.json(geeseByLanguage);
 });
 
@@ -312,18 +350,18 @@ app.patch("/api/geese/:id/motivations", async (c) => {
   const id = c.req.param("id");
   const { motivations } = await c.req.json();
 
-  const updatedGoose = (
-    await db
-      .update(geese)
-      .set({ motivations })
-      .where(eq(geese.id, +id))
-      .returning()
-  )?.[0];
+  console.log(`Updating motivations for goose ${id}`);
+
+  const updatedGoose = await measure("updateGoose", () =>
+    updateGoose(db, +id, { motivations }),
+  )();
 
   if (!updatedGoose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
+  console.log(`Motivations updated for goose ${id}`);
   return c.json(updatedGoose);
 });
 
@@ -332,9 +370,10 @@ app.post("/api/geese/:id/change-name-url-form", async (c) => {
   const db = drizzle(sql);
 
   const id = c.req.param("id");
-  const [goose] = await db.select().from(geese).where(eq(geese.id, +id));
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
@@ -342,15 +381,16 @@ app.post("/api/geese/:id/change-name-url-form", async (c) => {
   const name = form.get("name");
 
   if (!name) {
+    console.error("Name is required for changing goose name");
     return c.json({ message: "Name is required" }, 400);
   }
 
-  const [updatedGoose] = await db
-    .update(geese)
-    .set({ name })
-    .where(eq(geese.id, +id))
-    .returning();
+  console.log(`Changing name of goose ${id} to ${name}`);
+  const updatedGoose = await measure("updateGoose", () =>
+    updateGoose(db, +id, { name }),
+  )();
 
+  console.log(`Name changed for goose ${id}`);
   return c.json(updatedGoose, 200);
 });
 
@@ -363,16 +403,18 @@ app.post("/api/geese/:id/avatar", async (c) => {
 
   const id = c.req.param("id");
 
-  const [goose] = await db.select().from(geese).where(eq(geese.id, +id));
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
   const { avatar, avatarName } = await c.req.parseBody();
-  console.log({ avatarName }, "is the avatar name");
+  console.log({ action: "update_avatar", gooseId: id, avatarName });
   // Validate the avatar is a file
   if (!(avatar instanceof File)) {
+    console.error(`Invalid avatar type for goose ${id}: ${typeof avatar}`);
     return c.json(
       { message: "Avatar must be a file", actualType: typeof avatar },
       422,
@@ -382,6 +424,7 @@ app.post("/api/geese/:id/avatar", async (c) => {
   // Validate the avatar is a JPEG, PNG, or GIF
   const allowedTypes = ["image/jpeg", "image/png", "image/gif"];
   if (!allowedTypes.includes(avatar.type)) {
+    console.error(`Invalid avatar file type for goose ${id}: ${avatar.type}`);
     return c.json({ message: "Avatar must be a JPEG, PNG, or GIF image" }, 422);
   }
 
@@ -390,16 +433,19 @@ app.post("/api/geese/:id/avatar", async (c) => {
 
   // Save the avatar to the bucket
   const bucketKey = `goose-${id}-avatar-${Date.now()}.${fileExtension}`;
-  await c.env.GOOSE_AVATARS.put(bucketKey, avatar.stream(), {
-    httpMetadata: { contentType: avatar.type },
-  });
+  await measure("uploadAvatar", () =>
+    c.env.GOOSE_AVATARS.put(bucketKey, avatar.stream(), {
+      httpMetadata: { contentType: avatar.type },
+    }),
+  )();
 
-  const [updatedGoose] = await db
-    .update(geese)
-    .set({ avatar: bucketKey })
-    .where(eq(geese.id, +id))
-    .returning();
+  console.log(`Avatar uploaded for goose ${id}: ${bucketKey}`);
 
+  const updatedGoose = await measure("updateGoose", () =>
+    updateGoose(db, +id, { avatar: bucketKey }),
+  )();
+
+  console.log(`Avatar updated for goose ${id}`);
   return c.json(updatedGoose);
 });
 
@@ -412,24 +458,32 @@ app.get("/api/geese/:id/avatar", async (c) => {
 
   const id = c.req.param("id");
 
-  const [goose] = await db.select().from(geese).where(eq(geese.id, +id));
+  const goose = await measure("getGooseById", () => getGooseById(db, +id))();
 
   if (!goose) {
+    console.warn(`Goose not found: ${id}`);
     return c.json({ message: "Goose not found" }, 404);
   }
 
   const avatarKey = goose.avatar;
 
   if (!avatarKey) {
+    console.warn(`Goose ${id} has no avatar`);
     return c.json({ message: "Goose has no avatar" }, 404);
   }
 
-  const avatar = await c.env.GOOSE_AVATARS.get(avatarKey);
+  console.log(`Fetching avatar for goose ${id}: ${avatarKey}`);
+
+  const avatar = await measure("getAvatar", () =>
+    c.env.GOOSE_AVATARS.get(avatarKey),
+  )();
 
   if (!avatar) {
+    console.error(`Avatar not found for goose ${id}: ${avatarKey}`);
     return c.json({ message: "Goose avatar not found" }, 404);
   }
 
+  console.log(`Avatar retrieved for goose ${id}`);
   const responseHeaders = mapR2HttpMetadataToHeaders(avatar.httpMetadata);
   return new Response(avatar.body, {
     headers: responseHeaders,
@@ -442,7 +496,9 @@ app.get("/api/geese/:id/avatar", async (c) => {
  * For all methods, print "Honk honk!"
  */
 app.all("/always-honk/:echo?", (c) => {
-  return c.text(`Honk honk! ${c.req.param("echo") ?? ""}`);
+  const echo = c.req.param("echo");
+  console.log(`Always honk endpoint called with echo: ${echo}`);
+  return c.text(`Honk honk! ${echo ?? ""}`);
 });
 
 app.get(
@@ -454,13 +510,14 @@ app.get(
         const sql = neon(c.env.DATABASE_URL);
         const db = drizzle(sql);
 
+        console.log(`WebSocket message received: ${type}`);
+
         switch (type) {
           case "GET_GEESE":
-            db.select()
-              .from(geese)
-              .then((geese) => {
-                ws.send(JSON.stringify({ type: "GEESE", payload: geese }));
-              });
+            measure("getAllGeese", () => getAllGeese(db))().then((geese) => {
+              console.log(`Sending ${geese.length} geese over WebSocket`);
+              ws.send(JSON.stringify({ type: "GEESE", payload: geese }));
+            });
             break;
           case "CREATE_GOOSE": {
             const {
@@ -472,38 +529,30 @@ app.get(
             } = payload;
             const description = `A person named ${name} who talks like a Goose`;
 
-            db.insert(geese)
-              .values({
+            console.log(`Creating new goose via WebSocket: ${name}`);
+            measure("createGoose", () =>
+              createGoose(db, {
                 name,
                 description,
                 isFlockLeader,
                 programmingLanguage,
                 motivations,
                 location,
-              })
-              .returning({
-                id: geese.id,
-                name: geese.name,
-                description: geese.description,
-                isFlockLeader: geese.isFlockLeader,
-                programmingLanguage: geese.programmingLanguage,
-                motivations: geese.motivations,
-                location: geese.location,
-              })
-              .then((newGoose) => {
-                ws.send(
-                  JSON.stringify({ type: "NEW_GOOSE", payload: newGoose[0] }),
-                );
-              });
+              }),
+            )().then((newGoose) => {
+              console.log(`New goose created via WebSocket: ${newGoose[0].id}`);
+              ws.send(JSON.stringify({ type: "NEW_GOOSE", payload: newGoose }));
+            });
             break;
           }
           // ... (handle other message types)
           default:
+            console.warn(`Unknown WebSocket message type: ${type}`);
             break;
         }
       },
       onClose: () => {
-        console.log("Connection closed");
+        console.log("WebSocket connection closed");
       },
     };
   }),

--- a/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
+++ b/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
@@ -41,7 +41,7 @@ export function CodeMirrorJsonEditor(props: CodeMirrorEditorProps) {
       height={height}
       maxHeight={maxHeight}
       minHeight={minHeight}
-      extensions={[json()]}
+      extensions={[EditorView.lineWrapping, json()]}
       onChange={onChange}
       theme={[duotoneDark, customTheme]}
       readOnly={readOnly}
@@ -83,7 +83,7 @@ export function CodeMirrorSqlEditor(props: CodeMirrorSqlEditorProps) {
       minHeight={minHeight}
       maxHeight={maxHeight}
       readOnly={readOnly}
-      extensions={[sql()]}
+      extensions={[EditorView.lineWrapping, sql()]}
       onChange={onChange}
       theme={[duotoneDark, customTheme]}
     />

--- a/studio/src/components/Timeline/DetailsList/OrphanLog.tsx
+++ b/studio/src/components/Timeline/DetailsList/OrphanLog.tsx
@@ -5,9 +5,9 @@ import {
   objectHasStack,
   renderFullLogMessage,
 } from "@/utils";
-import { useTimelineIcon } from "../hooks";
+import { Icon } from "@iconify/react";
 import { SubSectionHeading } from "../shared";
-import { getColorForLevel } from "../utils";
+import { getBgColorForLevel, getTextColorForLevel } from "../utils";
 import { StackTrace } from "./StackTrace";
 
 export function OrphanLog({ log }: { log: MizuOrphanLog }) {
@@ -27,9 +27,11 @@ export function OrphanLog({ log }: { log: MizuOrphanLog }) {
   const description = getDescription(message ?? "", log.args);
   // TODO - Get stack from the span!
   const stack = objectHasStack(message) ? message.stack : null;
-  const icon = useTimelineIcon(log, {
-    colorOverride: getColorForLevel(log.level),
-  });
+  const textColorLevel = getTextColorForLevel(level);
+  const bgColorLevel = getBgColorForLevel(level);
+  // const icon = useTimelineIcon(log, {
+  //   colorOverride: getColorForLevel(log.level),
+  // });
 
   const hasDescription = !!description;
 
@@ -50,16 +52,19 @@ export function OrphanLog({ log }: { log: MizuOrphanLog }) {
   return (
     <div
       id={id?.toString()}
-      className="overflow-x-auto overflow-y-hidden max-w-full"
+      className={cn(
+        "overflow-x-auto overflow-y-hidden max-w-full px-2",
+        bgColorLevel,
+      )}
     >
-      <div className={cn("grid gap-2 grid-cols-[auto_1fr_auto] items-center")}>
-        {icon}
+      <div className={cn("grid gap-1 grid-cols-[auto_1fr_auto] items-center")}>
+        <Icon icon="lucide:terminal" className={textColorLevel} />
         {topContent}
 
         <SubSectionHeading
           className={cn(
             "font-semibold text-sm flex items-center gap-2",
-            getColorForLevel(log.level),
+            textColorLevel,
           )}
         >
           {heading}
@@ -67,15 +72,15 @@ export function OrphanLog({ log }: { log: MizuOrphanLog }) {
       </div>
 
       {hasDescription && contentsType === "multi-arg-log" && (
-        <LogContents className="px-2 text-xs" fullLogArgs={contents} />
+        <LogContents className="text-xs" fullLogArgs={contents} />
       )}
 
       {hasDescription && contentsType === "json" && (
-        <LogContents className="px-2 text-xs" fullLogArgs={contents} />
+        <LogContents className="text-xs" fullLogArgs={contents} />
       )}
 
       {stack && (
-        <div className="mt-2 max-h-[200px] overflow-y-auto text-gray-400 text-xs">
+        <div className="max-h-[200px] overflow-y-auto text-gray-400 text-xs">
           <StackTrace stackTrace={stack} />
         </div>
       )}

--- a/studio/src/components/Timeline/DetailsList/TimelineDetailsList.tsx
+++ b/studio/src/components/Timeline/DetailsList/TimelineDetailsList.tsx
@@ -25,7 +25,7 @@ function TimelineListDetailsComponent({
           onMouseEnter={() => setHighlightedSpanId(getId(item))}
           onMouseLeave={() => setHighlightedSpanId(null)}
           className={cn(
-            "p-2 max-w-full overflow-hidden",
+            "max-w-full overflow-hidden",
             "border-l-2 border-transparent rounded-sm transition-all bg-transparent",
             "hover:bg-primary/10 hover:border-blue-500 hover:rounded-l-none",
             "data-[highlighted=true]:bg-primary/10",

--- a/studio/src/components/Timeline/DetailsList/TimelineDetailsList.tsx
+++ b/studio/src/components/Timeline/DetailsList/TimelineDetailsList.tsx
@@ -30,6 +30,7 @@ function TimelineListDetailsComponent({
             "hover:bg-primary/10 hover:border-blue-500 hover:rounded-l-none",
             "data-[highlighted=true]:bg-primary/10",
             "relative after:absolute after:bottom-[-4px] after:bg-muted-foreground/30 after:w-full after:h-px last:after:h-0",
+            "h-full",
           )}
           data-highlighted={highlightedSpanId === getId(item)}
         >

--- a/studio/src/components/Timeline/graph/TimelineGraphLog.tsx
+++ b/studio/src/components/Timeline/graph/TimelineGraphLog.tsx
@@ -1,8 +1,9 @@
 import type { MizuOrphanLog } from "@/queries";
 import { cn } from "@/utils";
+import { Icon } from "@iconify/react";
 import { useTimelineContext } from "../context";
-import { useTimelineIcon, useTimelineTitle } from "../hooks";
-import { getColorForLevel } from "../utils";
+import { useTimelineTitle } from "../hooks";
+import { getBgColorForLevel, getTextColorForLevel } from "../utils";
 
 export const TimelineGraphLog: React.FC<{
   log: MizuOrphanLog;
@@ -13,9 +14,8 @@ export const TimelineGraphLog: React.FC<{
   const left =
     ((new Date(log.timestamp).getTime() - startTime) / duration) * 100;
   const lineOffset = `calc(${left.toFixed(4)}% - ${3 * 0.0625}rem)`;
-  const icon = useTimelineIcon(log, {
-    colorOverride: getColorForLevel(log.level),
-  });
+  const colorTextLevel = getTextColorForLevel(log.level);
+  const colorBgLevel = getBgColorForLevel(log.level);
   const title = useTimelineTitle(log);
   const { setHighlightedSpanId, highlightedSpanId } = useTimelineContext();
 
@@ -29,6 +29,7 @@ export const TimelineGraphLog: React.FC<{
         "transition-all",
         "cursor-pointer",
         "data-[highlighted=true]:bg-primary/10",
+        colorBgLevel,
       )}
       data-highlighted={highlightedSpanId === `${log.id}`}
       href={`#${log.id}`}
@@ -39,7 +40,9 @@ export const TimelineGraphLog: React.FC<{
           : undefined
       }
     >
-      <div className={cn(icon ? "mr-2" : "mr-0")}>{icon}</div>
+      <div className={cn("mr-2")}>
+        <Icon icon="lucide:terminal" className={cn(colorTextLevel)} />
+      </div>
       <div className="flex flex-col w-20 overflow-hidden">
         <div className="font-mono font-normal text-xs truncate text-gray-200">
           {title}

--- a/studio/src/components/Timeline/hooks/useTimelineTitle.tsx
+++ b/studio/src/components/Timeline/hooks/useTimelineTitle.tsx
@@ -115,10 +115,10 @@ export const useTimelineTitle = (waterfallItem: Waterfall[0]) => {
 
     const message = waterfallItem.message
       ? safeParseJson(waterfallItem.message)
-      : "log";
+      : `log.${waterfallItem.level}`;
     return (
       <div className="font-mono font-normal text-xs truncate text-gray-200">
-        {typeof message === "string" ? message : "log"}
+        {typeof message === "string" ? message : `log.${waterfallItem.level}`}
       </div>
     );
   }, [waterfallItem]);

--- a/studio/src/components/Timeline/utils.tsx
+++ b/studio/src/components/Timeline/utils.tsx
@@ -93,7 +93,22 @@ export const getTypeIcon = (type: string, colorOverride = "") => {
   }
 };
 
-export function getColorForLevel(level: string) {
+// NOTE: can't use a generic *-yellow-500 because transparency modifiers are
+// resolved before the color is applied and tailwind borks
+export function getBgColorForLevel(level: string) {
+  switch (level) {
+    case "info":
+      return "bg-muted/50";
+    case "warn":
+      return "bg-yellow-500/10";
+    case "error":
+      return "bg-red-500/10";
+    default:
+      return "bg-gray-500/10";
+  }
+}
+
+export function getTextColorForLevel(level: string) {
   switch (level) {
     case "info":
       return "text-muted-foreground";

--- a/studio/src/components/ui/table.tsx
+++ b/studio/src/components/ui/table.tsx
@@ -6,13 +6,11 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
 ));
 Table.displayName = "Table";
 

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -118,8 +118,8 @@ export function LogsTable({ traceId, togglePanel }: Props) {
         </div>
       </CustomTabsList>
       <CustomTabsContent value="logs" className="overflow-hidden">
-        {/* @ts-expect-error: TODO: fix the log levels that are reported as strings but need to be string unions */}
         <TableContent
+          //  @ts-expect-error: TODO: fix the log levels that are reported as strings but need to be string unions
           data={logs}
           columns={columns}
           expandedRowId={expandedRowId}

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -1,4 +1,3 @@
-import { getBgColorForLevel } from "@/components/Timeline/utils";
 import { Button } from "@/components/ui/button";
 import {
   Table,

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -1,0 +1,195 @@
+import { getBgColorForLevel } from "@/components/Timeline/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useOtelTrace } from "@/queries";
+import { cn } from "@/utils";
+import { Cross1Icon } from "@radix-ui/react-icons";
+import { Tabs } from "@radix-ui/react-tabs";
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useOrphanLogs } from "../../RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs";
+import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
+import type { Panels } from "../types";
+
+type OrphanLog = {
+  traceId: string;
+  id: number;
+  timestamp: string;
+  level: "error" | "warn" | "info" | "debug";
+  message: string | null;
+  args: unknown[];
+  createdAt: string;
+  updatedAt: string;
+  callerLocation?: { file: string; line: string; column: string } | null;
+  ignored?: boolean | null;
+  service?: string | null;
+  relatedSpanId?: string | null;
+};
+
+type Props = {
+  traceId: string;
+  togglePanel: (panelName: keyof Panels) => void;
+};
+
+export function LogsTable({ traceId, togglePanel }: Props) {
+  const { data: spans } = useOtelTrace(traceId);
+  const logs = useOrphanLogs(traceId, spans ?? []);
+
+  const columns: ColumnDef<OrphanLog>[] = [
+    {
+      accessorKey: "level",
+      header: "",
+      maxSize: 30,
+      cell: ({ row }) => {
+        return (
+          <div className="flex items-center justify-center">
+            <div
+              className={cn("w-1.5 h-6 rounded-full", {
+                "bg-red-700": row.original.level === "error",
+                "bg-yellow-700": row.original.level === "warn",
+                "bg-blue-700": row.original.level === "info",
+                "bg-muted": row.original.level === "debug",
+              })}
+              title={row.original.level.toUpperCase()}
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "timestamp",
+      header: "Timestamp",
+      maxSize: 80,
+      cell: ({ row }) => (
+        <span className="font-mono text-xs text-nowrap">
+          {new Date(row.original.timestamp)
+            .toISOString()
+            .replace("T", " ")
+            .replace("Z", "")}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "message",
+      header: "Message",
+      cell: ({ row }) => {
+        return (
+          <div className="cursor-pointer" role="button" tabIndex={0}>
+            <div className="font-mono text-xs truncate">
+              {row.original.message}
+            </div>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Tabs defaultValue="logs" className="h-full">
+      <CustomTabsList>
+        <CustomTabTrigger value="logs">Logs ({logs.length})</CustomTabTrigger>
+        <div className="flex-grow flex justify-end">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => togglePanel("logs")}
+            className="h-6 w-6"
+          >
+            <Cross1Icon className="h-3 w-3 cursor-pointer" />
+          </Button>
+        </div>
+      </CustomTabsList>
+      <CustomTabsContent
+        value="logs"
+        className="overflow-hidden md:overflow-hidden px-0"
+      >
+        {/* @ts-expect-error: TODO: fix the log levels that are reported as strings but need to be string unions */}
+        <TableContent columns={columns} data={logs} />
+      </CustomTabsContent>
+    </Tabs>
+  );
+}
+
+type TableProps = {
+  columns: ColumnDef<OrphanLog>[];
+  data: OrphanLog[];
+};
+
+function TableContent({ columns, data }: TableProps) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  return (
+    <Table className="border-separate border-spacing-y-1">
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id}>
+            {headerGroup.headers.map((header) => {
+              return (
+                <TableHead
+                  key={header.id}
+                  className={cn("text-left text-xs font-mono")}
+                  style={{ width: header.getSize() }}
+                >
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {table.getRowModel().rows?.length ? (
+          table.getRowModel().rows.map((row) => {
+            const bgColor = getBgColorForLevel(row.original.level);
+            return (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                className={cn(
+                  "cursor-pointer",
+                  // "border-l-2 border-b-0 border-transparent",
+                  bgColor,
+                  "hover:bg-muted",
+                )}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="py-1 px-2">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            );
+          })
+        ) : (
+          <TableRow>
+            <TableCell
+              colSpan={columns.length}
+              className="h-24 text-center font-mono text-muted-foreground"
+            >
+              No logs found.
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -52,61 +52,32 @@ export function LogsTable({ traceId, togglePanel }: Props) {
   const [expandedRowId, setExpandedRowId] = useState<number | null>(null);
 
   const columns: ColumnDef<OrphanLog>[] = [
-    // {
-    //   accessorKey: "level",
-    //   header: "",
-    //   maxSize: 5,
-    //   size: 5,
-    //   cell: ({ row }) => {
-    //     return (
-    //       <div
-    //         className={cn("w-1.5 h-full rounded-full", {
-    //           "bg-red-700": row.original.level === "error",
-    //           "bg-yellow-700": row.original.level === "warn",
-    //           "bg-blue-700": row.original.level === "info",
-    //           "bg-muted": row.original.level === "debug",
-    //         })}
-    //         title={row.original.level.toUpperCase()}
-    //       />
-    //     );
-    //   },
-    // },
     {
       accessorKey: "timestamp",
       header: "Timestamp",
       cell: ({ row }) => {
         const isExpanded = expandedRowId === row.original.id;
         return (
-          <div className="flex gap-1 justify-between h-full">
-            <div className="grid gap-4 text-right">
-              <div className="font-mono text-xs text-nowrap whitespace-nowrap">
-                {new Date(row.original.timestamp)
-                  .toISOString()
-                  .replace("T", " ")
-                  .replace("Z", "")}
-              </div>
-              {isExpanded && (
-                <p className="text-xs font-mono">
-                  level:{" "}
-                  <span
-                    className={cn(
-                      "uppercase",
-                      getTextColorForLevel(row.original.level),
-                    )}
-                  >
-                    {row.original.level}
-                  </span>
-                </p>
-              )}
+          <div className="grid gap-4 text-right">
+            <div className="font-mono text-xs text-nowrap whitespace-nowrap">
+              {new Date(row.original.timestamp)
+                .toISOString()
+                .replace("T", " ")
+                .replace("Z", "")}
             </div>
-            <div
-              className={cn("inline-block h-full w-1.5 rounded-full", {
-                "bg-red-700": row.original.level === "error",
-                "bg-yellow-700": row.original.level === "warn",
-                "bg-blue-700": row.original.level === "info",
-                "bg-muted": row.original.level === "debug",
-              })}
-            />
+            {isExpanded && (
+              <p className="text-xs font-mono">
+                level:{" "}
+                <span
+                  className={cn(
+                    "uppercase",
+                    getTextColorForLevel(row.original.level),
+                  )}
+                >
+                  {row.original.level}
+                </span>
+              </p>
+            )}
           </div>
         );
       },

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -21,10 +21,10 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { useState } from "react";
 import { useOrphanLogs } from "../../RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs";
 import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
 import type { Panels } from "../types";
-import { useState } from "react";
 
 type OrphanLog = {
   traceId: string;

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -72,7 +72,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
       maxSize: 145,
       size: 145,
       cell: ({ row }) => (
-        <span className="font-mono text-xs text-nowrap">
+        <span className="font-mono text-xs text-nowrap max-w-fit">
           {new Date(row.original.timestamp)
             .toISOString()
             .replace("T", " ")
@@ -142,7 +142,7 @@ function TableContent({ columns, data }: TableProps) {
               return (
                 <TableHead
                   key={header.id}
-                  className={cn("text-left text-xs font-mono")}
+                  className={cn("text-left text-xs font-mono max-w-fit")}
                   style={{ width: header.getSize() }}
                 >
                   {header.isPlaceholder
@@ -173,7 +173,7 @@ function TableContent({ columns, data }: TableProps) {
                 )}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id} className="py-1 px-2">
+                  <TableCell key={cell.id} className="py-1 px-2 max-w-fit">
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}
@@ -184,7 +184,7 @@ function TableContent({ columns, data }: TableProps) {
           <TableRow>
             <TableCell
               colSpan={columns.length}
-              className="h-24 text-center font-mono text-muted-foreground overflow-x-hidden"
+              className="h-24 text-center font-mono text-muted-foreground max-w-fit"
             >
               No logs found.
             </TableCell>

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -52,53 +52,61 @@ export function LogsTable({ traceId, togglePanel }: Props) {
   const [expandedRowId, setExpandedRowId] = useState<number | null>(null);
 
   const columns: ColumnDef<OrphanLog>[] = [
-    {
-      accessorKey: "level",
-      header: "",
-      maxSize: 5,
-      size: 5,
-      cell: ({ row }) => {
-        return (
-          <div
-            className={cn("w-1.5 h-full rounded-full", {
-              "bg-red-700": row.original.level === "error",
-              "bg-yellow-700": row.original.level === "warn",
-              "bg-blue-700": row.original.level === "info",
-              "bg-muted": row.original.level === "debug",
-            })}
-            title={row.original.level.toUpperCase()}
-          />
-        );
-      },
-    },
+    // {
+    //   accessorKey: "level",
+    //   header: "",
+    //   maxSize: 5,
+    //   size: 5,
+    //   cell: ({ row }) => {
+    //     return (
+    //       <div
+    //         className={cn("w-1.5 h-full rounded-full", {
+    //           "bg-red-700": row.original.level === "error",
+    //           "bg-yellow-700": row.original.level === "warn",
+    //           "bg-blue-700": row.original.level === "info",
+    //           "bg-muted": row.original.level === "debug",
+    //         })}
+    //         title={row.original.level.toUpperCase()}
+    //       />
+    //     );
+    //   },
+    // },
     {
       accessorKey: "timestamp",
       header: "Timestamp",
-      maxSize: 145,
-      size: 145,
       cell: ({ row }) => {
         const isExpanded = expandedRowId === row.original.id;
         return (
-          <div className="grid justify-between h-full text-right">
-            <span className="font-mono text-xs text-nowrap max-w-fit whitespace-nowrap">
-              {new Date(row.original.timestamp)
-                .toISOString()
-                .replace("T", " ")
-                .replace("Z", "")}
-            </span>
-            {isExpanded && (
-              <p className="text-xs font-mono">
-                level:{" "}
-                <span
-                  className={cn(
-                    "uppercase",
-                    getTextColorForLevel(row.original.level),
-                  )}
-                >
-                  {row.original.level}
-                </span>
-              </p>
-            )}
+          <div className="flex gap-1 justify-between h-full">
+            <div className="grid gap-4 text-right">
+              <div className="font-mono text-xs text-nowrap whitespace-nowrap">
+                {new Date(row.original.timestamp)
+                  .toISOString()
+                  .replace("T", " ")
+                  .replace("Z", "")}
+              </div>
+              {isExpanded && (
+                <p className="text-xs font-mono">
+                  level:{" "}
+                  <span
+                    className={cn(
+                      "uppercase",
+                      getTextColorForLevel(row.original.level),
+                    )}
+                  >
+                    {row.original.level}
+                  </span>
+                </p>
+              )}
+            </div>
+            <div
+              className={cn("inline-block h-full w-1.5 rounded-full", {
+                "bg-red-700": row.original.level === "error",
+                "bg-yellow-700": row.original.level === "warn",
+                "bg-blue-700": row.original.level === "info",
+                "bg-muted": row.original.level === "debug",
+              })}
+            />
           </div>
         );
       },
@@ -106,18 +114,17 @@ export function LogsTable({ traceId, togglePanel }: Props) {
     {
       accessorKey: "message",
       header: "Message",
-      size: Number.MAX_SAFE_INTEGER,
       cell: ({ row }) => {
         const isExpanded = expandedRowId === row.original.id;
         return (
-          <div className="">
-            <div
-              className={cn("font-mono text-xs overflow-x-hidden", {
-                truncate: !isExpanded,
-              })}
-            >
-              {row.original.message}
-            </div>
+          <div
+            className={cn("font-mono text-xs", {
+              "text-ellipsis overflow-hidden": !isExpanded,
+              "whitespace-nowrap": !isExpanded,
+              "w-full": !isExpanded,
+            })}
+          >
+            {row.original.message}
           </div>
         );
       },
@@ -139,14 +146,11 @@ export function LogsTable({ traceId, togglePanel }: Props) {
           </Button>
         </div>
       </CustomTabsList>
-      <CustomTabsContent
-        value="logs"
-        className="overflow-hidden md:overflow-hidden px-0 h-full"
-      >
+      <CustomTabsContent value="logs" className="overflow-hidden">
         {/* @ts-expect-error: TODO: fix the log levels that are reported as strings but need to be string unions */}
         <TableContent
-          columns={columns}
           data={logs}
+          columns={columns}
           expandedRowId={expandedRowId}
           setExpandedRowId={setExpandedRowId}
         />
@@ -174,7 +178,7 @@ function TableContent({
     getCoreRowModel: getCoreRowModel(),
   });
   return (
-    <Table className="border-separate border-spacing-y-1">
+    <Table className="border-separate border-spacing-y-1 table-fixed w-full">
       <TableHeader>
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
@@ -182,11 +186,9 @@ function TableContent({
               return (
                 <TableHead
                   key={header.id}
-                  className={cn("text-left text-xs font-mono")}
-                  style={{
-                    width: header.getSize(),
-                    minWidth: header.getSize(),
-                  }}
+                  className={cn("text-left text-xs font-mono", {
+                    "w-[180px]": header.column.id === "timestamp",
+                  })}
                 >
                   {header.isPlaceholder
                     ? null
@@ -209,9 +211,12 @@ function TableContent({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && "selected"}
-                className={cn("cursor-pointer", bgColor, "hover:bg-muted", {
-                  "bg-muted": isExpanded,
-                })}
+                className={cn(
+                  "cursor-pointer",
+                  bgColor,
+                  "hover:bg-muted",
+                  "px-2",
+                )}
                 onClick={() =>
                   setExpandedRowId(isExpanded ? null : row.original.id)
                 }
@@ -219,8 +224,9 @@ function TableContent({
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    className={cn("py-1 px-2")}
-                    style={{ minWidth: cell.column.getSize() }}
+                    className={cn("align-top", {
+                      "w-[180px]": cell.column.id === "timestamp",
+                    })}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -51,6 +51,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
       accessorKey: "level",
       header: "",
       maxSize: 5,
+      size: 5,
       cell: ({ row }) => {
         return (
           <div
@@ -68,8 +69,8 @@ export function LogsTable({ traceId, togglePanel }: Props) {
     {
       accessorKey: "timestamp",
       header: "Timestamp",
-      maxSize: 80,
-      size: 60,
+      maxSize: 145,
+      size: 145,
       cell: ({ row }) => (
         <span className="font-mono text-xs text-nowrap">
           {new Date(row.original.timestamp)
@@ -82,6 +83,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
     {
       accessorKey: "message",
       header: "Message",
+      size: Number.MAX_SAFE_INTEGER,
       cell: ({ row }) => {
         return (
           <div className="" role="button" tabIndex={0}>

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -1,3 +1,4 @@
+import { getBgColorForLevel } from "@/components/Timeline/utils";}
 import { Button } from "@/components/ui/button";
 import {
   Table,

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTable.tsx
@@ -1,4 +1,4 @@
-import { getBgColorForLevel } from "@/components/Timeline/utils";}
+import { getBgColorForLevel } from "@/components/Timeline/utils";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -50,20 +50,18 @@ export function LogsTable({ traceId, togglePanel }: Props) {
     {
       accessorKey: "level",
       header: "",
-      maxSize: 30,
+      maxSize: 5,
       cell: ({ row }) => {
         return (
-          <div className="flex items-center justify-center">
-            <div
-              className={cn("w-1.5 h-6 rounded-full", {
-                "bg-red-700": row.original.level === "error",
-                "bg-yellow-700": row.original.level === "warn",
-                "bg-blue-700": row.original.level === "info",
-                "bg-muted": row.original.level === "debug",
-              })}
-              title={row.original.level.toUpperCase()}
-            />
-          </div>
+          <div
+            className={cn("w-1.5 h-6 rounded-full", {
+              "bg-red-700": row.original.level === "error",
+              "bg-yellow-700": row.original.level === "warn",
+              "bg-blue-700": row.original.level === "info",
+              "bg-muted": row.original.level === "debug",
+            })}
+            title={row.original.level.toUpperCase()}
+          />
         );
       },
     },
@@ -71,6 +69,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
       accessorKey: "timestamp",
       header: "Timestamp",
       maxSize: 80,
+      size: 60,
       cell: ({ row }) => (
         <span className="font-mono text-xs text-nowrap">
           {new Date(row.original.timestamp)
@@ -85,7 +84,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
       header: "Message",
       cell: ({ row }) => {
         return (
-          <div className="cursor-pointer" role="button" tabIndex={0}>
+          <div className="" role="button" tabIndex={0}>
             <div className="font-mono text-xs truncate">
               {row.original.message}
             </div>
@@ -112,7 +111,7 @@ export function LogsTable({ traceId, togglePanel }: Props) {
       </CustomTabsList>
       <CustomTabsContent
         value="logs"
-        className="overflow-hidden md:overflow-hidden px-0"
+        className="overflow-hidden md:overflow-hidden px-0 h-full"
       >
         {/* @ts-expect-error: TODO: fix the log levels that are reported as strings but need to be string unions */}
         <TableContent columns={columns} data={logs} />
@@ -133,7 +132,7 @@ function TableContent({ columns, data }: TableProps) {
     getCoreRowModel: getCoreRowModel(),
   });
   return (
-    <Table className="border-separate border-spacing-y-1">
+    <Table className="border-separate border-spacing-y-1 h-full overflow-x-hidden">
       <TableHeader>
         {table.getHeaderGroups().map((headerGroup) => (
           <TableRow key={headerGroup.id}>
@@ -183,7 +182,7 @@ function TableContent({ columns, data }: TableProps) {
           <TableRow>
             <TableCell
               colSpan={columns.length}
-              className="h-24 text-center font-mono text-muted-foreground"
+              className="h-24 text-center font-mono text-muted-foreground overflow-x-hidden"
             >
               No logs found.
             </TableCell>

--- a/studio/src/pages/RequestorPage/LogsTable/index.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/index.tsx
@@ -1,0 +1,1 @@
+export { LogsTable } from "./LogsTable";

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -311,7 +311,6 @@ export const RequestorPage = () => {
                       "border",
                       "h-full",
                       "mt-2",
-                      "overflow-y-scroll",
                     )}
                   >
                     <RequestorTimeline

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -118,7 +118,7 @@ export const RequestorPage = () => {
               history={history}
               sessionHistory={sessionHistory}
               recordRequestInSessionHistory={recordRequestInSessionHistory}
-              traceId={id}
+              overrideTraceId={id}
             />
           )}
         </ResizablePanel>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -15,6 +15,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { NavigationPanel } from "./NavigationPanel";
 import { RequestPanel } from "./RequestPanel";
 import { RequestorInput } from "./RequestorInput";
+import { RequestorTimeline } from "./RequestorTimeline";
 import { ResponsePanel } from "./ResponsePanel";
 import { RoutesCombobox } from "./RoutesCombobox";
 import { AiTestGenerationPanel, useAi } from "./ai";
@@ -22,12 +23,11 @@ import { type Requestornator, useMakeProxiedRequest } from "./queries";
 import { useRoutes } from "./routes";
 import { useActiveRoute, useRequestorStore } from "./store";
 import { BACKGROUND_LAYER } from "./styles";
+import type { Panels } from "./types";
 import { useMakeWebsocketRequest } from "./useMakeWebsocketRequest";
 import { useRequestorHistory } from "./useRequestorHistory";
 import { useRequestorSubmitHandler } from "./useRequestorSubmitHandler";
 import { sortRequestornatorsDescending } from "./utils";
-import { RequestorTimeline } from "./RequestorTimeline";
-import type { Panels } from "./types";
 
 /**
  * Estimate the size of the main section based on the window width

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -12,6 +12,7 @@ import { useIsLgScreen } from "@/hooks";
 import { cn } from "@/utils";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { LogsTable } from "./LogsTable";
 import { NavigationPanel } from "./NavigationPanel";
 import { RequestPanel } from "./RequestPanel";
 import { RequestorInput } from "./RequestorInput";
@@ -130,6 +131,7 @@ export const RequestorPage = () => {
   const [openPanels, setOpenPanels] = useState<Panels>({
     aiTestGeneration: "closed",
     timeline: "closed",
+    logs: "closed",
   });
 
   const togglePanel = useCallback((panelName: keyof Panels) => {
@@ -213,7 +215,6 @@ export const RequestorPage = () => {
       <ResizablePanelGroup
         direction="horizontal"
         id="requestor-page-main"
-        autoSaveId="requestor-page-main"
         className="w-full"
       >
         {isLgScreen && (
@@ -257,13 +258,11 @@ export const RequestorPage = () => {
             <ResizablePanelGroup
               direction="vertical"
               id="requestor-page-main-panel"
-              autoSaveId="requestor-page-main-panel"
             >
               <ResizablePanel defaultSize={panelSize}>
                 <ResizablePanelGroup
                   direction={isLgScreen ? "horizontal" : "vertical"}
                   id="requestor-page-request-panel-group"
-                  autoSaveId="requestor-page-request-panel-group"
                   className={cn(
                     "rounded-md",
                     // HACK - This defensively prevents overflow from getting too excessive,
@@ -320,9 +319,27 @@ export const RequestorPage = () => {
                   </ResizablePanel>
                 </>
               )}
-              {/*
-               <ResizablePanel> </ResizablePanel>
-              */}
+              {openPanels.logs === "open" && traceId && (
+                <>
+                  <ResizableHandle
+                    hitAreaMargins={{ coarse: 20, fine: 10 }}
+                    className="bg-transparent"
+                  />
+                  <ResizablePanel
+                    id="logs"
+                    order={3}
+                    className={cn(
+                      BACKGROUND_LAYER,
+                      "h-full",
+                      "mt-2",
+                      "rounded-md",
+                      "border",
+                    )}
+                  >
+                    <LogsTable traceId={traceId} togglePanel={togglePanel} />
+                  </ResizablePanel>
+                </>
+              )}
               {openPanels.aiTestGeneration === "open" && (
                 <>
                   <ResizableHandle

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -311,6 +311,7 @@ export const RequestorPage = () => {
                       "border",
                       "h-full",
                       "mt-2",
+                      "overflow-y-scroll",
                     )}
                   >
                     <RequestorTimeline

--- a/studio/src/pages/RequestorPage/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent.tsx
@@ -9,19 +9,19 @@ import { useIsLgScreen } from "@/hooks";
 import { cn } from "@/utils";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { LogsTable } from "./LogsTable";
 import { RequestPanel } from "./RequestPanel";
 import { RequestorInput } from "./RequestorInput";
+import { RequestorTimeline } from "./RequestorTimeline";
 import { ResponsePanel } from "./ResponsePanel";
 import { AiTestGenerationPanel, useAi } from "./ai";
 import { type Requestornator, useMakeProxiedRequest } from "./queries";
 import { useActiveRoute, useRequestorStore } from "./store";
 import { BACKGROUND_LAYER } from "./styles";
+import type { Panels } from "./types";
 import { useMakeWebsocketRequest } from "./useMakeWebsocketRequest";
 import { useRequestorSubmitHandler } from "./useRequestorSubmitHandler";
 import { sortRequestornatorsDescending } from "./utils";
-import type { Panels } from "./types";
-import { LogsTable } from "./LogsTable";
-import { RequestorTimeline } from "./RequestorTimeline";
 
 interface RequestorPageContentProps {
   history: Requestornator[]; // Replace 'any[]' with the correct type

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -48,7 +48,7 @@ export function RequestorTimeline(props: Props) {
           <>
             <ResizablePanel
               minSize={minSize}
-              defaultSize={33}
+              defaultSize={25}
               order={0}
               id="graph"
             >

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -5,6 +5,7 @@ import {
   extractWaterfallTimeStats,
 } from "@/components/Timeline";
 import { useAsWaterfall } from "@/components/Timeline/hooks/useAsWaterfall";
+import { Button } from "@/components/ui/button";
 import {
   ResizableHandle,
   ResizablePanel,
@@ -14,12 +15,11 @@ import {
 import { useIsSmScreen } from "@/hooks";
 import { useOtelTrace } from "@/queries";
 import { cn } from "@/utils";
-import type { ReactNode } from "react";
-import { useOrphanLogs } from "../RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs";
-import { Button } from "@/components/ui/button";
 import { Cross1Icon } from "@radix-ui/react-icons";
 import { Tabs } from "@radix-ui/react-tabs";
-import { CustomTabsList, CustomTabTrigger, CustomTabsContent } from "./Tabs";
+import type { ReactNode } from "react";
+import { useOrphanLogs } from "../RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs";
+import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "./Tabs";
 import type { Panels } from "./types";
 
 type Props = {

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -43,8 +43,8 @@ export function RequestorTimeline({ traceId, togglePanel }: Props) {
   });
 
   return (
-    <Tabs defaultValue="timeline">
-      <CustomTabsList className="sticky">
+    <Tabs defaultValue="timeline" className="h-full">
+      <CustomTabsList>
         <CustomTabTrigger value="timeline">Timeline</CustomTabTrigger>
         <div className="flex-grow flex justify-end">
           <Button
@@ -57,42 +57,43 @@ export function RequestorTimeline({ traceId, togglePanel }: Props) {
           </Button>
         </div>
       </CustomTabsList>
-      <CustomTabsContent value="timeline" className="">
-        <div className="w-full">
-          <TimelineProvider>
-            <ResizablePanelGroup
-              direction="horizontal"
-              id="requestor-timeline"
-              className=""
-            >
-              {!isSmallScreen && (
-                <>
-                  <ResizablePanel
-                    minSize={minSize}
-                    defaultSize={25}
-                    order={0}
-                    id="graph"
-                  >
-                    <Content className="pr-3 sticky top-0">
-                      <TimelineGraph
-                        waterfall={waterfall}
-                        minStart={minStart}
-                        duration={duration}
-                        activeId=""
-                      />
-                    </Content>
-                  </ResizablePanel>
-                  <ResizableHandle hitAreaMargins={{ coarse: 20, fine: 10 }} />
-                </>
-              )}
-              <ResizablePanel className="max-h-full" order={1} id="details">
-                <Content className="overflow-y-scroll h-fit">
-                  <TimelineListDetails waterfall={waterfall} />
-                </Content>
-              </ResizablePanel>
-            </ResizablePanelGroup>
-          </TimelineProvider>
-        </div>
+      <CustomTabsContent
+        value="timeline"
+        className="overflow-hidden md:overflow-hidden"
+      >
+        <TimelineProvider>
+          <ResizablePanelGroup
+            direction="horizontal"
+            id="requestor-timeline"
+            className="h-full"
+          >
+            {!isSmallScreen && (
+              <>
+                <ResizablePanel
+                  minSize={minSize}
+                  defaultSize={25}
+                  order={0}
+                  id="graph"
+                >
+                  <Content className="pr-3 sticky top-0">
+                    <TimelineGraph
+                      waterfall={waterfall}
+                      minStart={minStart}
+                      duration={duration}
+                      activeId=""
+                    />
+                  </Content>
+                </ResizablePanel>
+                <ResizableHandle hitAreaMargins={{ coarse: 20, fine: 10 }} />
+              </>
+            )}
+            <ResizablePanel className="" order={1} id="details">
+              <Content className="overflow-y-auto h-full">
+                <TimelineListDetails waterfall={waterfall} />
+              </Content>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </TimelineProvider>
       </CustomTabsContent>
     </Tabs>
   );

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -44,7 +44,7 @@ export function RequestorTimeline({ traceId, togglePanel }: Props) {
 
   return (
     <Tabs defaultValue="timeline">
-      <CustomTabsList>
+      <CustomTabsList className="sticky">
         <CustomTabTrigger value="timeline">Timeline</CustomTabTrigger>
         <div className="flex-grow flex justify-end">
           <Button
@@ -86,7 +86,7 @@ export function RequestorTimeline({ traceId, togglePanel }: Props) {
                 </>
               )}
               <ResizablePanel className="max-h-full" order={1} id="details">
-                <Content className="overflow-auto h-fit">
+                <Content className="overflow-y-scroll h-fit">
                   <TimelineListDetails waterfall={waterfall} />
                 </Content>
               </ResizablePanel>

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -16,13 +16,18 @@ import { useOtelTrace } from "@/queries";
 import { cn } from "@/utils";
 import type { ReactNode } from "react";
 import { useOrphanLogs } from "../RequestDetailsPage/RequestDetailsPageV2/useOrphanLogs";
+import { Button } from "@/components/ui/button";
+import { Cross1Icon } from "@radix-ui/react-icons";
+import { Tabs } from "@radix-ui/react-tabs";
+import { CustomTabsList, CustomTabTrigger, CustomTabsContent } from "./Tabs";
+import type { Panels } from "./types";
 
 type Props = {
   traceId: string;
+  togglePanel: (panelName: keyof Panels) => void;
 };
 
-export function RequestorTimeline(props: Props) {
-  const { traceId } = props;
+export function RequestorTimeline({ traceId, togglePanel }: Props) {
   const { data: spans } = useOtelTrace(traceId);
 
   const orphanLogs = useOrphanLogs(traceId, spans ?? []);
@@ -38,39 +43,58 @@ export function RequestorTimeline(props: Props) {
   });
 
   return (
-    <TimelineProvider>
-      <ResizablePanelGroup
-        direction="horizontal"
-        id="requestor-timeline"
-        className=""
-      >
-        {!isSmallScreen && (
-          <>
-            <ResizablePanel
-              minSize={minSize}
-              defaultSize={25}
-              order={0}
-              id="graph"
+    <Tabs defaultValue="timeline">
+      <CustomTabsList>
+        <CustomTabTrigger value="timeline">Timeline</CustomTabTrigger>
+        <div className="flex-grow flex justify-end">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => togglePanel("timeline")}
+            className="h-6 w-6"
+          >
+            <Cross1Icon className="h-3 w-3 cursor-pointer" />
+          </Button>
+        </div>
+      </CustomTabsList>
+      <CustomTabsContent value="timeline" className="">
+        <div className="w-full">
+          <TimelineProvider>
+            <ResizablePanelGroup
+              direction="horizontal"
+              id="requestor-timeline"
+              className=""
             >
-              <Content className="pr-3 sticky top-0">
-                <TimelineGraph
-                  waterfall={waterfall}
-                  minStart={minStart}
-                  duration={duration}
-                  activeId=""
-                />
-              </Content>
-            </ResizablePanel>
-            <ResizableHandle hitAreaMargins={{ coarse: 20, fine: 10 }} />
-          </>
-        )}
-        <ResizablePanel className="max-h-full" order={1} id="details">
-          <Content className="overflow-auto h-fit">
-            <TimelineListDetails waterfall={waterfall} />
-          </Content>
-        </ResizablePanel>
-      </ResizablePanelGroup>
-    </TimelineProvider>
+              {!isSmallScreen && (
+                <>
+                  <ResizablePanel
+                    minSize={minSize}
+                    defaultSize={25}
+                    order={0}
+                    id="graph"
+                  >
+                    <Content className="pr-3 sticky top-0">
+                      <TimelineGraph
+                        waterfall={waterfall}
+                        minStart={minStart}
+                        duration={duration}
+                        activeId=""
+                      />
+                    </Content>
+                  </ResizablePanel>
+                  <ResizableHandle hitAreaMargins={{ coarse: 20, fine: 10 }} />
+                </>
+              )}
+              <ResizablePanel className="max-h-full" order={1} id="details">
+                <Content className="overflow-auto h-fit">
+                  <TimelineListDetails waterfall={waterfall} />
+                </Content>
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </TimelineProvider>
+        </div>
+      </CustomTabsContent>
+    </Tabs>
   );
 }
 

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -99,6 +99,19 @@ export const ResponsePanel = memo(function ResponsePanel({
               variant={openPanels.timeline === "open" ? "outline" : "ghost"}
               size="icon"
               disabled={!traceId}
+              onClick={() => togglePanel("logs")}
+              className={cn(
+                openPanels.timeline === "open" && "opacity-50 bg-slate-900",
+                "h-6 w-6",
+              )}
+              title="Show logs from the request-response lifecycle"
+            >
+              <Icon icon="lucide:logs" className="cursor-pointer h-4 w-4" />
+            </Button>
+            <Button
+              variant={openPanels.timeline === "open" ? "outline" : "ghost"}
+              size="icon"
+              disabled={!traceId}
               onClick={() => togglePanel("timeline")}
               className={cn(
                 openPanels.timeline === "open" && "opacity-50 bg-slate-900",

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -95,12 +95,12 @@ export const ResponsePanel = memo(function ResponsePanel({
           )}
           <div className="flex-grow flex justify-end">
             <Button
-              variant={openPanels.timeline === "open" ? "outline" : "ghost"}
+              variant={openPanels.logs === "open" ? "outline" : "ghost"}
               size="icon"
               disabled={!traceId}
               onClick={() => togglePanel("logs")}
               className={cn(
-                openPanels.timeline === "open" && "opacity-50 bg-slate-900",
+                openPanels.logs === "open" && "opacity-50 bg-slate-900",
                 "h-6 w-6",
               )}
               title="Show logs from the request-response lifecycle"

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
 import { SENSITIVE_HEADERS, cn, parsePathFromRequestUrl } from "@/utils";
+import { Icon } from "@iconify/react/dist/iconify.js";
 import { memo } from "react";
 import { Method, StatusCode } from "../RequestorHistory";
 import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
@@ -14,7 +15,7 @@ import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../store/types";
-import { isWsRequest, type Panels } from "../types";
+import { type Panels, isWsRequest } from "../types";
 import type { WebSocketState } from "../useMakeWebsocketRequest";
 import { FailedRequest, ResponseBody } from "./ResponseBody";
 import {
@@ -22,7 +23,6 @@ import {
   NoWebsocketConnection,
   WebsocketMessages,
 } from "./Websocket";
-import { Icon } from "@iconify/react/dist/iconify.js";
 
 type Props = {
   tracedResponse?: Requestornator;

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -1,21 +1,11 @@
 import RobotIcon from "@/assets/Robot.svg";
-import {
-  CollapsibleKeyValueTableV2,
-  SubSectionHeading,
-} from "@/components/Timeline";
+import { CollapsibleKeyValueTableV2 } from "@/components/Timeline";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
 import { SENSITIVE_HEADERS, cn, parsePathFromRequestUrl } from "@/utils";
-import { CaretDownIcon, CaretRightIcon } from "@radix-ui/react-icons";
-import { memo, useState } from "react";
+import { memo } from "react";
 import { Method, StatusCode } from "../RequestorHistory";
-import { RequestorTimeline } from "../RequestorTimeline";
 import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
 import type { Requestornator } from "../queries";
 import type { ResponsePanelTab } from "../store";
@@ -24,7 +14,7 @@ import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../store/types";
-import { isWsRequest } from "../types";
+import { isWsRequest, type Panels } from "../types";
 import type { WebSocketState } from "../useMakeWebsocketRequest";
 import { FailedRequest, ResponseBody } from "./ResponseBody";
 import {
@@ -32,21 +22,22 @@ import {
   NoWebsocketConnection,
   WebsocketMessages,
 } from "./Websocket";
+import { Icon } from "@iconify/react/dist/iconify.js";
 
 type Props = {
   tracedResponse?: Requestornator;
   isLoading: boolean;
   websocketState: WebSocketState;
-  openAiTestGenerationPanel: () => void;
-  isAiTestGenerationPanelOpen: boolean;
+  openPanels: Panels;
+  togglePanel: (panelName: keyof Panels & {}) => void;
 };
 
 export const ResponsePanel = memo(function ResponsePanel({
   tracedResponse,
   isLoading,
   websocketState,
-  openAiTestGenerationPanel,
-  isAiTestGenerationPanelOpen,
+  openPanels,
+  togglePanel,
 }: Props) {
   const {
     activeResponse,
@@ -82,8 +73,6 @@ export const ResponsePanel = memo(function ResponsePanel({
   const shouldShowMessages = shouldShowResponseTab("messages");
   const traceId = tracedResponse?.app_responses.traceId;
 
-  const [isOpen, setIsOpen] = useState(true);
-
   return (
     <div className="overflow-x-hidden overflow-y-auto h-full relative">
       <Tabs
@@ -107,13 +96,33 @@ export const ResponsePanel = memo(function ResponsePanel({
           )}
           <div className="flex-grow flex justify-end">
             <Button
-              variant={isAiTestGenerationPanelOpen ? "outline" : "ghost"}
+              variant={openPanels.timeline === "open" ? "outline" : "ghost"}
               size="icon"
-              onClick={openAiTestGenerationPanel}
+              disabled={!traceId}
+              onClick={() => togglePanel("timeline")}
               className={cn(
-                isAiTestGenerationPanelOpen && "opacity-50 bg-slate-900",
+                openPanels.timeline === "open" && "opacity-50 bg-slate-900",
                 "h-6 w-6",
               )}
+              title="Show timeline of the response"
+            >
+              <Icon
+                icon="lucide:list-tree"
+                className="cursor-pointer h-4 w-4"
+              />
+            </Button>
+            <Button
+              variant={
+                openPanels.aiTestGeneration === "open" ? "outline" : "ghost"
+              }
+              size="icon"
+              onClick={() => togglePanel("aiTestGeneration")}
+              className={cn(
+                openPanels.aiTestGeneration === "open" &&
+                  "opacity-50 bg-slate-900",
+                "h-6 w-6",
+              )}
+              title="Show test prompt generator"
             >
               <RobotIcon className="h-3 w-3 cursor-pointer" />
             </Button>
@@ -170,27 +179,6 @@ export const ResponsePanel = memo(function ResponsePanel({
                 // HACK - To support absolutely positioned bottom toolbar
                 className={cn(showBottomToolbar && "pb-2")}
               />
-              {traceId && (
-                <Collapsible
-                  open={isOpen}
-                  onOpenChange={setIsOpen}
-                  className="pl-0 border-t pt-2.5 mt-0.5"
-                >
-                  <CollapsibleTrigger asChild className="mb-2">
-                    <SubSectionHeading className="flex items-center gap-2 cursor-pointer">
-                      {isOpen ? (
-                        <CaretDownIcon className="w-4 h-4 cursor-pointer" />
-                      ) : (
-                        <CaretRightIcon className="w-4 h-4 cursor-pointer" />
-                      )}
-                      Logs & Events
-                    </SubSectionHeading>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <RequestorTimeline traceId={traceId} />
-                  </CollapsibleContent>
-                </Collapsible>
-              )}
             </div>
           </TabContentInner>
         </CustomTabsContent>

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -15,13 +15,14 @@ import { findMatchedRoute } from "../routes";
 import { useActiveRoute, useServiceBaseUrl } from "../store";
 import { ContextEntry } from "./AiTestGenerationDrawer";
 import { usePrompt } from "./ai-test-generation";
+import type { Panels } from "../types";
 
 export function AiTestGenerationPanel({
   history,
-  toggleAiTestGenerationPanel,
+  togglePanel,
 }: {
   history: Array<Requestornator>;
-  toggleAiTestGenerationPanel: () => void;
+  togglePanel: (panelName: keyof Panels) => void;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
 
@@ -71,7 +72,7 @@ export function AiTestGenerationPanel({
             <Button
               variant="ghost"
               size="icon"
-              onClick={toggleAiTestGenerationPanel}
+              onClick={() => togglePanel("aiTestGeneration")}
               className="h-6 w-6"
             >
               <Cross1Icon className="h-3 w-3 cursor-pointer" />

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -13,9 +13,9 @@ import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
 import type { Requestornator } from "../queries";
 import { findMatchedRoute } from "../routes";
 import { useActiveRoute, useServiceBaseUrl } from "../store";
+import type { Panels } from "../types";
 import { ContextEntry } from "./AiTestGenerationDrawer";
 import { usePrompt } from "./ai-test-generation";
-import type { Panels } from "../types";
 
 export function AiTestGenerationPanel({
   history,

--- a/studio/src/pages/RequestorPage/types.ts
+++ b/studio/src/pages/RequestorPage/types.ts
@@ -6,6 +6,7 @@ export type PanelState = "open" | "closed";
 export type Panels = {
   timeline: PanelState;
   aiTestGeneration: PanelState;
+  logs: PanelState;
 };
 
 export const RequestMethodSchema = z.enum([

--- a/studio/src/pages/RequestorPage/types.ts
+++ b/studio/src/pages/RequestorPage/types.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 import { WEBSOCKETS_ENABLED } from "./webSocketFeatureFlag";
 
+export type PanelState = "open" | "closed";
+
+export type Panels = {
+  timeline: PanelState;
+  aiTestGeneration: PanelState;
+};
+
 export const RequestMethodSchema = z.enum([
   "GET",
   "POST",


### PR DESCRIPTION
FP-4097

This PR extracts the timeline as a separate panel component akin to the AI test prompt generator. This enables more flexibility in terms of laying out the timeline contents confidently.

TODO:
- [ ] add a more prominent CTA in the response section to open the timeline

Preview
![image](https://github.com/user-attachments/assets/c2970f78-483c-42ad-a17d-9ca3b07f9a2a)
