### PR TITLE
Use optional chains on app_responses because it might be falsy

### DIFF
--- a/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
+++ b/studio/src/pages/RequestorPage/NavigationPanel/RequestsPanel/RequestsPanel.tsx
@@ -275,7 +275,7 @@ const NavItem = memo(({ to, item, isSelected }: NavItemProps) => {
 });
 
 const getId = (item: ProxiedRequestResponse) => {
-  return item.app_responses.traceId || item.app_requests.id.toString();
+  return item.app_responses?.traceId || item.app_requests.id.toString();
 };
 
 const PathCell = ({ item }: { item: ProxiedRequestResponse }) => {
@@ -290,7 +290,7 @@ const PathCell = ({ item }: { item: ProxiedRequestResponse }) => {
 };
 
 const StatusCell = ({ item }: { item: ProxiedRequestResponse }) => {
-  const code = Number.parseInt(item.app_responses.responseStatusCode);
+  const code = Number.parseInt(item.app_responses?.responseStatusCode);
 
   return <Status statusCode={code} />;
 };

--- a/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentProxiedRequestResponse.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/useMostRecentProxiedRequestResponse.tsx
@@ -35,7 +35,7 @@ export function useMostRecentProxiedRequestResponse(
       (r: ProxiedRequestResponse) =>
         r.app_requests?.requestRoute === routePath &&
         r.app_requests?.requestMethod === method &&
-        r.app_responses.traceId &&
+        r.app_responses?.traceId &&
         sessionHistory.includes(r.app_responses?.traceId),
     );
 
@@ -55,7 +55,7 @@ export function useMostRecentProxiedRequestResponse(
       (r: ProxiedRequestResponse) =>
         r?.app_requests?.requestUrl === path &&
         r?.app_requests?.requestMethod === method &&
-        r.app_responses.traceId &&
+        r.app_responses?.traceId &&
         sessionHistory.includes(r.app_responses?.traceId),
     );
 


### PR DESCRIPTION
The `app_responses` property on a proxied request might be blank if a request is cancelled or times out. 

Right now, if that's the case, the UI will break. This PR adds some defense agains that 