### PR TITLE
Improve Route Updates

### DIFF
--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm --filter @fiberplane/studio-frontend test
 
       - name: Test Client Library
-        run: pnpm --filter @fiberplane/client-library-otel test
+        run: pnpm --filter @fiberplane/hono-otel test
 
       # Building
 

--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Test Studio Frontend
         run: pnpm --filter @fiberplane/studio-frontend test
 
+      - name: Test Client Library
+        run: pnpm --filter @fiberplane/client-library-otel test
+
       # Building
 
       - name: Build api, frontend, and client library

--- a/api/src/probe-routes.ts
+++ b/api/src/probe-routes.ts
@@ -40,8 +40,8 @@ export function startRouteProbeWatcher(watchDir: string) {
   const probeMaxRetries = 10;
   // Send the initial probe 500ms after startup
   const initialProbeDelay = 500;
-  // Add 1.5s delay for all successive probes (e.g., after filesystem change of watched project)
-  const probeDelay = 1500;
+  // Add 2.2s delay for all successive probes (e.g., after filesystem change of watched project)
+  const probeDelay = 2200;
 
   debouncedProbeRoutesWithExponentialBackoff(
     serviceTargetArgument,

--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.3.1-beta.1",
+  "version": "0.3.1-beta.2",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -25,7 +25,8 @@
     "nodemon": "^3.1.7",
     "rimraf": "^6.0.1",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
   },
   "publishConfig": {
     "access": "public"
@@ -50,6 +51,7 @@
     "dev": "wrangler dev sample/index.ts",
     "prepublishOnly": "pnpm run build",
     "clean": "rimraf dist",
+    "test": "vitest --run",
     "watch": "nodemon --watch src --ext ts,js,json --exec \"pnpm run build\""
   }
 }

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -129,15 +129,17 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
             return await originalFetch(request, rawEnv, executionContext);
           }
 
-          // If the request is from the route inspector, respond with the routes
+          // If the request is from the route inspector, send latest routes to the Studio API and respond with 200 OK
           if (isRouteInspectorRequest(request)) {
             logger.debug("Responding to route inspector request");
-            return respondWithRoutes(webStandardFetch, endpoint, app);
+            const response = await respondWithRoutes(
+              webStandardFetch,
+              endpoint,
+              app,
+              logger,
+            );
+            return response;
           }
-
-          // NOTE - We want to report the latest routes to FPX on every request
-          //        so that we have an up-to-date list of routes in the UI
-          sendRoutes(webStandardFetch, endpoint, app);
 
           const serviceName =
             getFromEnv(env, ENV_FPX_SERVICE_NAME) ?? "unknown";
@@ -159,6 +161,14 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
           });
 
           const promiseStore = new PromiseStore();
+
+          // NOTE - We want to report the latest routes to Studio on every request,
+          //        so that we have an up-to-date list of routes in the UI.
+          //        This will place the request in the promise store, so that we can
+          //        send the routes in the background while still ensuring the request
+          //        completes as usual.
+          sendRoutes(webStandardFetch, endpoint, app, logger, promiseStore);
+
           // Enable tracing for waitUntil
           const proxyExecutionCtx =
             executionContext && patchWaitUntil(executionContext, promiseStore);

--- a/packages/client-library-otel/src/instrumentation.ts
+++ b/packages/client-library-otel/src/instrumentation.ts
@@ -25,7 +25,11 @@ import {
 } from "./patch";
 import { PromiseStore } from "./promiseStore";
 import { propagateFpxTraceId } from "./propagation";
-import { isRouteInspectorRequest, respondWithRoutes } from "./routes";
+import {
+  isRouteInspectorRequest,
+  respondWithRoutes,
+  sendRoutes,
+} from "./routes";
 import type { HonoLikeApp, HonoLikeEnv, HonoLikeFetch } from "./types";
 import {
   getFromEnv,
@@ -130,6 +134,10 @@ export function instrument(app: HonoLikeApp, config?: FpxConfigOptions) {
             logger.debug("Responding to route inspector request");
             return respondWithRoutes(webStandardFetch, endpoint, app);
           }
+
+          // NOTE - We want to report the latest routes to FPX on every request
+          //        so that we have an up-to-date list of routes in the UI
+          sendRoutes(webStandardFetch, endpoint, app);
 
           const serviceName =
             getFromEnv(env, ENV_FPX_SERVICE_NAME) ?? "unknown";

--- a/packages/client-library-otel/src/routes.test.ts
+++ b/packages/client-library-otel/src/routes.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { FpxLogger } from "./logger";
+import type { PromiseStore } from "./promiseStore";
+import {
+  isRouteInspectorRequest,
+  respondWithRoutes,
+  sendRoutes,
+} from "./routes";
+import type { HonoLikeApp, HonoLikeFetch } from "./types";
+
+describe("routes", () => {
+  describe("isRouteInspectorRequest", () => {
+    it("should return true when X-Fpx-Route-Inspector header is present", () => {
+      const request = new Request("https://example.com", {
+        headers: { "X-Fpx-Route-Inspector": "true" },
+      });
+      expect(isRouteInspectorRequest(request)).toBe(true);
+    });
+
+    it("should return false when X-Fpx-Route-Inspector header is not present", () => {
+      const request = new Request("https://example.com");
+      expect(isRouteInspectorRequest(request)).toBe(false);
+    });
+  });
+
+  describe("sendRoutes", () => {
+    let mockFetch: ReturnType<typeof vi.fn<[HonoLikeFetch], unknown>>;
+    let mockApp: HonoLikeApp;
+    let mockLogger: FpxLogger;
+    let mockPromiseStore: PromiseStore;
+
+    beforeEach(() => {
+      mockFetch = vi.fn().mockResolvedValue(new Response("OK"));
+      mockApp = {
+        routes: [{ method: "GET", path: "/test", handler: () => {} }],
+        fetch: vi.fn(),
+      } as unknown as HonoLikeApp;
+      mockLogger = { debug: vi.fn() } as unknown as FpxLogger;
+      mockPromiseStore = { add: vi.fn() } as unknown as PromiseStore;
+    });
+
+    it("should send routes successfully", async () => {
+      const result = await sendRoutes(
+        mockFetch as unknown as typeof fetch,
+        "https://fpx.example.com",
+        mockApp,
+        mockLogger,
+      );
+      expect(result).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://fpx.example.com/v0/probed-routes",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: expect.any(String),
+        }),
+      );
+    });
+
+    it("should use promiseStore when provided", async () => {
+      await sendRoutes(
+        mockFetch as unknown as typeof fetch,
+        "https://fpx.example.com",
+        mockApp,
+        mockLogger,
+        mockPromiseStore,
+      );
+      expect(mockPromiseStore.add).toHaveBeenCalled();
+    });
+
+    it("should return false and log error on failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+      const result = await sendRoutes(
+        mockFetch as unknown as typeof fetch,
+        "https://fpx.example.com",
+        mockApp,
+        mockLogger,
+      );
+      expect(result).toBe(false);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "Error sending routes to FPX:",
+        "Network error",
+      );
+    });
+  });
+
+  describe("respondWithRoutes", () => {
+    let mockFetch: ReturnType<typeof vi.fn<[HonoLikeFetch], unknown>>;
+    let mockApp: HonoLikeApp;
+    let mockLogger: FpxLogger;
+
+    beforeEach(() => {
+      mockFetch = vi.fn().mockResolvedValue(new Response("OK"));
+      mockApp = {
+        routes: [{ method: "GET", path: "/test", handler: () => {} }],
+        fetch: vi.fn(),
+      } as unknown as HonoLikeApp;
+      mockLogger = { debug: vi.fn() } as unknown as FpxLogger;
+    });
+
+    it("should respond with 200 OK when routes are sent successfully", async () => {
+      const response = await respondWithRoutes(
+        mockFetch as unknown as typeof fetch,
+        "https://fpx.example.com",
+        mockApp,
+        mockLogger,
+      );
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("OK");
+    });
+
+    it("should respond with 500 error when sending routes fails", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+      const response = await respondWithRoutes(
+        mockFetch as unknown as typeof fetch,
+        "https://fpx.example.com",
+        mockApp,
+        mockLogger,
+      );
+      expect(response.status).toBe(500);
+      expect(await response.text()).toBe("Error sending routes to FPX");
+    });
+  });
+});

--- a/packages/client-library-otel/src/routes.ts
+++ b/packages/client-library-otel/src/routes.ts
@@ -12,14 +12,14 @@ export function isRouteInspectorRequest(request: Request) {
 }
 
 /**
- * Responds to the route inspector request by sending the routes to the FPX service.
+ * Sends the routes from the app to the FPX service.
  *
  * @param fetchFn - The fetch function to use to send the request.
  * @param fpxEndpoint - The endpoint of the FPX service.
  * @param app - The Hono app to get the routes from.
  * @returns
  */
-export function respondWithRoutes(
+export function sendRoutes(
   fetchFn: FetchFn,
   fpxEndpoint: string,
   app: HonoLikeApp,
@@ -48,7 +48,23 @@ export function respondWithRoutes(
     // TODO - Use a logger, or only log if library debugging is enabled
     // console.error("Error sending routes to FPX", e);
   }
+}
 
+/**
+ * Sends the routes from the app to the FPX service, then returns a response that can be used
+ * for fpx route inspection requests.
+ *
+ * @param fetchFn - The fetch function to use to send the request.
+ * @param fpxEndpoint - The endpoint of the FPX service.
+ * @param app - The Hono app to get the routes from.
+ * @returns
+ */
+export function respondWithRoutes(
+  fetchFn: FetchFn,
+  fpxEndpoint: string,
+  app: HonoLikeApp,
+) {
+  sendRoutes(fetchFn, fpxEndpoint, app);
   return new Response("OK");
 }
 

--- a/packages/client-library-otel/tsconfig.json
+++ b/packages/client-library-otel/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "lib": ["ESNext"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["vitest/globals", "@cloudflare/workers-types"],
     "esModuleInterop": true,
     "outDir": "./dist",
     "rootDir": "./src",

--- a/packages/client-library-otel/vitest.config.ts
+++ b/packages/client-library-otel/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.5.4
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.0(@types/node@20.14.15)
 
   packages/types:
     devDependencies:

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -10,6 +10,8 @@ draft: true
 
 - **Improved AI request generation** We've added some static analysis smarts for wrangler projects in order to give LLM providers more context about the code that powers each route.
 
+- **Improved Route Updating** We've added some improvements to how we refresh your list of API routes in the Studio.
+
 ### Bug fixes
 
 - **D1 autoinstrumentation** The client library, `@fiberplane/hono-otel`, now instruments D1 queries in latest versions of wrangler/miniflare.


### PR DESCRIPTION
## Changes

- Increase delay before firing off probe
- Send latest routes every time a new request comes into the monitored Hono app
- Add unit tests (and vitest) to client library, for the route probe functionality
- Update CI to run client library unit tests


## To Try

- [x] Make sure the frontend websocket connection is still live when page is not in focus 

## For Later

### Monitoring `.wrangler/tmp/dev-*`

okay so i want to make sure we're also monitoring this path in the watchDir:

`.wrangler/tmp/dev-*/index.js`

however, we need to only monitor the most recent dev-* folder in that directory...

we should modify the code in `api/src/lib/utils` to make sure we also respond to these changes ((and if that folder is present it's probably the only one we want to monitor right?))
