### PR TITLE
Unify request rendering and some additional fixes

### DIFF
--- a/packages/client-library-otel/sample/index.ts
+++ b/packages/client-library-otel/sample/index.ts
@@ -27,6 +27,7 @@ app.get("/", async (c) => {
   console.log("Hello Hono!");
   console.error("This message is logged as an error");
   console.debug("Debug message", { with: "extra", data: true });
+  console.warn({ with: "extra", data: true });
 
   loop(3);
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,10 +1,13 @@
-import type { OtelSpan } from "./otel.js";
+import { z } from "zod";
+import { type OtelSpan, OtelSpanSchema } from "./otel.js";
 
-export type TraceSummary = {
-  traceId: string;
-  spans: Array<OtelSpan>;
-};
+export const TraceSummarySchema = z.object({
+  traceId: z.string(),
+  spans: z.array(OtelSpanSchema),
+});
+export type TraceSummary = z.infer<typeof TraceSummarySchema>;
 
-export type TraceListResponse = Array<TraceSummary>;
+export const TraceListResponseSchema = z.array(TraceSummarySchema);
+export type TraceListResponse = z.infer<typeof TraceListResponseSchema>;
 
 export type TraceDetailSpansResponse = Array<OtelSpan>;

--- a/packages/types/src/otel.ts
+++ b/packages/types/src/otel.ts
@@ -75,7 +75,7 @@ export const OtelSpanSchema = z
       }),
     ),
   })
-  .passthrough(); // HACK - Passthrough to vendorify traces
+  .passthrough(); // HACK - Passthrough for now to allow for additional fields
 
 export type OtelSpan = z.infer<typeof OtelSpanSchema>;
 

--- a/studio/src/App.tsx
+++ b/studio/src/App.tsx
@@ -3,21 +3,16 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
 import { Layout } from "./Layout";
 import { Toaster } from "./components/ui/toaster";
+import {
+  REQUESTOR_TRACE_ROUTE,
+  REQUESTS_ROUTE,
+  REQUEST_DETAILS_OTEL_ROUTE,
+  REQUEST_DETAILS_TRACE_ROUTE,
+  ROOT_ROUTE,
+} from "./constants";
 import { RequestDetailsPage } from "./pages/RequestDetailsPage/RequestDetailsPage";
 import { RequestorPage } from "./pages/RequestorPage";
 import { RequestsPage } from "./pages/RequestsPage/RequestsPage";
-
-export const REQUESTS_ROUTE = "/requests";
-export const REQUEST_DETAILS_OTEL_ROUTE = "/requests/otel/:traceId";
-export const REQUEST_DETAILS_TRACE_ROUTE = "/requests/:traceId";
-export const ROOT_ROUTE = "/";
-export const REQUESTOR_TRACE_ROUTE = "/:requestType/:traceId";
-
-export const TRACE_ID_ROUTES = [
-  REQUEST_DETAILS_OTEL_ROUTE,
-  REQUEST_DETAILS_TRACE_ROUTE,
-  REQUESTOR_TRACE_ROUTE,
-];
 
 export function App() {
   return (

--- a/studio/src/constants.ts
+++ b/studio/src/constants.ts
@@ -22,7 +22,7 @@ export const CF_BINDING_RESULT = "cf.binding.result";
 export const CF_BINDING_ERROR = "cf.binding.error";
 
 // <note>
-// THESE FPX_* attrs NOT YET IMPLMENTED
+// THESE FPX_* attrs NOT YET IMPLEMENTED
 export const FPX_REQUEST_HANDLER_FILE = "fpx.http.request.handler.file";
 export const FPX_REQUEST_HANDLER_SOURCE_CODE =
   "fpx.http.request.handler.source_code";
@@ -60,3 +60,15 @@ export const SpanKind = {
    */
   CONSUMER: "Consumer",
 };
+
+export const REQUESTS_ROUTE = "/requests";
+export const REQUEST_DETAILS_OTEL_ROUTE = "/requests/otel/:traceId";
+export const REQUEST_DETAILS_TRACE_ROUTE = "/requests/:traceId";
+export const ROOT_ROUTE = "/";
+export const REQUESTOR_TRACE_ROUTE = "/:requestType/:traceId";
+
+export const TRACE_ID_ROUTES = [
+  REQUEST_DETAILS_OTEL_ROUTE,
+  REQUEST_DETAILS_TRACE_ROUTE,
+  REQUESTOR_TRACE_ROUTE,
+];

--- a/studio/src/hooks/useActiveTraceId.ts
+++ b/studio/src/hooks/useActiveTraceId.ts
@@ -1,4 +1,4 @@
-import { TRACE_ID_ROUTES } from "@/App";
+import { TRACE_ID_ROUTES } from "@/constants";
 import { useRequestorStore } from "@/pages/RequestorPage/store";
 import { useMemo } from "react";
 import { matchRoutes, useLocation } from "react-router-dom";
@@ -25,5 +25,6 @@ function useTraceIdFromRoute() {
   if (match && match.length > 0) {
     return match[0].params.traceId;
   }
+
   return null;
 }

--- a/studio/src/hooks/useWebsocketQueryInvalidation.ts
+++ b/studio/src/hooks/useWebsocketQueryInvalidation.ts
@@ -15,7 +15,7 @@ export function useWebsocketQueryInvalidation() {
   if (wsMessage) {
     switch (wsMessage.event) {
       case "trace_created": {
-        // console.debug("trace_created");
+        console.debug("trace_created");
         queryClient.invalidateQueries({ queryKey: wsMessage.payload });
         break;
       }

--- a/studio/src/pages/RequestorPage/LogsTable/LogsTableRow.tsx
+++ b/studio/src/pages/RequestorPage/LogsTable/LogsTableRow.tsx
@@ -25,7 +25,12 @@ export function LogRow({ log }: LogRowProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   // we don't want the focus ring to be visible when the user is selecting the row with the mouse
   const [isMouseSelected, setIsMouseSelected] = useState(false);
-  const { isCopied, copyToClipboard } = useCopyToClipboard();
+  const { isCopied: isMessageCopied, copyToClipboard: copyMessageToClipboard } =
+    useCopyToClipboard();
+  const {
+    isCopied: isArgumentsCopied,
+    copyToClipboard: copyArgumentsToClipboard,
+  } = useCopyToClipboard();
 
   return (
     <details
@@ -71,37 +76,73 @@ export function LogRow({ log }: LogRowProps) {
           {log.message && (
             <div className="flex gap-2">
               <p>Message:</p>
-              <p className="text-foreground break-words">
+              <div className="text-foreground break-words grow">
                 {safeParseJson(log.message) ? (
                   <pre className="whitespace-pre-wrap">
                     {JSON.stringify(JSON.parse(log.message), null, 2)}
                   </pre>
                 ) : (
-                  log.message
+                  <p>{log.message}</p>
                 )}
-              </p>
+              </div>
+              <div className="-mt-2 flex justify-start">
+                <TooltipProvider>
+                  <Tooltip open={isMessageCopied}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        title="Copy log message"
+                        onClick={() =>
+                          copyMessageToClipboard(log.message ?? "")
+                        }
+                        className="flex items-center gap-1"
+                      >
+                        <CopyIcon className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Message copied</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
             </div>
           )}
-        </div>
-        <div className="mt-2 flex justify-start">
-          <TooltipProvider>
-            <Tooltip open={isCopied}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  title="Copy log message"
-                  onClick={() => copyToClipboard(log.message ?? "")}
-                  className="flex items-center gap-1"
-                >
-                  <CopyIcon className="h-3 w-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Message copied</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          {log.args.length > 0 && (
+            <div className="flex gap-2">
+              <p>Additional arguments:</p>
+              <div className="text-foreground break-words grow">
+                <pre className="whitespace-pre-wrap">
+                  {JSON.stringify(log.args, null, 2)}
+                </pre>
+              </div>
+              <div className="-mt-2 flex justify-start">
+                <TooltipProvider>
+                  <Tooltip open={isArgumentsCopied}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        title="Copy log message"
+                        onClick={() =>
+                          copyArgumentsToClipboard(
+                            JSON.stringify(log.args, null, 2),
+                          )
+                        }
+                        className="flex items-center gap-1"
+                      >
+                        <CopyIcon className="h-3 w-3" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Arguments copied</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </details>

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -45,18 +45,18 @@ export const RequestorPage = () => {
 
   const {
     history,
-    sessionHistory,
+    // sessionHistory,
     isLoading,
-    recordRequestInSessionHistory,
+    // recordRequestInSessionHistory,
     loadHistoricalRequest,
   } = useRequestorHistory();
 
   const hasHistory = history.length > 0;
   useEffect(() => {
-    if (id && hasHistory && requestType === "request") {
+    if (id && hasHistory) {
       loadHistoricalRequest(id);
     }
-  }, [id, loadHistoricalRequest, hasHistory, requestType]);
+  }, [id, loadHistoricalRequest, hasHistory]);
 
   const width = getMainSectionWidth();
   const isLgScreen = useIsLgScreen();
@@ -80,7 +80,7 @@ export const RequestorPage = () => {
   const generateNavigation = useHandler((traceId: string) => {
     const search = searchParams.toString();
     return {
-      path: `/request/${traceId}/navigation`,
+      pathname: `/request/${traceId}`,
       search,
     };
   });
@@ -131,8 +131,6 @@ export const RequestorPage = () => {
             <RequestorPageContent
               history={history}
               historyLoading={isLoading}
-              sessionHistory={sessionHistory}
-              recordRequestInSessionHistory={recordRequestInSessionHistory}
               overrideTraceId={id}
               generateNavigation={generateNavigation}
             />

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -27,8 +27,8 @@ import { getMainSectionWidth } from "./util";
 interface RequestorPageContentProps {
   history: Requestornator[]; // Replace 'any[]' with the correct type
   historyLoading: boolean;
-  sessionHistory: Requestornator[];
-  recordRequestInSessionHistory: (traceId: string) => void;
+  // sessionHistory: Requestornator[];
+  // recordRequestInSessionHistory: (traceId: string) => void;
   overrideTraceId?: string;
   generateNavigation: (traceId: string) => To;
 }
@@ -38,9 +38,8 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
 ) => {
   const {
     history,
-    recordRequestInSessionHistory,
     overrideTraceId,
-    sessionHistory,
+    // sessionHistory,
     historyLoading,
     generateNavigation,
   } = props;
@@ -48,7 +47,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
   const { toast } = useToast();
 
   const mostRecentRequestornatorForRoute = useMostRecentRequestornator(
-    sessionHistory,
+    history,
     overrideTraceId,
   );
 
@@ -92,7 +91,6 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
   const onSubmit = useRequestorSubmitHandler({
     makeRequest,
     connectWebsocket,
-    recordRequestInSessionHistory,
     generateNavigation,
   });
 

--- a/studio/src/pages/RequestorPage/store/slices/types.ts
+++ b/studio/src/pages/RequestorPage/store/slices/types.ts
@@ -82,9 +82,7 @@ export interface UISlice {
   bottomPanels: BOTTOM_PANEL_NAMES[];
   bottomPanelIndex: undefined | number;
   setBottomPanelIndex(index: number | undefined): void;
-  togglePanel: (
-    panelName: Exclude<keyof UISlice, "togglePanel"> | BOTTOM_PANEL_NAMES,
-  ) => void;
+  togglePanel: (panelName: "sidePanel" | BOTTOM_PANEL_NAMES) => void;
 }
 
 export type BOTTOM_PANEL_NAMES = "logsPanel" | "timelinePanel" | "aiPanel";

--- a/studio/src/pages/RequestorPage/store/slices/uiSlice.ts
+++ b/studio/src/pages/RequestorPage/store/slices/uiSlice.ts
@@ -14,12 +14,11 @@ export const uiSlice: StateCreator<
     sidePanel: isLgScreen() ? "open" : "closed",
     bottomPanels: validBottomPanelNames,
     bottomPanelIndex: undefined,
-    togglePanel: (
-      panelName: Exclude<keyof UISlice, "togglePanel"> | BOTTOM_PANEL_NAMES,
-    ) =>
+    togglePanel: (panelName: "sidePanel" | BOTTOM_PANEL_NAMES) =>
       set((state) => {
         if (!isBottomPanelName(panelName)) {
-          state[panelName] === "open" ? "closed" : "open";
+          state[panelName] = state[panelName] === "open" ? "closed" : "open";
+          console.log("state[panelName]", state[panelName]);
           return;
         }
 

--- a/studio/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/studio/src/pages/RequestorPage/useRequestorHistory.ts
@@ -13,8 +13,6 @@ import { sortRequestornatorsDescending, traceToRequestornator } from "./utils";
 const EMPTY_TRACES: TraceListResponse = [];
 export function useRequestorHistory() {
   const {
-    // sessionHistory: sessionHistoryTraceIds,
-    // recordRequestInSessionHistory,
     routes,
     setActiveRoute: handleSelectRoute,
     updatePath: setPath,
@@ -24,8 +22,6 @@ export function useRequestorHistory() {
     setBody,
     showResponseBodyFromHistory,
   } = useRequestorStore(
-    // "sessionHistory",
-    // "recordRequestInSessionHistory",
     "routes",
     "setActiveRoute",
     "updatePath",
@@ -190,27 +186,9 @@ export function useRequestorHistory() {
     }
   });
 
-  // Keep a local history of requests that the user has made in the UI
-  // This should be a subset of the full history
-  // These will be cleared on page reload
-  // const sessionHistory = useMemo(() => {
-  //   return sessionHistoryTraceIds.reduce(
-  //     (matchedRequestornators, traceId) => {
-  //       const match = history.find((r) => r.app_responses?.traceId === traceId);
-  //       if (match) {
-  //         matchedRequestornators.push(match);
-  //       }
-  //       return matchedRequestornators;
-  //     },
-  //     [] as Array<Requestornator>,
-  //   );
-  // }, [history, sessionHistoryTraceIds]);
-
   return {
     history,
-    // sessionHistory,
     isLoading,
-    // recordRequestInSessionHistory,
     loadHistoricalRequest,
   };
 }

--- a/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -11,12 +11,10 @@ import { isWsRequest } from "./types";
 export function useRequestorSubmitHandler({
   makeRequest,
   connectWebsocket,
-  recordRequestInSessionHistory,
   generateNavigation,
 }: {
   makeRequest: MakeProxiedRequestQueryFn;
   connectWebsocket: (wsUrl: string) => void;
-  recordRequestInSessionHistory: (traceId: string) => void;
   generateNavigation: (traceId: string) => To;
 }) {
   const { toast } = useToast();
@@ -31,6 +29,7 @@ export function useRequestorSubmitHandler({
     queryParams,
     requestHeaders,
     requestType,
+    recordRequestInSessionHistory,
   } = useRequestorStore(
     "activeRoute",
     "body",
@@ -40,6 +39,7 @@ export function useRequestorSubmitHandler({
     "queryParams",
     "requestHeaders",
     "requestType",
+    "recordRequestInSessionHistory",
   );
 
   const { addServiceUrlIfBarePath } = useServiceBaseUrl();
@@ -99,10 +99,10 @@ export function useRequestorSubmitHandler({
       {
         onSuccess(data) {
           const traceId = data?.traceId;
-
           if (traceId && typeof traceId === "string") {
-            navigate(generateNavigation(traceId), { replace: true });
             recordRequestInSessionHistory(traceId);
+            const to = generateNavigation(traceId);
+            navigate(to, { replace: true });
           } else {
             console.error(
               "RequestorPage: onSuccess: traceId is not a string",

--- a/studio/src/pages/RequestorPage/utils.ts
+++ b/studio/src/pages/RequestorPage/utils.ts
@@ -1,3 +1,15 @@
+import {
+  getRequestBody,
+  getRequestHeaders,
+  getRequestMethod,
+  getRequestPath,
+  getRequestQueryParams,
+  getRequestUrl,
+  getResponseBody,
+  getResponseHeaders,
+  getStatusCode,
+} from "@/utils";
+import type { TraceSummary } from "@fiberplane/fpx-types";
 import type { Requestornator } from "./queries";
 
 export function sortRequestornatorsDescending(
@@ -13,4 +25,44 @@ export function sortRequestornatorsDescending(
     return 1;
   }
   return 0;
+}
+
+export function traceToRequestornator(
+  trace: TraceSummary,
+): Requestornator | null {
+  const { spans, traceId } = trace;
+  const rootSpan = spans.find((s) => s.name === "request");
+  if (!rootSpan) {
+    // console.log("spans", spans);
+    // throw new Error("Could not find root span for trace");
+    return null;
+  }
+
+  const id = Math.random();
+  const status = getStatusCode(rootSpan);
+  const result = {
+    app_requests: {
+      id,
+      updatedAt: rootSpan.end_time.toISOString(),
+      requestUrl: getRequestUrl(rootSpan),
+      requestMethod: getRequestMethod(rootSpan),
+      requestRoute: getRequestPath(rootSpan),
+      requestHeaders: getRequestHeaders(rootSpan),
+      requestBody: getRequestBody(rootSpan),
+      requestPathParams: {},
+      getRequestQueryParams: getRequestQueryParams(rootSpan),
+    },
+    app_responses: {
+      id,
+      responseStatusCode: status ? status.toString() : "",
+      responseBody: getResponseBody(rootSpan) || "",
+      responseHeaders: getResponseHeaders(rootSpan),
+      traceId,
+      isFailure: false,
+      failureReason: null,
+      updatedAt: rootSpan.end_time.toISOString(),
+    },
+  };
+
+  return result;
 }

--- a/studio/src/pages/RequestorPage/utils.ts
+++ b/studio/src/pages/RequestorPage/utils.ts
@@ -33,8 +33,8 @@ export function traceToRequestornator(
   const { spans, traceId } = trace;
   const rootSpan = spans.find((s) => s.name === "request");
   if (!rootSpan) {
-    // console.log("spans", spans);
-    // throw new Error("Could not find root span for trace");
+    // This trace doesn't have a request span (yet)
+    // This can happen if the trace is still being processed
     return null;
   }
 

--- a/studio/src/queries/traces-otel.ts
+++ b/studio/src/queries/traces-otel.ts
@@ -1,8 +1,7 @@
 import {
   OtelSpanSchema,
-  type OtelTrace,
-  type TraceDetailSpansResponse,
   type TraceListResponse,
+  TraceListResponseSchema,
 } from "@fiberplane/fpx-types";
 import { type QueryFunctionContext, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
@@ -24,17 +23,19 @@ async function fetchOtelTrace(context: QueryFunctionContext<[string, string]>) {
   const response = await fetch(`/v1/traces/${traceId}/spans`, {
     mode: "cors",
   });
-  const json = (await response.json()) as TraceDetailSpansResponse;
+  const json = await response.json();
   return SpansSchema.parse(json);
 }
 
 export function useOtelTraces() {
-  return useQuery({
+  const result = useQuery({
     queryKey: [MIZU_TRACES_KEY],
-    queryFn: async (): Promise<OtelTrace[]> => {
+    queryFn: async (): Promise<TraceListResponse> => {
       const response = await fetch("/v1/traces");
-      const json = (await response.json()) as TraceListResponse;
-      return json;
+      const json = await response.json();
+      return TraceListResponseSchema.parse(json);
     },
   });
+
+  return result;
 }

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -12,6 +12,8 @@ draft: true
 
 - **Improved ai/timeline/logs panel** The panels are now combined into a single panel with tabs for each. This makes it easier to switch between them and reduces the amount of space they take up.
 
+- **Rendering outside requests** External requests are now rendered in the request panel, instead of the timeline panel.
+
 ### Bug fixes
 
 - **Initial size routes panel** Fixed an issue where routes panel would be rendered too big when the app was first loaded.
@@ -19,3 +21,9 @@ draft: true
 - **Panel resizing issue** If multiple panels were open, sometimes resizing would not work correctly.
 
 - **Logs panel toggle** Fixed an issue where the red dot when there are errors would not be displayed.
+
+- **Set response attributes** Fixed an issue where setting response attributes would not work correctly (for synchronous endpoints).
+
+- **Side panel not closing** Fixed an issue where the side panel would not close when clicking outside of it.
+
+- **Missing log information** Fixed an issue where logs would not be displayed fully in the logs panel.


### PR DESCRIPTION
Feature:

- **Rendering outside requests** External requests are now rendered in the request panel, instead of the timeline panel.

Fixes:

- **Set response attributes** Fixed an issue where setting response attributes would not work correctly (for synchronous endpoints).

- **Side panel not closing** Fixed an issue where the side panel would not close when clicking outside of it.

- **Missing log information** Fixed an issue where logs would not be displayed fully in the logs panel.

Demo:

https://github.com/user-attachments/assets/b83f5cd0-a727-4e77-88ed-93810c396294

