### PR TITLE
Publish v0.8.3 and update website changelog

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.3-canary.0",
+  "version": "0.8.4-canary.0",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.2-canary.0",
+  "version": "0.8.3-canary.0",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/studio/src/Layout/Branding.tsx
+++ b/studio/src/Layout/Branding.tsx
@@ -2,9 +2,9 @@ import FpLogo from "@/assets/fp-logo.svg";
 
 export function Branding() {
   return (
-    <div className="flex items-center gap-2 overflow-hidden">
-      <FpLogo className="w-4 h-4 text-muted-foreground/60 [&>path]:text-muted" />
-      <span className="text-sm text-muted-foreground/60">Fiberplane</span>
-    </div>
+    <a href="https://fiberplane.com" className="flex items-center gap-2 overflow-hidden group">
+      <FpLogo className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground [&>path]:text-muted" />
+      <span className="text-sm text-muted-foreground/60 group-hover:text-muted-foreground">Fiberplane</span>
+    </a>
   );
 }

--- a/studio/src/Layout/Branding.tsx
+++ b/studio/src/Layout/Branding.tsx
@@ -2,9 +2,14 @@ import FpLogo from "@/assets/fp-logo.svg";
 
 export function Branding() {
   return (
-    <a href="https://fiberplane.com" className="flex items-center gap-2 overflow-hidden group">
+    <a
+      href="https://fiberplane.com"
+      className="flex items-center gap-2 overflow-hidden group"
+    >
       <FpLogo className="w-4 h-4 text-muted-foreground/60 group-hover:text-muted-foreground [&>path]:text-muted" />
-      <span className="text-sm text-muted-foreground/60 group-hover:text-muted-foreground">Fiberplane</span>
+      <span className="text-sm text-muted-foreground/60 group-hover:text-muted-foreground">
+        Fiberplane
+      </span>
     </a>
   );
 }

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -6,6 +6,4 @@ draft: true
 
 ### Features
 
-
 ### Bug fixes
-

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -1,21 +1,11 @@
 ---
-date: 2024-09-20
+date: 2024-09-30
 version: canary
 draft: true
 ---
 
 ### Features
 
-- **Improved logs panel.** The logs panel now shows up automatically when there are error-level logs recorded (the logs icon in the bottom-right corner also shows a red dot). The panel itself is now more responsive, readable, and features a button for quickly copying the message to clipboard.
-
-- **Empty states.** Sometimes, you don't have the data. Sometimes it's intended and sometimes it's not. This release adds makes the uninteded cases easier to resolve with clear feedback and guidance directly shown in the UI.
-
-- **Improved ai/timeline/logs panel** The panels are now combined into a single panel with tabs for each. This makes it easier to switch between them and reduces the amount of space they take up.
 
 ### Bug fixes
 
-- **Initial size routes panel** Fixed an issue where routes panel would be rendered too big when the app was first loaded.
-
-- **Panel resizing issue** If multiple panels were open, sometimes resizing would not work correctly.
-
-- **Logs panel toggle** Fixed an issue where the red dot when there are errors would not be displayed.

--- a/www/src/content/changelog/2024-09-23-v0_8_2.mdx
+++ b/www/src/content/changelog/2024-09-23-v0_8_2.mdx
@@ -11,7 +11,6 @@ version: 0.8.2
 
 - **Empty states.** Sometimes, you don't have the data. Sometimes it's intended and sometimes it's not. This release adds makes the uninteded cases easier to resolve with clear feedback and guidance directly shown in the UI.
 
-
 ### Bug fixes
 
 - **Initial size routes panel**. Fixed an issue where routes panel would be rendered too big when the app was first loaded.

--- a/www/src/content/changelog/2024-09-23-v0_8_2.mdx
+++ b/www/src/content/changelog/2024-09-23-v0_8_2.mdx
@@ -1,0 +1,21 @@
+---
+date: 2024-09-23
+version: 0.8.2
+---
+
+### Features
+
+- **Improved AI/Timeline/Logs panel** The panels are now combined into a single panel with tabs for each. This makes it easier to switch between them and reduces the amount of space they take up in the UI.
+
+- **Improved logs panel.** The logs panel now shows up automatically when there are error-level logs recorded (the logs icon in the bottom-right corner also shows a red dot). The panel itself is now more responsive, readable, and features a button for quickly copying the message to clipboard.
+
+- **Empty states.** Sometimes, you don't have the data. Sometimes it's intended and sometimes it's not. This release adds makes the uninteded cases easier to resolve with clear feedback and guidance directly shown in the UI.
+
+
+### Bug fixes
+
+- **Initial size routes panel**. Fixed an issue where routes panel would be rendered too big when the app was first loaded.
+
+- **Panel resizing issue**. If multiple panels were open, sometimes resizing would not work correctly.
+
+- **Logs panel toggle**. Fixed an issue where the red dot when there are errors would not be displayed.

--- a/www/src/content/changelog/2024-09-23-v0_8_3.mdx
+++ b/www/src/content/changelog/2024-09-23-v0_8_3.mdx
@@ -1,13 +1,13 @@
 ---
 date: 2024-09-23
-version: 0.8.2
+version: 0.8.3
 ---
 
 ### Features
 
 - **Improved AI/Timeline/Logs panel** The panels are now combined into a single panel with tabs for each. This makes it easier to switch between them and reduces the amount of space they take up in the UI.
 
-- **Improved logs panel.** The logs panel now shows up automatically when there are error-level logs recorded (the logs icon in the bottom-right corner also shows a red dot). The panel itself is now more responsive, readable, and features a button for quickly copying the message to clipboard.
+- **Improved logs panel.** The logs icon in the bottom-right corner shows a red dot when there are error-level logs recorded. The panel itself is now more responsive, readable, and features a button for quickly copying the message to clipboard.
 
 - **Empty states.** Sometimes, you don't have the data. Sometimes it's intended and sometimes it's not. This release adds makes the uninteded cases easier to resolve with clear feedback and guidance directly shown in the UI.
 

--- a/www/src/pages/changelog.astro
+++ b/www/src/pages/changelog.astro
@@ -48,9 +48,9 @@ const changelogEntries = await Promise.all(
 </StarlightPage>
 
 <style>
-	div {
-		display: flex;
-		gap: 1rem;
-		align-items: center;
-	}
+  div {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
 </style>

--- a/www/src/pages/changelog.astro
+++ b/www/src/pages/changelog.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from "astro:content";
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import { Badge } from "@astrojs/starlight/components";
 
 const changelogEntriesUnsorted = await getCollection("changelog");
 const changelogEntries = await Promise.all(
@@ -29,16 +30,27 @@ const changelogEntries = await Promise.all(
     changelogEntries.map((entry) => {
       return (
         <section>
-          <h2>
-            {entry.data.date.toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric"
-            })}
-          </h2>
+          <div>
+            <h2>
+              {entry.data.date.toLocaleDateString("en-US", {
+                year: "numeric",
+                month: "long",
+                day: "numeric"
+              })}
+            </h2>
+            <Badge variant="default" text={`v${entry.data.version}`} />
+          </div>
           <entry.content.Content />
         </section>
       );
     })
   }
 </StarlightPage>
+
+<style>
+	div {
+		display: flex;
+		gap: 1rem;
+		align-items: center;
+	}
+</style>


### PR DESCRIPTION
Chore PR to update the published versions and align changelog on the website.

Also shoehorned an update to the product to link the logo to the main website.

The branch says v0.8.2 but it's actually v0.8.3 because we found a show-stopper bug