### PR TITLE
Visual fixes and tweaks to the timeline and other panel comps

### DIFF
--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -67,8 +67,8 @@ jobs:
 
       # Building
 
-      - name: Build all workspaces
-        run: pnpm --recursive build
+      - name: Build api, frontend, and client library
+        run: pnpm --filter=studio --filter=api --filter=@fiberplane/hono-otel build
 
       # Release a preview version
 

--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -68,7 +68,12 @@ jobs:
       # Building
 
       - name: Build api, frontend, and client library
-        run: pnpm --filter=studio --filter=api --filter=@fiberplane/hono-otel build
+        run: |
+          pnpm \
+            --filter=@fiberplane/studio-frontend \
+            --filter=@fiberplane/studio \
+            --filter=@fiberplane/hono-otel \
+            build
 
       # Release a preview version
 

--- a/api/package.json
+++ b/api/package.json
@@ -32,11 +32,7 @@
     "access": "public"
   },
   "license": "MIT or Apache 2",
-  "keywords": [
-    "hono",
-    "local",
-    "debugging"
-  ],
+  "keywords": ["hono", "local", "debugging"],
   "bin": {
     "fpx": "bin/cli.js"
   },

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-beta.4",
+  "version": "0.8.0-beta.8",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",
@@ -32,7 +32,11 @@
     "access": "public"
   },
   "license": "MIT or Apache 2",
-  "keywords": ["hono", "local", "debugging"],
+  "keywords": [
+    "hono",
+    "local",
+    "debugging"
+  ],
   "bin": {
     "fpx": "bin/cli.js"
   },

--- a/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
+++ b/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
@@ -68,7 +68,7 @@ const NavItem = ({ item }: { item: MergedListItem }) => {
         search: params.toString(),
       }}
       className={cn(
-        "grid grid-cols-[38px_38px_1fr] gap-2 hover:bg-muted p-1.5 rounded cursor-pointer",
+        "grid grid-cols-[38px_38px_1fr] gap-2 hover:bg-muted p-1.5 rounded cursor-pointer items-center",
         {
           "bg-muted": id === getId(item),
         },
@@ -93,15 +93,6 @@ const getId = (item: MergedListItem) => {
     : item.data.traceId;
 };
 
-/**
-         <DataTable
-          columns={columns}
-          data={filteredItems ?? []}
-        // handleRowClick={handleRowClick}
-        // getPaginationRowModel={getPaginationRowModel<OtelTrace>}
-        />
- */
-
 function getSpan(trace: OtelTrace) {
   return (
     trace.spans.find(
@@ -118,7 +109,7 @@ const PathCell = ({ item }: { item: MergedListItem }) => {
       ? removeServiceUrlFromPath(item.data.app_requests.requestUrl)
       : removeServiceUrlFromPath(getRequestUrl(getSpan(item.data)));
 
-  return <div>{path}</div>;
+  return <div className="text-sm font-mono">{path}</div>;
 };
 
 const StatusCell = ({ item }: { item: MergedListItem }) => {
@@ -134,7 +125,7 @@ const MethodCell = ({ item }: { item: MergedListItem }) => {
     item.type === "request"
       ? item.data.app_requests.requestMethod
       : getRequestMethod(getSpan(item.data));
-  return <RequestMethod method={method} />;
+  return <RequestMethod method={method} className="text-xs font-mono" />;
 };
 
 type MergedListItem =

--- a/studio/src/pages/RequestorPage/RequestorTimeline.tsx
+++ b/studio/src/pages/RequestorPage/RequestorTimeline.tsx
@@ -44,7 +44,7 @@ export function RequestorTimeline({ traceId, togglePanel }: Props) {
 
   return (
     <Tabs defaultValue="timeline" className="h-full">
-      <CustomTabsList>
+      <CustomTabsList className="sticky top-0 z-10">
         <CustomTabTrigger value="timeline">Timeline</CustomTabTrigger>
         <div className="flex-grow flex justify-end">
           <Button

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
@@ -21,11 +21,9 @@ import {
 } from "../store/types";
 
 export function ResponseBody({
-  headersSlot,
   response,
   className,
 }: {
-  headersSlot?: React.ReactNode;
   response?: Requestornator | RequestorActiveResponse;
   className?: string;
 }) {
@@ -49,10 +47,7 @@ export function ResponseBody({
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          {headersSlot}
-          <CollapsibleBodyContainer>
-            <ResponseBodyText body={body.value} className={className} />
-          </CollapsibleBodyContainer>
+          <ResponseBodyText body={body.value} className={className} />
         </div>
       );
     }
@@ -64,10 +59,7 @@ export function ResponseBody({
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          {headersSlot}
-          <CollapsibleBodyContainer>
-            <TextOrJsonViewer text={prettyBody} collapsed={false} />
-          </CollapsibleBodyContainer>
+          <TextOrJsonViewer text={prettyBody} collapsed={false} />
         </div>
       );
     }
@@ -78,7 +70,6 @@ export function ResponseBody({
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          {headersSlot}
           <CollapsibleBodyContainer>
             <ResponseBodyBinary body={body} />
           </CollapsibleBodyContainer>
@@ -88,12 +79,10 @@ export function ResponseBody({
 
     // TODO - Stylize
     if (body?.type === "unknown") {
-      return (
-        <UnknownResponse headersSlot={headersSlot} className={className} />
-      );
+      return <UnknownResponse className={className} />;
     }
 
-    return <UnknownResponse headersSlot={headersSlot} className={className} />;
+    return <UnknownResponse className={className} />;
   }
 
   if (!isRequestorActiveResponse(response)) {
@@ -107,15 +96,12 @@ export function ResponseBody({
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          {headersSlot}
-          <CollapsibleBodyContainer>
-            <CodeMirrorJsonEditor
-              value={prettyBody}
-              readOnly
-              onChange={noop}
-              minHeight="0"
-            />
-          </CollapsibleBodyContainer>
+          <CodeMirrorJsonEditor
+            value={prettyBody}
+            readOnly
+            onChange={noop}
+            minHeight="0"
+          />
         </div>
       );
     }
@@ -125,10 +111,7 @@ export function ResponseBody({
 
     return (
       <div className={cn("overflow-hidden overflow-y-auto w-full", className)}>
-        {headersSlot}
-        <CollapsibleBodyContainer>
-          <ResponseBodyText body={body ?? ""} className={className} />
-        </CollapsibleBodyContainer>
+        <ResponseBodyText body={body ?? ""} className={className} />
       </div>
     );
   }
@@ -136,14 +119,11 @@ export function ResponseBody({
 
 function UnknownResponse({
   className,
-  headersSlot,
 }: {
-  headersSlot: React.ReactNode;
   className?: string;
 }) {
   return (
     <div className={cn("overflow-hidden overflow-y-auto w-full", className)}>
-      {headersSlot}
       <CollapsibleBodyContainer>
         <div className="text-gray-400 py-20 flex flex-col items-center justify-center gap-4">
           <QuestionMarkIcon className="h-8 w-8" />

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -1,5 +1,4 @@
 import RobotIcon from "@/assets/Robot.svg";
-import { CollapsibleKeyValueTableV2 } from "@/components/Timeline";
 import { KeyValueTable } from "@/components/Timeline/DetailsList/KeyValueTableV2";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -23,6 +23,7 @@ import {
   NoWebsocketConnection,
   WebsocketMessages,
 } from "./Websocket";
+import { KeyValueTable } from "@/components/Timeline/DetailsList/KeyValueTableV2";
 
 type Props = {
   tracedResponse?: Requestornator;
@@ -93,6 +94,15 @@ export const ResponsePanel = memo(function ResponsePanel({
           {shouldShowMessages && (
             <CustomTabTrigger value="messages">Messages</CustomTabTrigger>
           )}
+          <CustomTabTrigger value="headers">
+            Headers
+            {responseHeaders && Object.keys(responseHeaders).length > 1 && (
+              <span className="ml-1 text-gray-400 font-mono text-xs">
+                ({Object.keys(responseHeaders).length})
+              </span>
+            )}
+          </CustomTabTrigger>
+
           <div className="flex-grow flex justify-end">
             <Button
               variant={openPanels.logs === "open" ? "outline" : "ghost"}
@@ -119,7 +129,7 @@ export const ResponsePanel = memo(function ResponsePanel({
               title="Show timeline of the response"
             >
               <Icon
-                icon="lucide:list-tree"
+                icon="lucide:chart-gantt"
                 className="cursor-pointer h-4 w-4"
               />
             </Button>
@@ -179,20 +189,20 @@ export const ResponsePanel = memo(function ResponsePanel({
           >
             <div className={cn("grid grid-rows-[auto_1fr]")}>
               <ResponseBody
-                headersSlot={
-                  <CollapsibleKeyValueTableV2
-                    sensitiveKeys={SENSITIVE_HEADERS}
-                    title="Headers"
-                    keyValue={responseHeaders ?? {}}
-                    className="mb-0.5 pb-2"
-                  />
-                }
                 response={responseToRender}
                 // HACK - To support absolutely positioned bottom toolbar
                 className={cn(showBottomToolbar && "pb-2")}
               />
             </div>
           </TabContentInner>
+        </CustomTabsContent>
+        <CustomTabsContent value="headers">
+          {responseHeaders && (
+            <KeyValueTable
+              sensitiveKeys={SENSITIVE_HEADERS}
+              keyValue={responseHeaders}
+            />
+          )}
         </CustomTabsContent>
       </Tabs>
     </div>

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -1,5 +1,6 @@
 import RobotIcon from "@/assets/Robot.svg";
 import { CollapsibleKeyValueTableV2 } from "@/components/Timeline";
+import { KeyValueTable } from "@/components/Timeline/DetailsList/KeyValueTableV2";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs } from "@/components/ui/tabs";
@@ -23,7 +24,6 @@ import {
   NoWebsocketConnection,
   WebsocketMessages,
 } from "./Websocket";
-import { KeyValueTable } from "@/components/Timeline/DetailsList/KeyValueTableV2";
 
 type Props = {
   tracedResponse?: Requestornator;

--- a/studio/src/pages/RequestorPage/store/slices/tabsSlice.ts
+++ b/studio/src/pages/RequestorPage/store/slices/tabsSlice.ts
@@ -9,7 +9,7 @@ export const tabsSlice: StateCreator<
   activeRequestsPanelTab: "params",
   visibleRequestsPanelTabs: ["params", "headers"],
   activeResponsePanelTab: "response",
-  visibleResponsePanelTabs: ["response", "debug"],
+  visibleResponsePanelTabs: ["response", "headers"],
 
   setActiveRequestsPanelTab: (tab) =>
     set((state) => {
@@ -31,5 +31,5 @@ function isRequestsPanelTab(tab: string): tab is RequestsPanelTab {
 }
 
 function isResponsePanelTab(tab: string): tab is ResponsePanelTab {
-  return ["response", "messages"].includes(tab);
+  return ["response", "messages", "headers"].includes(tab);
 }

--- a/studio/src/pages/RequestorPage/store/tabs.ts
+++ b/studio/src/pages/RequestorPage/store/tabs.ts
@@ -27,7 +27,11 @@ export const getVisibleRequestPanelTabs = (route: {
   return ["params", "headers", "body"];
 };
 
-export const ResponsePanelTabSchema = z.enum(["response", "messages", "debug"]);
+export const ResponsePanelTabSchema = z.enum([
+  "response",
+  "messages",
+  "headers",
+]);
 
 export type ResponsePanelTab = z.infer<typeof ResponsePanelTabSchema>;
 
@@ -39,7 +43,7 @@ export const getVisibleResponsePanelTabs = (route: {
   requestType: RequestType;
 }): ResponsePanelTab[] => {
   if (route.requestType === "websocket") {
-    return ["response", "messages", "debug"];
+    return ["response", "messages", "headers"];
   }
-  return ["response", "debug"];
+  return ["response", "headers"];
 };


### PR DESCRIPTION
A little bit of a catch-all for a few tweaks and fixes I noticed testing out the new timeline/logs components:

- the requests overview panel uses the same font and size as the routes panel
- timeline header no longer hides after you click on one of the graph components
- the timeline icon is something that stands out a little bit more next to the logs (although could probably still use an improvement