### PR TITLE
Allow form submissions from Headers inputs, Params inputs, JSON Body Input, and Text Body Input

### DIFF
--- a/studio/src/components/CodeMirrorEditor/CodeMirrorInput.tsx
+++ b/studio/src/components/CodeMirrorEditor/CodeMirrorInput.tsx
@@ -3,6 +3,7 @@ import "./CodeMirrorEditorCssOverrides.css";
 import { cn } from "@/utils";
 import CodeMirror, { EditorView, gutter, keymap } from "@uiw/react-codemirror";
 import { useMemo, useState } from "react";
+import { createOnSubmitKeymap, escapeKeymap } from "./keymaps";
 
 const inputTheme = EditorView.theme({
   "&": {
@@ -113,30 +114,6 @@ const preventNewlineInFirefox = keymap.of([
   },
 ]);
 
-// Extension that blurs the editor when the user presses "Escape"
-const escapeKeymap = keymap.of([
-  {
-    key: "Escape",
-    run: (view) => {
-      view.contentDOM.blur();
-      return true;
-    },
-  },
-]);
-
-const submitKeymap = (onSubmit: (() => void) | undefined) =>
-  keymap.of([
-    {
-      key: "Mod-Enter",
-      run: (_view) => {
-        if (onSubmit) {
-          onSubmit();
-        }
-        return true;
-      },
-    },
-  ]);
-
 export function CodeMirrorInput(props: CodeMirrorInputProps) {
   const { value, onChange, placeholder, className, readOnly, onSubmit } = props;
 
@@ -163,7 +140,7 @@ export function CodeMirrorInput(props: CodeMirrorInputProps) {
       EditorView.lineWrapping,
       readOnly ? readonlyExtension : noopExtension,
       isFocused ? noopExtension : inputTrucateExtension,
-      submitKeymap(onSubmit),
+      createOnSubmitKeymap(onSubmit),
     ];
   }, [isFocused, readOnly, onSubmit]);
 

--- a/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
+++ b/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
@@ -2,16 +2,12 @@ import "./CodeMirrorEditorCssOverrides.css";
 
 import { json } from "@codemirror/lang-json";
 import { duotoneDark } from "@uiw/codemirror-theme-duotone";
-
 import CodeMirror, {
   basicSetup,
   EditorView,
-  type KeyBinding,
   keymap,
 } from "@uiw/react-codemirror";
 import { useMemo } from "react";
-// import { defaultKeymap } from "@codemirror/commands";
-import { standardKeymap } from "./standard-keymap";
 import { customTheme } from "./themes";
 
 type CodeMirrorEditorProps = {

--- a/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
+++ b/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
@@ -8,6 +8,7 @@ import CodeMirror, {
   keymap,
 } from "@uiw/react-codemirror";
 import { useMemo } from "react";
+import { createOnSubmitKeymap, escapeKeymap } from "./keymaps";
 import { customTheme } from "./themes";
 
 type CodeMirrorEditorProps = {
@@ -20,31 +21,6 @@ type CodeMirrorEditorProps = {
   onChange: (value?: string) => void;
   onSubmit?: () => void;
 };
-
-// Extension that blurs the editor when the user presses "Escape"
-const escapeKeymap = keymap.of([
-  {
-    key: "Escape",
-    run: (view) => {
-      view.contentDOM.blur();
-      return true;
-    },
-  },
-]);
-
-const submitKeymap = (onSubmit: (() => void) | undefined) =>
-  keymap.of([
-    {
-      key: "Mod-Enter",
-      run: () => {
-        if (onSubmit) {
-          onSubmit();
-          return true;
-        }
-        return false;
-      },
-    },
-  ]);
 
 export function CodeMirrorJsonEditor(props: CodeMirrorEditorProps) {
   const {
@@ -59,7 +35,7 @@ export function CodeMirrorJsonEditor(props: CodeMirrorEditorProps) {
 
   const extensions = useMemo(
     () => [
-      submitKeymap(onSubmit),
+      createOnSubmitKeymap(onSubmit, false),
       basicSetup({
         // Turn off searching the input via cmd+g and cmd+f
         searchKeymap: false,

--- a/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
+++ b/studio/src/components/CodeMirrorEditor/CodeMirrorJsonEditor.tsx
@@ -2,11 +2,7 @@ import "./CodeMirrorEditorCssOverrides.css";
 
 import { json } from "@codemirror/lang-json";
 import { duotoneDark } from "@uiw/codemirror-theme-duotone";
-import CodeMirror, {
-  basicSetup,
-  EditorView,
-  keymap,
-} from "@uiw/react-codemirror";
+import CodeMirror, { basicSetup, EditorView } from "@uiw/react-codemirror";
 import { useMemo } from "react";
 import { createOnSubmitKeymap, escapeKeymap } from "./keymaps";
 import { customTheme } from "./themes";

--- a/studio/src/components/CodeMirrorEditor/keymaps.ts
+++ b/studio/src/components/CodeMirrorEditor/keymaps.ts
@@ -1,0 +1,36 @@
+import { keymap } from "@uiw/react-codemirror";
+
+// Extension that blurs the editor when the user presses "Escape"
+export const escapeKeymap = keymap.of([
+  {
+    key: "Escape",
+    run: (view) => {
+      view.contentDOM.blur();
+      return true;
+    },
+  },
+]);
+
+/**
+ * Creates a keymap that calls the given (optional) onSubmit function when the user presses "Mod-Enter"
+ *
+ * @param onSubmit - Function to call when the user presses "Mod-Enter"
+ * @param bubbleWhenNoHandler - If there is no onSubmit function, let another extension handle the key event
+ * @returns - Keymap that calls the onSubmit function when the user presses "Mod-Enter"
+ */
+export const createOnSubmitKeymap = (
+  onSubmit: (() => void) | undefined,
+  bubbleWhenNoHandler = true,
+) =>
+  keymap.of([
+    {
+      key: "Mod-Enter",
+      run: () => {
+        if (onSubmit) {
+          onSubmit();
+          return true;
+        }
+        return bubbleWhenNoHandler;
+      },
+    },
+  ]);

--- a/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
+++ b/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
@@ -1,3 +1,4 @@
+import { CodeMirrorInput } from "@/components/CodeMirrorEditor";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -18,6 +19,7 @@ import type {
 type Props = {
   keyValueParameters: FormDataParameter[];
   onChange: ChangeFormDataParametersHandler;
+  onSubmit?: () => void;
 };
 
 type FormDataRowProps = {
@@ -27,6 +29,7 @@ type FormDataRowProps = {
   onChangeKey?: (key: string) => void;
   onChangeValue: (value: FormDataParameter["value"]) => void;
   removeValue?: () => void;
+  onSubmit?: () => void;
 };
 
 const FormDataFormRow = (props: FormDataRowProps) => {
@@ -37,6 +40,7 @@ const FormDataFormRow = (props: FormDataRowProps) => {
     onChangeValue,
     removeValue,
     parameter,
+    onSubmit,
   } = props;
   const { enabled, key, value } = parameter;
   const [isHovering, setIsHovering] = useState(false);
@@ -67,23 +71,23 @@ const FormDataFormRow = (props: FormDataRowProps) => {
           return handler();
         }}
       />
-      <Input
-        type="text"
+      <CodeMirrorInput
+        className="w-[140px]"
         value={key}
-        placeholder="name"
+        placeholder="form_key"
         readOnly={!onChangeKey}
-        onChange={(e) => onChangeKey?.(e.target.value)}
-        className="w-28 h-8 bg-transparent shadow-none px-2 py-0 text-sm border-none"
+        onChange={(value) => onChangeKey?.(value ?? "")}
+        onSubmit={onSubmit}
       />
       {value.type === "text" && (
-        <Input
-          type="text"
+        <CodeMirrorInput
+          className="w-[calc(100%-140px)]"
           value={value.value}
           placeholder="value"
-          onChange={(e) =>
-            onChangeValue({ value: e.target.value, type: "text" })
+          onChange={(value) =>
+            onChangeValue({ value: value ?? "", type: "text" })
           }
-          className="h-8 flex-grow bg-transparent shadow-none px-2 py-0 text-sm border-none"
+          onSubmit={onSubmit}
         />
       )}
       {value.type === "file" && (
@@ -129,7 +133,7 @@ const FormDataFormRow = (props: FormDataRowProps) => {
 };
 
 export const FormDataForm = (props: Props) => {
-  const { onChange, keyValueParameters } = props;
+  const { onChange, keyValueParameters, onSubmit } = props;
 
   return (
     <div className="flex flex-col gap-0">
@@ -160,6 +164,7 @@ export const FormDataForm = (props: Props) => {
                 keyValueParameters.filter(({ id }) => parameter.id !== id),
               );
             }}
+            onSubmit={onSubmit}
           />
         );
       })}

--- a/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
+++ b/studio/src/pages/RequestorPage/FormDataForm/FormDataForm.tsx
@@ -1,7 +1,6 @@
 import { CodeMirrorInput } from "@/components/CodeMirrorEditor";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import { cn, noop } from "@/utils";
 import { FileIcon, TrashIcon } from "@radix-ui/react-icons";
 import { useCallback, useRef, useState } from "react";

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -38,7 +38,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
     onChangeValue,
     removeValue,
     parameter,
-    onSubmit
+    onSubmit,
   } = props;
   const { enabled, key, value } = parameter;
   const [isHovering, setIsHovering] = useState(false);

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -17,6 +17,7 @@ import type {
 type Props = {
   keyValueParameters: KeyValueParameter[];
   onChange: ChangeKeyValueParametersHandler;
+  onSubmit?: () => void;
 };
 
 type KeyValueRowProps = {
@@ -26,6 +27,7 @@ type KeyValueRowProps = {
   onChangeKey?: (key: string) => void;
   onChangeValue: (value: string) => void;
   removeValue?: () => void;
+  onSubmit?: () => void;
 };
 
 export const KeyValueRow = (props: KeyValueRowProps) => {
@@ -36,6 +38,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
     onChangeValue,
     removeValue,
     parameter,
+    onSubmit
   } = props;
   const { enabled, key, value } = parameter;
   const [isHovering, setIsHovering] = useState(false);
@@ -60,12 +63,14 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
         placeholder="name"
         readOnly={!onChangeKey}
         onChange={(value) => onChangeKey?.(value ?? "")}
+        onSubmit={onSubmit}
       />
       <CodeMirrorInput
         className="w-[calc(100%-140px)]"
         value={value}
         placeholder="value"
         onChange={(value) => onChangeValue(value ?? "")}
+        onSubmit={onSubmit}
       />
       <div
         className={cn("ml-1 flex invisible", {
@@ -84,7 +89,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
 };
 
 export const KeyValueForm = (props: Props) => {
-  const { onChange, keyValueParameters } = props;
+  const { onChange, keyValueParameters, onSubmit } = props;
 
   return (
     <div className="flex flex-col gap-0">
@@ -115,6 +120,7 @@ export const KeyValueForm = (props: Props) => {
                 keyValueParameters.filter(({ id }) => parameter.id !== id),
               );
             }}
+            onSubmit={onSubmit}
           />
         );
       })}

--- a/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
+++ b/studio/src/pages/RequestorPage/KeyValueForm/KeyValueForm.tsx
@@ -18,6 +18,7 @@ type Props = {
   keyValueParameters: KeyValueParameter[];
   onChange: ChangeKeyValueParametersHandler;
   onSubmit?: () => void;
+  keyPlaceholder?: string;
 };
 
 type KeyValueRowProps = {
@@ -28,6 +29,7 @@ type KeyValueRowProps = {
   onChangeValue: (value: string) => void;
   removeValue?: () => void;
   onSubmit?: () => void;
+  keyPlaceholder?: string;
 };
 
 export const KeyValueRow = (props: KeyValueRowProps) => {
@@ -39,6 +41,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
     removeValue,
     parameter,
     onSubmit,
+    keyPlaceholder = "name",
   } = props;
   const { enabled, key, value } = parameter;
   const [isHovering, setIsHovering] = useState(false);
@@ -60,7 +63,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
       <CodeMirrorInput
         className="w-[140px]"
         value={key}
-        placeholder="name"
+        placeholder={keyPlaceholder}
         readOnly={!onChangeKey}
         onChange={(value) => onChangeKey?.(value ?? "")}
         onSubmit={onSubmit}
@@ -89,7 +92,7 @@ export const KeyValueRow = (props: KeyValueRowProps) => {
 };
 
 export const KeyValueForm = (props: Props) => {
-  const { onChange, keyValueParameters, onSubmit } = props;
+  const { onChange, keyValueParameters, onSubmit, keyPlaceholder } = props;
 
   return (
     <div className="flex flex-col gap-0">
@@ -121,6 +124,7 @@ export const KeyValueForm = (props: Props) => {
               );
             }}
             onSubmit={onSubmit}
+            keyPlaceholder={keyPlaceholder}
           />
         );
       })}

--- a/studio/src/pages/RequestorPage/RequestPanel/PathParamForm/PathParamForm.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/PathParamForm/PathParamForm.tsx
@@ -10,6 +10,7 @@ type Props = {
   keyValueParameters: KeyValueParameter[];
   onChange: ChangeKeyValueParametersHandler;
   onSubmit?: () => void;
+  keyPlaceholder?: string;
 };
 
 /**
@@ -19,7 +20,7 @@ type Props = {
  * Remember: Path params are *computed* from the route pattern.
  */
 export const PathParamForm = (props: Props) => {
-  const { onChange, keyValueParameters, onSubmit } = props;
+  const { onChange, keyValueParameters, onSubmit, keyPlaceholder } = props;
 
   return (
     <div className="space-y-2">
@@ -41,6 +42,7 @@ export const PathParamForm = (props: Props) => {
               parameter,
             )}
             onSubmit={onSubmit}
+            keyPlaceholder={keyPlaceholder}
           />
         );
       })}

--- a/studio/src/pages/RequestorPage/RequestPanel/PathParamForm/PathParamForm.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/PathParamForm/PathParamForm.tsx
@@ -9,6 +9,7 @@ import { createChangePathParamValue } from "./data";
 type Props = {
   keyValueParameters: KeyValueParameter[];
   onChange: ChangeKeyValueParametersHandler;
+  onSubmit?: () => void;
 };
 
 /**
@@ -18,7 +19,7 @@ type Props = {
  * Remember: Path params are *computed* from the route pattern.
  */
 export const PathParamForm = (props: Props) => {
-  const { onChange, keyValueParameters } = props;
+  const { onChange, keyValueParameters, onSubmit } = props;
 
   return (
     <div className="space-y-2">
@@ -39,6 +40,7 @@ export const PathParamForm = (props: Props) => {
               keyValueParameters,
               parameter,
             )}
+            onSubmit={onSubmit}
           />
         );
       })}

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -171,6 +171,7 @@ export const RequestPanel = memo(function RequestPanel(
           }}
         />
         <KeyValueForm
+          keyPlaceholder="param_name"
           keyValueParameters={queryParams}
           onChange={(params) => {
             setQueryParams(params);
@@ -185,6 +186,7 @@ export const RequestPanel = memo(function RequestPanel(
               className="mt-4"
             />
             <PathParamForm
+              keyPlaceholder="param_name"
               keyValueParameters={pathParams}
               onChange={(params) => {
                 setPathParams(params);
@@ -207,6 +209,7 @@ export const RequestPanel = memo(function RequestPanel(
           }}
         />
         <KeyValueForm
+          keyPlaceholder="header-name"
           keyValueParameters={requestHeaders}
           onChange={(headers) => {
             setRequestHeaders(headers);
@@ -252,6 +255,7 @@ export const RequestPanel = memo(function RequestPanel(
                   value: params,
                 });
               }}
+              onSubmit={onSubmit}
             />
           )}
           {body.type === "file" && (

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -94,6 +94,10 @@ export const RequestPanel = memo(function RequestPanel(
   const shouldShowBody = shouldShowRequestTab("body");
   const shouldShowMessages = shouldShowRequestTab("messages");
 
+  const onSubmitTest = () => {
+    console.log("submit");
+  };
+
   return (
     <Tabs
       value={activeRequestsPanelTab}
@@ -173,6 +177,7 @@ export const RequestPanel = memo(function RequestPanel(
           onChange={(params) => {
             setQueryParams(params);
           }}
+          onSubmit={onSubmitTest}
         />
         {pathParams.length > 0 ? (
           <>
@@ -186,6 +191,7 @@ export const RequestPanel = memo(function RequestPanel(
               onChange={(params) => {
                 setPathParams(params);
               }}
+              onSubmit={onSubmitTest}
             />
           </>
         ) : null}
@@ -207,6 +213,7 @@ export const RequestPanel = memo(function RequestPanel(
           onChange={(headers) => {
             setRequestHeaders(headers);
           }}
+          onSubmit={onSubmitTest}
         />
       </CustomTabsContent>
       {shouldShowBody && (

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -239,6 +239,7 @@ export const RequestPanel = memo(function RequestPanel(
               onChange={setBody}
               value={body.value}
               maxHeight="800px"
+              onSubmit={onSubmit}
             />
           )}
           {body.type === "form-data" && (

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -30,6 +30,7 @@ type RequestPanelProps = {
   setIgnoreAiInputsBanner: Dispatch<SetStateAction<boolean>>;
   websocketState: WebSocketState;
   sendWebsocketMessage: (message: string) => void;
+  onSubmit: () => void;
 };
 
 export const RequestPanel = memo(function RequestPanel(
@@ -46,6 +47,7 @@ export const RequestPanel = memo(function RequestPanel(
     setIgnoreAiInputsBanner,
     websocketState,
     sendWebsocketMessage,
+    onSubmit,
   } = props;
 
   const {
@@ -93,10 +95,6 @@ export const RequestPanel = memo(function RequestPanel(
 
   const shouldShowBody = shouldShowRequestTab("body");
   const shouldShowMessages = shouldShowRequestTab("messages");
-
-  const onSubmitTest = () => {
-    console.log("submit");
-  };
 
   return (
     <Tabs
@@ -177,7 +175,7 @@ export const RequestPanel = memo(function RequestPanel(
           onChange={(params) => {
             setQueryParams(params);
           }}
-          onSubmit={onSubmitTest}
+          onSubmit={onSubmit}
         />
         {pathParams.length > 0 ? (
           <>
@@ -191,7 +189,7 @@ export const RequestPanel = memo(function RequestPanel(
               onChange={(params) => {
                 setPathParams(params);
               }}
-              onSubmit={onSubmitTest}
+              onSubmit={onSubmit}
             />
           </>
         ) : null}
@@ -213,7 +211,7 @@ export const RequestPanel = memo(function RequestPanel(
           onChange={(headers) => {
             setRequestHeaders(headers);
           }}
-          onSubmit={onSubmitTest}
+          onSubmit={onSubmit}
         />
       </CustomTabsContent>
       {shouldShowBody && (

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -182,6 +182,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
       setIgnoreAiInputsBanner={setIgnoreAiInputsBanner}
       websocketState={websocketState}
       sendWebsocketMessage={sendWebsocketMessage}
+      onSubmit={onSubmit}
     />
   );
 

--- a/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
+++ b/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
@@ -13,6 +13,7 @@ import {
   removeBaseUrl,
 } from "../utils";
 import type { RequestResponseSlice, Store } from "./types";
+import { getVisibleRequestPanelTabs } from "../tabs";
 
 export const requestResponseSlice: StateCreator<
   Store,
@@ -73,6 +74,20 @@ export const requestResponseSlice: StateCreator<
       // Update other state properties based on the new method and request type
       // (e.g., activeRoute, visibleRequestsPanelTabs, activeRequestsPanelTab, etc.)
       // You might want to move some of this logic to separate functions or slices
+      
+
+      // Update visibleRequestsPanelTabs based on the new method and request type
+      state.visibleRequestsPanelTabs = getVisibleRequestPanelTabs({
+        requestType,
+        method,
+      });
+
+      // Ensure the activeRequestsPanelTab is valid
+      state.activeRequestsPanelTab = state.visibleRequestsPanelTabs.includes(
+        state.activeRequestsPanelTab
+      )
+        ? state.activeRequestsPanelTab
+        : state.visibleRequestsPanelTabs[0];
     }),
 
   setPathParams: (pathParams) =>

--- a/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
+++ b/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
@@ -5,6 +5,7 @@ import { enforceTerminalDraftParameter } from "../../KeyValueForm";
 import { findMatchedRoute } from "../../routes";
 import { updateContentTypeHeaderInState } from "../content-type";
 import { setBodyTypeInState } from "../set-body-type";
+import { getVisibleRequestPanelTabs } from "../tabs";
 import {
   addBaseUrl,
   extractMatchedPathParams,
@@ -13,7 +14,6 @@ import {
   removeBaseUrl,
 } from "../utils";
 import type { RequestResponseSlice, Store } from "./types";
-import { getVisibleRequestPanelTabs } from "../tabs";
 
 export const requestResponseSlice: StateCreator<
   Store,
@@ -74,7 +74,6 @@ export const requestResponseSlice: StateCreator<
       // Update other state properties based on the new method and request type
       // (e.g., activeRoute, visibleRequestsPanelTabs, activeRequestsPanelTab, etc.)
       // You might want to move some of this logic to separate functions or slices
-      
 
       // Update visibleRequestsPanelTabs based on the new method and request type
       state.visibleRequestsPanelTabs = getVisibleRequestPanelTabs({
@@ -84,7 +83,7 @@ export const requestResponseSlice: StateCreator<
 
       // Ensure the activeRequestsPanelTab is valid
       state.activeRequestsPanelTab = state.visibleRequestsPanelTabs.includes(
-        state.activeRequestsPanelTab
+        state.activeRequestsPanelTab,
       )
         ? state.activeRequestsPanelTab
         : state.visibleRequestsPanelTabs[0];

--- a/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
+++ b/studio/src/pages/RequestorPage/useRequestorSubmitHandler.ts
@@ -44,8 +44,9 @@ export function useRequestorSubmitHandler({
 
   const { addServiceUrlIfBarePath } = useServiceBaseUrl();
   const { activeHistoryResponseTraceId } = useRequestorStore();
-  return useHandler((e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  // NOTE - We make the submit handler optional to make it easier to call this as a standalone function
+  return useHandler((e?: React.FormEvent<HTMLFormElement>) => {
+    e?.preventDefault?.();
     // TODO - Make it clear in the UI that we're auto-adding this header
     const canHaveBody =
       !isWsRequest(requestType) && !["GET", "DELETE"].includes(method);


### PR DESCRIPTION
## Overview

Currently, in the UI, when you have focus inside the following inputs, you cannot submit the request with CMD+ENTER:

- Query Params
- Path Params
- Headers
- Body

Now, CMD+Enter should work for all of those.


https://github.com/user-attachments/assets/3c951b88-04cd-46ff-9833-c65be2332f98



***

## Other Improvements

- Fixed a bug where changing the Method input would not update the tabs in the request panel
- Added placeholder to the Query/Header inputs that indicate whether they are for headers or query params, etc
- Implemented the new fancy inputs for the FormData forms