### PR TITLE
Handle our workspace:* deps properly in static analysis code

### DIFF
--- a/api/src/lib/expand-function/ast-helpers/identifier-analyzer.ts
+++ b/api/src/lib/expand-function/ast-helpers/identifier-analyzer.ts
@@ -205,6 +205,11 @@ export function analyzeOutOfScopeIdentifiers(
       const parent = node.parent;
       const name = node.text;
 
+      // HACK - Just ignore the `arguments` identifier, it can cause us heartache following this
+      if (name === "arguments") {
+        return;
+      }
+
       // Ignore property names in property assignments and declarations
       const isIgnoredPropertyName =
         (ts.isPropertyAssignment(parent) && parent.name === node) ||

--- a/api/src/lib/expand-function/expand-function.ts
+++ b/api/src/lib/expand-function/expand-function.ts
@@ -410,6 +410,7 @@ async function extractContext(
         logger.warn(
           `[extractContext] TSServer found no definition found for ${identifier.name}`,
         );
+        logger.warn(`[extractContext] Originating file: ${filePath}`);
       }
     }
   } catch (error) {

--- a/api/src/lib/expand-function/imports/is-dependency.ts
+++ b/api/src/lib/expand-function/imports/is-dependency.ts
@@ -7,7 +7,18 @@ export function isDependency(filePath: string): boolean {
 
   // Normalize the path to handle Windows
   const normalizedPath = filePath.replace(/\\/g, "/");
-  return dependencyFolders.some((folder) =>
+  const isTypicalDependency = dependencyFolders.some((folder) =>
     normalizedPath.includes(`/${folder}/`),
   );
+
+  if (isTypicalDependency) {
+    return true;
+  }
+
+  // HACK - Handle workspace:* packages in our own monorepo
+  if (normalizedPath.includes("/fpx/packages/")) {
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Testing static analysis with goose-quotes in the example folder got tricky. We were trying to follow the defintion of `measure` back to the workspace dist (compiled js for the hono client lib), and that overloaded the language server.

This PR makes sure we ignore fpx workspace deps when doing static analysis 

***

Bonus: Do not follow the `arguments` identifier at all, as this can cause serious issues