### PR TITLE
Small fix: Disable search keyboard shortcuts (cmd + g) in codemirror json component

### DIFF
--- a/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
+++ b/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
@@ -45,6 +45,10 @@ export function CodeMirrorJsonEditor(props: CodeMirrorEditorProps) {
       onChange={onChange}
       theme={[duotoneDark, customTheme]}
       readOnly={readOnly}
+      basicSetup={{
+        // Turn off searching the input via cmd+g and cmd+f
+        searchKeymap: false,
+      }}
     />
   );
 }

--- a/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
+++ b/studio/src/components/Timeline/DetailsList/CodeMirrorEditor.tsx
@@ -48,6 +48,8 @@ export function CodeMirrorJsonEditor(props: CodeMirrorEditorProps) {
       basicSetup={{
         // Turn off searching the input via cmd+g and cmd+f
         searchKeymap: false,
+        // Investigate: Remap the default keymap: https://codemirror.net/docs/ref/#commands.defaultKeymap
+        //              This will allow us to do things like cmd+enter to submit a payload
       }}
     />
   );


### PR DESCRIPTION
One-liner. Also added a comment to investigate remapping the default keymap somehow in a future PR