### PR TITLE
Fix file previews in the requestor response panel

### DIFF
--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/FailedRequest.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/FailedRequest.tsx
@@ -1,0 +1,33 @@
+import { LinkBreak2Icon } from "@radix-ui/react-icons";
+import type { ProxiedRequestResponse } from "../../queries";
+import {
+  type RequestorActiveResponse,
+  isRequestorActiveResponse,
+} from "../../store/types";
+
+export function FailedRequest({
+  response,
+}: { response?: ProxiedRequestResponse | RequestorActiveResponse }) {
+  // TODO - Show a more friendly error message
+  const failureReason = isRequestorActiveResponse(response)
+    ? null
+    : response?.app_responses?.failureReason;
+  const friendlyMessage =
+    failureReason === "fetch failed" ? "Service unreachable" : null;
+  // const failureDetails = response?.app_responses?.failureDetails;
+  return (
+    <div className="h-full pb-8 sm:pb-20 md:pb-32 flex flex-col items-center justify-center p-4">
+      <div className="flex flex-col items-center justify-center p-4">
+        <LinkBreak2Icon className="h-10 w-10 text-red-200" />
+        <div className="mt-4 text-md text-white text-center">
+          {friendlyMessage
+            ? `Request failed: ${friendlyMessage}`
+            : "Request failed"}
+        </div>
+        <div className="mt-2 text-ms text-gray-400 text-center font-light">
+          Make sure your api is up and has FPX Middleware enabled!
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
@@ -38,6 +38,9 @@ export function ResponseBody({
     return <FailedRequest response={response} />;
   }
 
+  // NOTE - This means we have the *actual* response from the service in the store,
+  //        which may contain binary data that we can render in the UI.
+  //        This is different from history responses, which will only have whatever data was stored in the trace
   if (isRequestorActiveResponse(response)) {
     const body = response?.responseBody;
     if (body?.type === "error") {

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
@@ -10,7 +10,6 @@ import { cn, isJson, noop, safeParseJson } from "@/utils";
 import {
   CaretDownIcon,
   CaretRightIcon,
-  LinkBreak2Icon,
   QuestionMarkIcon,
 } from "@radix-ui/react-icons";
 import { useState } from "react";
@@ -19,6 +18,7 @@ import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../../store/types";
+import { FailedRequest } from "./FailedRequest";
 import { ResponseBodyBinary } from "./ResponseBodyBinary";
 import { ResponseBodyText } from "./ResponseBodyText";
 
@@ -133,33 +133,6 @@ function UnknownResponse({
           </span>
         </div>
       </CollapsibleBodyContainer>
-    </div>
-  );
-}
-
-export function FailedRequest({
-  response,
-}: { response?: ProxiedRequestResponse | RequestorActiveResponse }) {
-  // TODO - Show a more friendly error message
-  const failureReason = isRequestorActiveResponse(response)
-    ? null
-    : response?.app_responses?.failureReason;
-  const friendlyMessage =
-    failureReason === "fetch failed" ? "Service unreachable" : null;
-  // const failureDetails = response?.app_responses?.failureDetails;
-  return (
-    <div className="h-full pb-8 sm:pb-20 md:pb-32 flex flex-col items-center justify-center p-4">
-      <div className="flex flex-col items-center justify-center p-4">
-        <LinkBreak2Icon className="h-10 w-10 text-red-200" />
-        <div className="mt-4 text-md text-white text-center">
-          {friendlyMessage
-            ? `Request failed: ${friendlyMessage}`
-            : "Request failed"}
-        </div>
-        <div className="mt-2 text-ms text-gray-400 text-center font-light">
-          Make sure your api is up and has FPX Middleware enabled!
-        </div>
-      </div>
     </div>
   );
 }

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
@@ -15,11 +15,11 @@ import {
   QuestionMarkIcon,
 } from "@radix-ui/react-icons";
 import { useMemo, useState } from "react";
-import type { ProxiedRequestResponse } from "../queries";
+import type { ProxiedRequestResponse } from "../../queries";
 import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
-} from "../store/types";
+} from "../../store/types";
 
 export function ResponseBody({
   response,
@@ -65,7 +65,6 @@ export function ResponseBody({
       );
     }
 
-    // TODO
     if (body?.type === "binary") {
       return (
         <div

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
@@ -1,7 +1,6 @@
 import { CodeMirrorJsonEditor } from "@/components/CodeMirrorEditor";
 import { SubSectionHeading } from "@/components/Timeline";
 import { TextOrJsonViewer } from "@/components/Timeline/DetailsList/TextJsonViewer";
-import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
@@ -14,12 +13,14 @@ import {
   LinkBreak2Icon,
   QuestionMarkIcon,
 } from "@radix-ui/react-icons";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import type { ProxiedRequestResponse } from "../../queries";
 import {
   type RequestorActiveResponse,
   isRequestorActiveResponse,
 } from "../../store/types";
+import { ResponseBodyBinary } from "./ResponseBodyBinary";
+import { ResponseBodyText } from "./ResponseBodyText";
 
 export function ResponseBody({
   response,
@@ -134,144 +135,6 @@ function UnknownResponse({
       </CollapsibleBodyContainer>
     </div>
   );
-}
-
-function ResponseBodyBinary({
-  body,
-}: {
-  body: { contentType: string; type: "binary"; value: ArrayBuffer };
-}) {
-  const isImage = body.contentType.startsWith("image/");
-
-  if (isImage) {
-    const blob = new Blob([body.value], { type: body.contentType });
-    const imageUrl = URL.createObjectURL(blob);
-    return (
-      <img
-        src={imageUrl}
-        alt="Response"
-        className="max-w-full h-auto"
-        onLoad={() => URL.revokeObjectURL(imageUrl)}
-      />
-    );
-  }
-
-  // TODO - Stylize
-  return <div>Binary response {body.contentType}</div>;
-}
-
-export function ResponseBodyText({
-  body,
-  maxPreviewLength = null,
-  maxPreviewLines = null,
-  defaultExpanded = false,
-  className,
-}: {
-  body: string;
-  maxPreviewLength?: number | null;
-  maxPreviewLines?: number | null;
-  defaultExpanded?: boolean;
-  className?: string;
-}) {
-  const [isExpanded, setIsExpanded] = useState(!!defaultExpanded);
-  const toggleIsExpanded = () => setIsExpanded((e) => !e);
-
-  // For text responses, just split into lines and render with rudimentary line numbers
-  const { lines, hiddenLinesCount, hiddenCharsCount, shouldShowExpandButton } =
-    useTextPreview(body, isExpanded, maxPreviewLength, maxPreviewLines);
-
-  // TODO - if response is empty, show that in a ux friendly way, with 204 for example
-
-  return (
-    <div
-      className={cn("overflow-hidden overflow-y-auto w-full py-2", className)}
-    >
-      <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap">
-        <code className="h-full">{lines}</code>
-      </pre>
-      {shouldShowExpandButton && (
-        <div
-          className={cn(
-            "w-full flex flex-row items-center gap-2 mt-4 border-t border-gray-500/50",
-          )}
-        >
-          {!isExpanded && (
-            <div className="text-sm text-gray-400">
-              {hiddenLinesCount > 0 ? (
-                <>{hiddenLinesCount} lines hidden</>
-              ) : (
-                <>{hiddenCharsCount} characters hidden</>
-              )}
-            </div>
-          )}
-          <Button
-            variant="ghost"
-            onClick={toggleIsExpanded}
-            className="text-blue-400 font-normal py-1 px-1 hover:bg-transparent hover:text-blue-400 hover:underline"
-          >
-            {isExpanded ? "Show Less" : "Show More"}
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function useTextPreview(
-  body: string,
-  isExpanded: boolean,
-  maxPreviewLength: number | null,
-  maxPreviewLines: number | null,
-) {
-  return useMemo(() => {
-    let hiddenCharsCount = 0;
-    let hiddenLinesCount = 0;
-    const allLinesCount = body.split("\n")?.length;
-
-    const exceedsMaxPreviewLength = maxPreviewLength
-      ? body.length > maxPreviewLength
-      : false;
-
-    const exceedsMaxPreviewLines = maxPreviewLines
-      ? allLinesCount > maxPreviewLines
-      : false;
-
-    // If we're not expanded, we want to show a preview of the body depending on the maxPreviewLength
-    let previewBody = body;
-    if (maxPreviewLength && exceedsMaxPreviewLength && !isExpanded) {
-      previewBody = body ? `${body.slice(0, maxPreviewLength)}...` : "";
-      hiddenCharsCount = body.length - maxPreviewLength;
-    }
-
-    let previewLines = previewBody?.split("\n");
-    if (
-      maxPreviewLines &&
-      !isExpanded &&
-      previewLines.length > maxPreviewLines
-    ) {
-      previewLines = previewLines.slice(0, maxPreviewLines);
-      previewBody = `${previewLines.join("\n")}...`;
-      hiddenLinesCount = allLinesCount - previewLines.length;
-    }
-
-    const lines = (isExpanded ? body : previewBody)
-      ?.split("\n")
-      ?.map((line, index) => (
-        <div key={index} className="flex h-full">
-          <span className="w-8 text-right pr-2 text-gray-500 bg-muted mr-1">
-            {index + 1}
-          </span>
-          <span>{line}</span>
-        </div>
-      ));
-
-    return {
-      lines,
-      shouldShowExpandButton: exceedsMaxPreviewLength || exceedsMaxPreviewLines,
-      hiddenLinesCount,
-      hiddenCharsCount,
-    };
-  }, [body, maxPreviewLines, maxPreviewLength, isExpanded]);
 }
 
 export function FailedRequest({

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyBinary.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyBinary.tsx
@@ -1,0 +1,23 @@
+export function ResponseBodyBinary({
+  body,
+}: {
+  body: { contentType: string; type: "binary"; value: ArrayBuffer };
+}) {
+  const isImage = body.contentType.startsWith("image/");
+
+  if (isImage) {
+    const blob = new Blob([body.value], { type: body.contentType });
+    const imageUrl = URL.createObjectURL(blob);
+    return (
+      <img
+        src={imageUrl}
+        alt="Response"
+        className="max-w-full h-auto"
+        onLoad={() => URL.revokeObjectURL(imageUrl)}
+      />
+    );
+  }
+
+  // TODO - Stylize
+  return <div>Binary response {body.contentType}</div>;
+}

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyBinary.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyBinary.tsx
@@ -1,23 +1,72 @@
+import { useEffect, useState } from "react";
+
+function ImageBody({
+  value,
+  contentType,
+}: { value: ArrayBuffer; contentType: string }) {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const blob = new Blob([value], { type: contentType });
+    const url = URL.createObjectURL(blob);
+    setImageUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [value, contentType]);
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  return <img src={imageUrl} alt="Response" className="max-w-full h-auto" />;
+}
+
+function AudioBody({
+  value,
+  contentType,
+}: { value: ArrayBuffer; contentType: string }) {
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const blob = new Blob([value], { type: contentType });
+    const url = URL.createObjectURL(blob);
+    setAudioUrl(url);
+
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [value, contentType]);
+
+  if (!audioUrl) {
+    return null;
+  }
+
+  return (
+    // biome-ignore lint/a11y/useMediaCaption: we do not have captions
+    <audio src={audioUrl} controls className="w-full">
+      Your browser does not support the audio element.
+    </audio>
+  );
+}
+
 export function ResponseBodyBinary({
   body,
 }: {
   body: { contentType: string; type: "binary"; value: ArrayBuffer };
 }) {
   const isImage = body.contentType.startsWith("image/");
+  const isAudio = body.contentType.startsWith("audio/");
 
   if (isImage) {
-    const blob = new Blob([body.value], { type: body.contentType });
-    const imageUrl = URL.createObjectURL(blob);
-    return (
-      <img
-        src={imageUrl}
-        alt="Response"
-        className="max-w-full h-auto"
-        onLoad={() => URL.revokeObjectURL(imageUrl)}
-      />
-    );
+    return <ImageBody value={body.value} contentType={body.contentType} />;
   }
 
-  // TODO - Stylize
-  return <div>Binary response {body.contentType}</div>;
+  if (isAudio) {
+    return <AudioBody value={body.value} contentType={body.contentType} />;
+  }
+
+  // TODO - Stylize for other binary types
+  return <div>Binary response: {body.contentType}</div>;
 }

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
@@ -1,0 +1,117 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/utils";
+import { useMemo, useState } from "react";
+
+export function ResponseBodyText({
+  body,
+  maxPreviewLength = null,
+  maxPreviewLines = null,
+  defaultExpanded = false,
+  className,
+}: {
+  body: string;
+  maxPreviewLength?: number | null;
+  maxPreviewLines?: number | null;
+  defaultExpanded?: boolean;
+  className?: string;
+}) {
+  const [isExpanded, setIsExpanded] = useState(!!defaultExpanded);
+  const toggleIsExpanded = () => setIsExpanded((e) => !e);
+
+  // For text responses, just split into lines and render with rudimentary line numbers
+  const { lines, hiddenLinesCount, hiddenCharsCount, shouldShowExpandButton } =
+    useTextPreview(body, isExpanded, maxPreviewLength, maxPreviewLines);
+
+  // TODO - if response is empty, show that in a ux friendly way, with 204 for example
+
+  return (
+    <div
+      className={cn("overflow-hidden overflow-y-auto w-full py-2", className)}
+    >
+      <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap">
+        <code className="h-full">{lines}</code>
+      </pre>
+      {shouldShowExpandButton && (
+        <div
+          className={cn(
+            "w-full flex flex-row items-center gap-2 mt-4 border-t border-gray-500/50",
+          )}
+        >
+          {!isExpanded && (
+            <div className="text-sm text-gray-400">
+              {hiddenLinesCount > 0 ? (
+                <>{hiddenLinesCount} lines hidden</>
+              ) : (
+                <>{hiddenCharsCount} characters hidden</>
+              )}
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            onClick={toggleIsExpanded}
+            className="text-blue-400 font-normal py-1 px-1 hover:bg-transparent hover:text-blue-400 hover:underline"
+          >
+            {isExpanded ? "Show Less" : "Show More"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function useTextPreview(
+  body: string,
+  isExpanded: boolean,
+  maxPreviewLength: number | null,
+  maxPreviewLines: number | null,
+) {
+  return useMemo(() => {
+    let hiddenCharsCount = 0;
+    let hiddenLinesCount = 0;
+    const allLinesCount = body.split("\n")?.length;
+
+    const exceedsMaxPreviewLength = maxPreviewLength
+      ? body.length > maxPreviewLength
+      : false;
+
+    const exceedsMaxPreviewLines = maxPreviewLines
+      ? allLinesCount > maxPreviewLines
+      : false;
+
+    // If we're not expanded, we want to show a preview of the body depending on the maxPreviewLength
+    let previewBody = body;
+    if (maxPreviewLength && exceedsMaxPreviewLength && !isExpanded) {
+      previewBody = body ? `${body.slice(0, maxPreviewLength)}...` : "";
+      hiddenCharsCount = body.length - maxPreviewLength;
+    }
+
+    let previewLines = previewBody?.split("\n");
+    if (
+      maxPreviewLines &&
+      !isExpanded &&
+      previewLines.length > maxPreviewLines
+    ) {
+      previewLines = previewLines.slice(0, maxPreviewLines);
+      previewBody = `${previewLines.join("\n")}...`;
+      hiddenLinesCount = allLinesCount - previewLines.length;
+    }
+
+    const lines = (isExpanded ? body : previewBody)
+      ?.split("\n")
+      ?.map((line, index) => (
+        <div key={index} className="flex h-full">
+          <span className="w-8 text-right pr-2 text-gray-500 bg-muted mr-1">
+            {index + 1}
+          </span>
+          <span>{line}</span>
+        </div>
+      ));
+
+    return {
+      lines,
+      shouldShowExpandButton: exceedsMaxPreviewLength || exceedsMaxPreviewLines,
+      hiddenLinesCount,
+      hiddenCharsCount,
+    };
+  }, [body, maxPreviewLines, maxPreviewLength, isExpanded]);
+}

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
@@ -1,1 +1,2 @@
 export * from "./ResponseBody";
+export * from "./ResponseBodyText";

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
@@ -1,2 +1,3 @@
 export * from "./ResponseBody";
 export * from "./ResponseBodyText";
+export * from "./FailedRequest";

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResponseBody";

--- a/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
+++ b/studio/src/pages/RequestorPage/store/slices/requestResponseSlice.ts
@@ -193,7 +193,13 @@ export const requestResponseSlice: StateCreator<
   showResponseBodyFromHistory: (traceId) =>
     set((state) => {
       state.activeHistoryResponseTraceId = traceId;
-      state.activeResponse = null;
+      // Recall that an 'active response' is one for which we will have the body we received from the service
+      // This means it can contain binary data, whereas the history response will not
+      // We should prefer to keep the active response as response to render, so long as its traceId matches the current history response traceId
+      const activeTraceId = state.activeResponse?.traceId;
+      if (!activeTraceId || activeTraceId !== traceId) {
+        state.activeResponse = null;
+      }
     }),
   clearResponseBodyFromHistory: () =>
     set((state) => {

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -12,6 +12,8 @@ draft: true
 
 - **Improved Route Updating** We've added some improvements to how we refresh your list of API routes in the Studio.
 
+- **Render audio files** When your api returns a binary audio response, we will render an audio player for you to listen to it.
+
 ### Bug fixes
 
 - **D1 autoinstrumentation** The client library, `@fiberplane/hono-otel`, now instruments D1 queries in latest versions of wrangler/miniflare.
@@ -21,3 +23,5 @@ draft: true
 - **Side panel not closing** Fixed an issue where the side panel would not close when clicking outside of it.
 
 - **Missing log information** Fixed an issue where logs would not be displayed fully in the logs panel.
+
+- **Render images returned from API** Fixed an issue where images returned from an API request made through Studio would not be rendered in the response panel.


### PR DESCRIPTION
Fixes an issue where the "active response" was being cleared from the store whenever a new request returned and we set the new response in history.

The fix was to only clear the "active response" when its traceId does not match the trace of the request we're loading from history.

Aside from that, several components were factored out of the ResponseBody.tsx file, into their own files.

And finally, added the ability to render Audio responses, as a cherry on top.