### PR TITLE
Rename Requestornator to ProxiedRequestResponse

### DIFF
--- a/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
+++ b/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
@@ -7,7 +7,7 @@ import { Icon } from "@iconify/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { Link, type To, useNavigate, useSearchParams } from "react-router-dom";
-import type { Requestornator } from "../../queries";
+import type { ProxiedRequestResponse } from "../../queries";
 import { useServiceBaseUrl } from "../../store";
 import { useRequestorHistory } from "../../useRequestorHistory";
 import { Search } from "../Search";
@@ -37,7 +37,7 @@ export function RequestsPanel() {
   const searchRef = useRef<HTMLInputElement>(null);
 
   const handleItemSelect = useCallback(
-    (item: Requestornator) => {
+    (item: ProxiedRequestResponse) => {
       navigate({
         pathname: `/request/${getId(item)}`,
         search: searchParams.toString(),
@@ -222,7 +222,7 @@ function EmptyState() {
 }
 
 type NavItemProps = {
-  item: Requestornator;
+  item: ProxiedRequestResponse;
   isSelected: boolean;
   to: To;
   searchParams: URLSearchParams;
@@ -274,11 +274,11 @@ const NavItem = memo(({ to, item, isSelected }: NavItemProps) => {
   );
 });
 
-const getId = (item: Requestornator) => {
+const getId = (item: ProxiedRequestResponse) => {
   return item.app_responses.traceId || item.app_requests.id.toString();
 };
 
-const PathCell = ({ item }: { item: Requestornator }) => {
+const PathCell = ({ item }: { item: ProxiedRequestResponse }) => {
   const { removeServiceUrlFromPath } = useServiceBaseUrl();
   const path = removeServiceUrlFromPath(item.app_requests.requestUrl);
 
@@ -289,13 +289,13 @@ const PathCell = ({ item }: { item: Requestornator }) => {
   );
 };
 
-const StatusCell = ({ item }: { item: Requestornator }) => {
+const StatusCell = ({ item }: { item: ProxiedRequestResponse }) => {
   const code = Number.parseInt(item.app_responses.responseStatusCode);
 
   return <Status statusCode={code} />;
 };
 
-const MethodCell = ({ item }: { item: Requestornator }) => {
+const MethodCell = ({ item }: { item: ProxiedRequestResponse }) => {
   const method = item.app_requests.requestMethod;
   return <RequestMethod method={method} className="text-xs font-mono" />;
 };

--- a/studio/src/pages/RequestorPage/RequestorHistory.tsx
+++ b/studio/src/pages/RequestorPage/RequestorHistory.tsx
@@ -4,11 +4,11 @@ import {
   parsePathFromRequestUrl,
   truncatePathWithEllipsis,
 } from "@/utils";
-import type { Requestornator } from "./queries";
+import type { ProxiedRequestResponse } from "./queries";
 import { useServiceBaseUrl } from "./store";
 
 type RequestorHistoryProps = {
-  history: Array<Requestornator>;
+  history: Array<ProxiedRequestResponse>;
   loadHistoricalRequest: (traceId: string) => void;
 };
 
@@ -45,7 +45,7 @@ export function RequestorHistory({
 
 type HistoryEntryProps = {
   traceId: string;
-  response: Requestornator;
+  response: ProxiedRequestResponse;
   loadHistoricalRequest?: (traceId: string) => void;
   removeServiceUrlFromPath: (path: string) => string;
 };

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -45,9 +45,7 @@ export const RequestorPage = () => {
 
   const {
     history,
-    // sessionHistory,
     isLoading,
-    // recordRequestInSessionHistory,
     loadHistoricalRequest,
   } = useRequestorHistory();
 

--- a/studio/src/pages/RequestorPage/RequestorPage.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPage.tsx
@@ -43,11 +43,7 @@ export const RequestorPage = () => {
   //   );
   // }, [setQueryParams]);
 
-  const {
-    history,
-    isLoading,
-    loadHistoricalRequest,
-  } = useRequestorHistory();
+  const { history, isLoading, loadHistoricalRequest } = useRequestorHistory();
 
   const hasHistory = history.length > 0;
   useEffect(() => {

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -34,24 +34,19 @@ interface RequestorPageContentProps {
 export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
   props,
 ) => {
-  const {
-    history,
-    overrideTraceId,
-    historyLoading,
-    generateNavigation,
-  } = props;
+  const { history, overrideTraceId, historyLoading, generateNavigation } =
+    props;
 
   const { toast } = useToast();
 
-  const mostRecentProxiedRequestResponseForRoute = useMostRecentProxiedRequestResponse(
-    history,
-    overrideTraceId,
-  );
+  const mostRecentProxiedRequestResponseForRoute =
+    useMostRecentProxiedRequestResponse(history, overrideTraceId);
 
   // This is the preferred traceId to show in the UI
   // It is either the traceId from the url or a recent traceId from the session history
   const traceId =
-    overrideTraceId ?? mostRecentProxiedRequestResponseForRoute?.app_responses?.traceId;
+    overrideTraceId ??
+    mostRecentProxiedRequestResponseForRoute?.app_responses?.traceId;
 
   const { setActiveHistoryResponseTraceId, activeHistoryResponseTraceId } =
     useRequestorStore(

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -21,14 +21,12 @@ import { BACKGROUND_LAYER } from "../styles";
 import { useMakeWebsocketRequest } from "../useMakeWebsocketRequest";
 import { useRequestorSubmitHandler } from "../useRequestorSubmitHandler";
 import RequestorPageContentBottomPanel from "./RequestorPageContentBottomPanel";
-import { useMostRecentRequestornator } from "./useMostRecentRequestornator";
+import { useMostRecentProxiedRequestResponse } from "./useMostRecentProxiedRequestResponse";
 import { getMainSectionWidth } from "./util";
 
 interface RequestorPageContentProps {
-  history: ProxiedRequestResponse[]; // Replace 'any[]' with the correct type
+  history: ProxiedRequestResponse[];
   historyLoading: boolean;
-  // sessionHistory: Requestornator[];
-  // recordRequestInSessionHistory: (traceId: string) => void;
   overrideTraceId?: string;
   generateNavigation: (traceId: string) => To;
 }
@@ -39,14 +37,13 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
   const {
     history,
     overrideTraceId,
-    // sessionHistory,
     historyLoading,
     generateNavigation,
   } = props;
 
   const { toast } = useToast();
 
-  const mostRecentRequestornatorForRoute = useMostRecentRequestornator(
+  const mostRecentProxiedRequestResponseForRoute = useMostRecentProxiedRequestResponse(
     history,
     overrideTraceId,
   );
@@ -54,7 +51,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
   // This is the preferred traceId to show in the UI
   // It is either the traceId from the url or a recent traceId from the session history
   const traceId =
-    overrideTraceId ?? mostRecentRequestornatorForRoute?.app_responses?.traceId;
+    overrideTraceId ?? mostRecentProxiedRequestResponseForRoute?.app_responses?.traceId;
 
   const { setActiveHistoryResponseTraceId, activeHistoryResponseTraceId } =
     useRequestorStore(
@@ -188,7 +185,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
 
   const responseContent = (
     <ResponsePanel
-      tracedResponse={mostRecentRequestornatorForRoute}
+      tracedResponse={mostRecentProxiedRequestResponseForRoute}
       isLoading={isRequestorRequesting || historyLoading}
       websocketState={websocketState}
     />

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -15,7 +15,7 @@ import { RequestPanel } from "../RequestPanel";
 import { RequestorInput } from "../RequestorInput";
 import { ResponsePanel } from "../ResponsePanel";
 import { useAi } from "../ai";
-import { type Requestornator, useMakeProxiedRequest } from "../queries";
+import { type ProxiedRequestResponse, useMakeProxiedRequest } from "../queries";
 import { useRequestorStore, useRequestorStoreRaw } from "../store";
 import { BACKGROUND_LAYER } from "../styles";
 import { useMakeWebsocketRequest } from "../useMakeWebsocketRequest";
@@ -25,7 +25,7 @@ import { useMostRecentRequestornator } from "./useMostRecentRequestornator";
 import { getMainSectionWidth } from "./util";
 
 interface RequestorPageContentProps {
-  history: Requestornator[]; // Replace 'any[]' with the correct type
+  history: ProxiedRequestResponse[]; // Replace 'any[]' with the correct type
   historyLoading: boolean;
   // sessionHistory: Requestornator[];
   // recordRequestInSessionHistory: (traceId: string) => void;

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContentBottomPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContentBottomPanel.tsx
@@ -7,13 +7,13 @@ import { LogsLabel } from "../LogsTable";
 import { RequestorTimeline } from "../RequestorTimeline";
 import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
 import { AiTestGenerationPanel } from "../ai";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import { useRequestorStore } from "../store";
 import type { BOTTOM_PANEL_NAMES } from "../store/slices/types";
 
 interface RequestorPageContentBottomPanelProps {
   traceId?: string;
-  history: Requestornator[];
+  history: ProxiedRequestResponse[];
 }
 
 const RequestorPageContentBottomPanel: React.FC<

--- a/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentProxiedRequestResponse.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentProxiedRequestResponse.tsx
@@ -2,13 +2,13 @@
 import { useMemo } from "react";
 import type { ProxiedRequestResponse } from "../queries";
 import { useActiveRoute, useRequestorStore } from "../store";
-import { sortRequestornatorsDescending } from "../utils";
+import { sortProxiedRequestResponsesDescending } from "../utils";
 
 /**
  * When you select a route from the route side panel,
  * this will look for the most recent request made against that route.
  */
-export function useMostRecentRequestornator(
+export function useMostRecentProxiedRequestResponse(
   all: ProxiedRequestResponse[],
   overrideTraceId: string | null = null,
 ) {
@@ -40,7 +40,7 @@ export function useMostRecentRequestornator(
     );
 
     // Descending sort by updatedAt
-    matchingResponses?.sort(sortRequestornatorsDescending);
+    matchingResponses?.sort(sortProxiedRequestResponsesDescending);
 
     const latestMatch = matchingResponses?.[0];
 
@@ -59,7 +59,7 @@ export function useMostRecentRequestornator(
         sessionHistory.includes(r.app_responses?.traceId),
     );
 
-    matchingResponsesFallback?.sort(sortRequestornatorsDescending);
+    matchingResponsesFallback?.sort(sortProxiedRequestResponsesDescending);
 
     return matchingResponsesFallback?.[0];
   }, [all, routePath, method, path, traceId, sessionHistory]);

--- a/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentRequestornator.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentRequestornator.tsx
@@ -1,6 +1,6 @@
 // import { useOtelTraces } from "@/queries";
 import { useMemo } from "react";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import { useActiveRoute, useRequestorStore } from "../store";
 import { sortRequestornatorsDescending } from "../utils";
 
@@ -9,7 +9,7 @@ import { sortRequestornatorsDescending } from "../utils";
  * this will look for the most recent request made against that route.
  */
 export function useMostRecentRequestornator(
-  all: Requestornator[],
+  all: ProxiedRequestResponse[],
   overrideTraceId: string | null = null,
 ) {
   const { path: routePath } = useActiveRoute();
@@ -22,17 +22,17 @@ export function useMostRecentRequestornator(
     );
 
   const traceId = overrideTraceId ?? activeHistoryResponseTraceId;
-  return useMemo<Requestornator | undefined>(() => {
+  return useMemo<ProxiedRequestResponse | undefined>(() => {
     if (traceId) {
       const result = all.find(
-        (r: Requestornator) => r?.app_responses?.traceId === traceId,
+        (r: ProxiedRequestResponse) => r?.app_responses?.traceId === traceId,
       );
 
       return result;
     }
 
     const matchingResponses = all?.filter(
-      (r: Requestornator) =>
+      (r: ProxiedRequestResponse) =>
         r.app_requests?.requestRoute === routePath &&
         r.app_requests?.requestMethod === method &&
         r.app_responses.traceId &&
@@ -52,7 +52,7 @@ export function useMostRecentRequestornator(
     //        This is a fallback to support the case where the route doesn't exist,
     //        perhaps because we made a request to a service we are not explicitly monitoring
     const matchingResponsesFallback = all?.filter(
-      (r: Requestornator) =>
+      (r: ProxiedRequestResponse) =>
         r?.app_requests?.requestUrl === path &&
         r?.app_requests?.requestMethod === method &&
         r.app_responses.traceId &&

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody.tsx
@@ -15,7 +15,7 @@ import {
   QuestionMarkIcon,
 } from "@radix-ui/react-icons";
 import { useMemo, useState } from "react";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
@@ -25,7 +25,7 @@ export function ResponseBody({
   response,
   className,
 }: {
-  response?: Requestornator | RequestorActiveResponse;
+  response?: ProxiedRequestResponse | RequestorActiveResponse;
   className?: string;
 }) {
   const isFailure = isRequestorActiveResponse(response)
@@ -277,7 +277,7 @@ function useTextPreview(
 
 export function FailedRequest({
   response,
-}: { response?: Requestornator | RequestorActiveResponse }) {
+}: { response?: ProxiedRequestResponse | RequestorActiveResponse }) {
   // TODO - Show a more friendly error message
   const failureReason = isRequestorActiveResponse(response)
     ? null

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponsePanel.tsx
@@ -6,7 +6,7 @@ import { Icon } from "@iconify/react";
 import { memo } from "react";
 import { Method, StatusCode } from "../RequestorHistory";
 import { CustomTabTrigger, CustomTabsContent, CustomTabsList } from "../Tabs";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import type { ResponsePanelTab } from "../store";
 import { useActiveRoute, useRequestorStore, useServiceBaseUrl } from "../store";
 import {
@@ -23,7 +23,7 @@ import {
 } from "./Websocket";
 
 type Props = {
-  tracedResponse?: Requestornator;
+  tracedResponse?: ProxiedRequestResponse;
   isLoading: boolean;
   websocketState: WebSocketState;
 };
@@ -189,7 +189,7 @@ function ResponseSummary({
   response,
   transformUrl = (url: string) => url,
 }: {
-  response?: Requestornator | RequestorActiveResponse;
+  response?: ProxiedRequestResponse | RequestorActiveResponse;
   transformUrl?: (url: string) => string;
 }) {
   const status = isRequestorActiveResponse(response)

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
@@ -15,13 +15,13 @@ import { cn, parsePathFromRequestUrl, truncatePathWithEllipsis } from "@/utils";
 import { CopyIcon } from "@radix-ui/react-icons";
 import { useState } from "react";
 import { Method, StatusCode } from "../RequestorHistory";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import { usePrompt } from "./ai-test-generation";
 
 export function AiTestGenerationDrawer({
   history,
 }: {
-  history: null | Array<Requestornator>;
+  history: null | Array<ProxiedRequestResponse>;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
   const lastRequest = history?.[0] ?? null;
@@ -85,7 +85,7 @@ export function AiTestGenerationDrawer({
   );
 }
 
-export function ContextEntry({ response }: { response: Requestornator }) {
+export function ContextEntry({ response }: { response: ProxiedRequestResponse }) {
   const isFailure = response?.app_responses?.isFailure;
   const requestMethod = response.app_requests?.requestMethod;
   const responseStatusCode = response.app_responses?.responseStatusCode;

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationDrawer.tsx
@@ -85,7 +85,9 @@ export function AiTestGenerationDrawer({
   );
 }
 
-export function ContextEntry({ response }: { response: ProxiedRequestResponse }) {
+export function ContextEntry({
+  response,
+}: { response: ProxiedRequestResponse }) {
   const isFailure = response?.app_responses?.isFailure;
   const requestMethod = response.app_requests?.requestMethod;
   const responseStatusCode = response.app_responses?.responseStatusCode;

--- a/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
+++ b/studio/src/pages/RequestorPage/ai/AiTestGenerationPanel.tsx
@@ -4,7 +4,7 @@ import { useCopyToClipboard } from "@/hooks";
 import { parsePathFromRequestUrl } from "@/utils";
 import { CopyIcon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import { useMemo, useState } from "react";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import { findMatchedRoute } from "../routes";
 import { useActiveRoute, useServiceBaseUrl } from "../store";
 import { ContextEntry } from "./AiTestGenerationDrawer";
@@ -13,13 +13,13 @@ import { usePrompt } from "./ai-test-generation";
 export function AiTestGenerationPanel({
   history,
 }: {
-  history: Array<Requestornator>;
+  history: Array<ProxiedRequestResponse>;
 }) {
   const { isCopied, copyToClipboard } = useCopyToClipboard();
 
   const activeRoute = useActiveRoute();
   const { removeServiceUrlFromPath } = useServiceBaseUrl();
-  const lastMatchingRequest = useMemo<Requestornator | null>(() => {
+  const lastMatchingRequest = useMemo<ProxiedRequestResponse | null>(() => {
     const match = history.find((response) => {
       const path = parsePathFromRequestUrl(response.app_requests?.requestUrl);
 

--- a/studio/src/pages/RequestorPage/ai/ai-test-generation.ts
+++ b/studio/src/pages/RequestorPage/ai/ai-test-generation.ts
@@ -11,10 +11,10 @@ import {
 import { formatHeaders, redactSensitiveHeaders } from "@/utils";
 import type { OtelSpan } from "@fiberplane/fpx-types";
 import { useMemo } from "react";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import { appRequestToHttpRequest, appResponseToHttpRequest } from "./utils";
 
-function createRequestDescription(request: Requestornator | null): string {
+function createRequestDescription(request: ProxiedRequestResponse | null): string {
   if (!request) {
     return "NO_MATCHING_REQUEST_FOUND";
   }
@@ -28,7 +28,7 @@ function createRequestDescription(request: Requestornator | null): string {
   ].join("\n");
 }
 
-function createResponseDescription(response: Requestornator | null) {
+function createResponseDescription(response: ProxiedRequestResponse | null) {
   if (!response) {
     return "NO_MATCHING_RESPONSE_FOUND";
   }
@@ -36,7 +36,7 @@ function createResponseDescription(response: Requestornator | null) {
 }
 
 export function usePrompt(
-  latestRequest: Requestornator | null,
+  latestRequest: ProxiedRequestResponse | null,
   userInput: string,
 ) {
   const traceId = latestRequest?.app_responses?.traceId ?? "";

--- a/studio/src/pages/RequestorPage/ai/ai-test-generation.ts
+++ b/studio/src/pages/RequestorPage/ai/ai-test-generation.ts
@@ -14,7 +14,9 @@ import { useMemo } from "react";
 import type { ProxiedRequestResponse } from "../queries";
 import { appRequestToHttpRequest, appResponseToHttpRequest } from "./utils";
 
-function createRequestDescription(request: ProxiedRequestResponse | null): string {
+function createRequestDescription(
+  request: ProxiedRequestResponse | null,
+): string {
   if (!request) {
     return "NO_MATCHING_REQUEST_FOUND";
   }

--- a/studio/src/pages/RequestorPage/ai/ai.ts
+++ b/studio/src/pages/RequestorPage/ai/ai.ts
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 import { createFormDataParameter } from "../FormDataForm/data";
 import { createKeyValueParameters } from "../KeyValueForm";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import type { RequestorBody } from "../store";
 import { useRequestorStore, useServiceBaseUrl } from "../store";
 import { isRequestorBodyType } from "../store/request-body";
@@ -17,7 +17,7 @@ export const HOSTILE = "QA" as const;
 
 export type AiTestingPersona = "Friendly" | "QA";
 
-export function useAi(requestHistory: Array<Requestornator>) {
+export function useAi(requestHistory: Array<ProxiedRequestResponse>) {
   const { toast } = useToast();
   const isAiEnabled = useAiEnabled();
   const { addServiceUrlIfBarePath } = useServiceBaseUrl();

--- a/studio/src/pages/RequestorPage/ai/generate-request-data.ts
+++ b/studio/src/pages/RequestorPage/ai/generate-request-data.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 import type { RequestBodyType } from "../store";
 import type { ProbedRoute } from "../types";
 import { simplifyHistoryEntry } from "./utils";
@@ -8,7 +8,7 @@ const fetchAiRequestData = (
   route: ProbedRoute | null,
   middleware: ProbedRoute[] | null,
   bodyType: RequestBodyType,
-  history: Array<Requestornator>,
+  history: Array<ProxiedRequestResponse>,
   persona: string,
 ) => {
   // FIXME - type wonkiness
@@ -42,7 +42,7 @@ export function useAiRequestData(
   route: ProbedRoute | null,
   matchingMiddleware: ProbedRoute[] | null,
   bodyType: RequestBodyType,
-  history: Array<Requestornator>,
+  history: Array<ProxiedRequestResponse>,
   persona = "Friendly",
 ) {
   return useQuery({

--- a/studio/src/pages/RequestorPage/ai/utils.ts
+++ b/studio/src/pages/RequestorPage/ai/utils.ts
@@ -1,5 +1,5 @@
 import { redactSensitiveHeaders } from "@/utils";
-import type { Requestornator } from "../queries";
+import type { ProxiedRequestResponse } from "../queries";
 
 /**
  * Simplify a history entry into a string that can be used to represent previous requests/responses.
@@ -7,14 +7,14 @@ import type { Requestornator } from "../queries";
  * Uses xml-style tags to represent the request and response.
  * The request and response themselves are formatted closely to how a server would render them as text.
  */
-export function simplifyHistoryEntry(entry: Requestornator) {
+export function simplifyHistoryEntry(entry: ProxiedRequestResponse) {
   // NOTE - Can we glean the http version somehow, somewhere?
   return [appRequestToHttpRequest(entry), appResponseToHttpRequest(entry)].join(
     "\n",
   );
 }
 
-export function appRequestToHttpRequest(entry: Requestornator) {
+export function appRequestToHttpRequest(entry: ProxiedRequestResponse) {
   const requestHeaders =
     redactSensitiveHeaders(entry.app_requests.requestHeaders) ?? {};
 
@@ -42,7 +42,7 @@ export function appRequestToHttpRequest(entry: Requestornator) {
   ].join("\n");
 }
 
-export function appResponseToHttpRequest(entry: Requestornator) {
+export function appResponseToHttpRequest(entry: ProxiedRequestResponse) {
   const responseHeaders =
     redactSensitiveHeaders(entry.app_responses?.responseHeaders) ?? {};
 

--- a/studio/src/pages/RequestorPage/queries/index.ts
+++ b/studio/src/pages/RequestorPage/queries/index.ts
@@ -14,7 +14,7 @@ export const JsonSchema: z.ZodType<unknown> = z.lazy(() =>
 export type JsonSchemaType = z.infer<typeof JsonSchema>;
 
 // TODO - Use validation schema
-export type Requestornator = {
+export type ProxiedRequestResponse = {
   app_requests: {
     id: number;
     requestUrl: string;

--- a/studio/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/studio/src/pages/RequestorPage/useRequestorHistory.ts
@@ -4,11 +4,17 @@ import type { TraceListResponse } from "@fiberplane/fpx-types";
 import { useHandler } from "@fiberplane/hooks";
 import { useMemo } from "react";
 import { createKeyValueParameters } from "./KeyValueForm";
-import { type ProxiedRequestResponse, useFetchRequestorRequests } from "./queries";
+import {
+  type ProxiedRequestResponse,
+  useFetchRequestorRequests,
+} from "./queries";
 import { findMatchedRoute } from "./routes";
 import { useRequestorStore } from "./store";
 import { isRequestMethod, isWsRequest } from "./types";
-import { sortProxiedRequestResponsesDescending, traceToProxiedRequestResponse } from "./utils";
+import {
+  sortProxiedRequestResponsesDescending,
+  traceToProxiedRequestResponse,
+} from "./utils";
 
 const EMPTY_TRACES: TraceListResponse = [];
 export function useRequestorHistory() {

--- a/studio/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/studio/src/pages/RequestorPage/useRequestorHistory.ts
@@ -8,7 +8,7 @@ import { type ProxiedRequestResponse, useFetchRequestorRequests } from "./querie
 import { findMatchedRoute } from "./routes";
 import { useRequestorStore } from "./store";
 import { isRequestMethod, isWsRequest } from "./types";
-import { sortRequestornatorsDescending, traceToRequestornator } from "./utils";
+import { sortProxiedRequestResponsesDescending, traceToProxiedRequestResponse } from "./utils";
 
 const EMPTY_TRACES: TraceListResponse = [];
 export function useRequestorHistory() {
@@ -44,14 +44,14 @@ export function useRequestorHistory() {
 
     for (const trace of traces) {
       if (!items.find((r) => r.app_responses?.traceId === trace.traceId)) {
-        const convertedTrace = traceToRequestornator(trace);
+        const convertedTrace = traceToProxiedRequestResponse(trace);
         if (convertedTrace) {
           items.push(convertedTrace);
         }
       }
     }
 
-    items.sort(sortRequestornatorsDescending);
+    items.sort(sortProxiedRequestResponsesDescending);
 
     return items;
   }, [allRequests, traces]);

--- a/studio/src/pages/RequestorPage/useRequestorHistory.ts
+++ b/studio/src/pages/RequestorPage/useRequestorHistory.ts
@@ -4,7 +4,7 @@ import type { TraceListResponse } from "@fiberplane/fpx-types";
 import { useHandler } from "@fiberplane/hooks";
 import { useMemo } from "react";
 import { createKeyValueParameters } from "./KeyValueForm";
-import { type Requestornator, useFetchRequestorRequests } from "./queries";
+import { type ProxiedRequestResponse, useFetchRequestorRequests } from "./queries";
 import { findMatchedRoute } from "./routes";
 import { useRequestorStore } from "./store";
 import { isRequestMethod, isWsRequest } from "./types";
@@ -36,8 +36,8 @@ export function useRequestorHistory() {
   const { data: traces = EMPTY_TRACES } = useOtelTraces();
 
   // Keep a history of recent requests and responses
-  const history = useMemo<Array<Requestornator>>(() => {
-    const items: Array<Requestornator> = [];
+  const history = useMemo<Array<ProxiedRequestResponse>>(() => {
+    const items: Array<ProxiedRequestResponse> = [];
     if (allRequests) {
       items.push(...allRequests);
     }

--- a/studio/src/pages/RequestorPage/utils.ts
+++ b/studio/src/pages/RequestorPage/utils.ts
@@ -10,11 +10,11 @@ import {
   getStatusCode,
 } from "@/utils";
 import type { TraceSummary } from "@fiberplane/fpx-types";
-import type { Requestornator } from "./queries";
+import type { ProxiedRequestResponse } from "./queries";
 
 export function sortRequestornatorsDescending(
-  a: Requestornator,
-  b: Requestornator,
+  a: ProxiedRequestResponse,
+  b: ProxiedRequestResponse,
 ) {
   const aLatestTimestamp = a.app_requests?.updatedAt;
   const bLatestTimestamp = b.app_requests?.updatedAt;
@@ -29,7 +29,7 @@ export function sortRequestornatorsDescending(
 
 export function traceToRequestornator(
   trace: TraceSummary,
-): Requestornator | null {
+): ProxiedRequestResponse | null {
   const { spans, traceId } = trace;
   const rootSpan = spans.find((s) => s.name === "request");
   if (!rootSpan) {

--- a/studio/src/pages/RequestorPage/utils.ts
+++ b/studio/src/pages/RequestorPage/utils.ts
@@ -12,7 +12,7 @@ import {
 import type { TraceSummary } from "@fiberplane/fpx-types";
 import type { ProxiedRequestResponse } from "./queries";
 
-export function sortRequestornatorsDescending(
+export function sortProxiedRequestResponsesDescending(
   a: ProxiedRequestResponse,
   b: ProxiedRequestResponse,
 ) {
@@ -27,7 +27,7 @@ export function sortRequestornatorsDescending(
   return 0;
 }
 
-export function traceToRequestornator(
+export function traceToProxiedRequestResponse(
   trace: TraceSummary,
 ): ProxiedRequestResponse | null {
   const { spans, traceId } = trace;


### PR DESCRIPTION
We had a nonsense type called `Requestornator`, which I named very fast a few months ago. I've updated the type name to something a bit more descriptive

This type represents an api request (and its response data) that was proxied through our api

The new name is `ProxiedRequestResponse`