### PR TITLE
Fix problem with enabling studio proxy (webhonc)

### DIFF
--- a/api/src/lib/webhonc/index.ts
+++ b/api/src/lib/webhonc/index.ts
@@ -170,7 +170,12 @@ const messageHandlers: {
   },
   connection_open: async (message, config) => {
     const { connectionId } = message.payload;
-    setWebHoncConnectionId(config.db, connectionId);
+    logger.debug(
+      "connection_open message received, setting webhonc connection id:",
+      connectionId,
+    );
+    // Await this call so that the webhonc id is set before the query on the studio side is invalidated
+    await setWebHoncConnectionId(config.db, connectionId);
     for (const ws of config.wsConnections) {
       ws.send(
         JSON.stringify({

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -18,8 +18,13 @@ app.get("/v0/settings", cors(), async (ctx) => {
 
 /**
  * Upsert the settings record
+ * 
+ * NOTE - We need to start and stop webhonc when the proxy requests setting is updated.
  */
 app.post("/v0/settings", cors(), async (ctx) => {
+  const currentSettings = await getAllSettings(ctx.get("db"));
+  const prevProxyUrlEnabled = currentSettings?.proxyRequestsEnabled;
+
   const { content } = (await ctx.req.json()) as {
     content: Record<string, string>;
   };
@@ -40,16 +45,19 @@ app.post("/v0/settings", cors(), async (ctx) => {
 
   logger.debug("Configuration updated...");
 
-  const proxyUrlEnabled = !!Number(
-    updatedSettings.find((setting) => setting.key === "proxyRequestsEnabled")
-      ?.value,
-  );
-
-  if (proxyUrlEnabled) {
+  // HACK - We should techincally JSON parse the value here, but whatever.
+  const proxyUrlEnabled = updatedSettings.find((setting) => setting.key === "proxyRequestsEnabled")
+    ?.value === "true";
+  
+  const shouldStartWebhonc = !prevProxyUrlEnabled && proxyUrlEnabled;
+  if (shouldStartWebhonc) {
+    logger.debug("Proxy requests enabled in settings update, starting webhonc");
     await webhonc.start();
   }
 
-  if (!proxyUrlEnabled) {
+  const shouldStopWebhonc = prevProxyUrlEnabled && !proxyUrlEnabled;
+  if (shouldStopWebhonc) {
+    logger.debug("Proxy requests disabled in settings update, stopping webhonc");
     await webhonc.stop();
   }
 

--- a/api/src/routes/settings.ts
+++ b/api/src/routes/settings.ts
@@ -18,7 +18,7 @@ app.get("/v0/settings", cors(), async (ctx) => {
 
 /**
  * Upsert the settings record
- * 
+ *
  * NOTE - We need to start and stop webhonc when the proxy requests setting is updated.
  */
 app.post("/v0/settings", cors(), async (ctx) => {
@@ -46,9 +46,10 @@ app.post("/v0/settings", cors(), async (ctx) => {
   logger.debug("Configuration updated...");
 
   // HACK - We should techincally JSON parse the value here, but whatever.
-  const proxyUrlEnabled = updatedSettings.find((setting) => setting.key === "proxyRequestsEnabled")
-    ?.value === "true";
-  
+  const proxyUrlEnabled =
+    updatedSettings.find((setting) => setting.key === "proxyRequestsEnabled")
+      ?.value === "true";
+
   const shouldStartWebhonc = !prevProxyUrlEnabled && proxyUrlEnabled;
   if (shouldStartWebhonc) {
     logger.debug("Proxy requests enabled in settings update, starting webhonc");
@@ -57,7 +58,9 @@ app.post("/v0/settings", cors(), async (ctx) => {
 
   const shouldStopWebhonc = prevProxyUrlEnabled && !proxyUrlEnabled;
   if (shouldStopWebhonc) {
-    logger.debug("Proxy requests disabled in settings update, stopping webhonc");
+    logger.debug(
+      "Proxy requests disabled in settings update, stopping webhonc",
+    );
     await webhonc.stop();
   }
 

--- a/studio/src/hooks/useWebsocketQueryInvalidation.ts
+++ b/studio/src/hooks/useWebsocketQueryInvalidation.ts
@@ -1,3 +1,4 @@
+import { WEBHONC_ID_KEY } from "@/components/WebhoncBadge/const";
 import { useRealtimeService } from "@/hooks/useRealtimeService";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -21,11 +22,10 @@ export function useWebsocketQueryInvalidation() {
       }
 
       case "connection_open": {
-        // TODO: rewriting some webhook/websocket stuff tbd if this is needed
-        console.debug("connection_open");
-        // queryClient.invalidateQueries({
-        // queryKey: [WEBHONC_ID_KEY, WEBHONC_REQUEST_KEY],
-        // });
+        console.debug("connection_open - invalidating webhonc id");
+        queryClient.invalidateQueries({
+          queryKey: [WEBHONC_ID_KEY],
+        });
         break;
       }
 


### PR DESCRIPTION
Fixes a few problems with enabling webhonc in the Studio. 

Currently, when you enable WebHonc, you get a `false` id back. This was because of a few problems:

- `POST /settings` was not accurately determining when the webhonc setting flag changed
- The UI did not properly invalidate the query for the webhonc id, in order to request the latest proxy id