### PR TITLE
release 0.8.1 and bump pre-release 0.8.2-canary.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.1-canary.3",
+  "version": "0.8.2-canary.0",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",


### PR DESCRIPTION
Release is already on NPM, this is just a PR to update the state of the repo.
