### PR TITLE
Do not fire keysequence events on [contenteditable]

### DIFF
--- a/studio/src/components/CodeMirrorEditor/keymaps.ts
+++ b/studio/src/components/CodeMirrorEditor/keymaps.ts
@@ -25,9 +25,12 @@ export const createOnSubmitKeymap = (
   keymap.of([
     {
       key: "Mod-Enter",
-      run: () => {
+      run: (view) => {
         if (onSubmit) {
           onSubmit();
+          // NOTE - It's important for our workflows to blur the editor after the onSubmit function is called
+          //        This way, you can submit a request and then type `g+t` to see the timeline
+          view.contentDOM.blur();
           return true;
         }
         return bubbleWhenNoHandler;

--- a/studio/src/hooks/useKeySequence.ts
+++ b/studio/src/hooks/useKeySequence.ts
@@ -7,6 +7,7 @@ type KeySequenceOptions = {
   isEnabled?: boolean;
   description?: string;
   timeoutMs?: number;
+  ignoreSelector?: string;
 };
 
 /**
@@ -23,7 +24,7 @@ export function useKeySequence(
   onSequenceMatched: () => void,
   options?: KeySequenceOptions,
 ) {
-  const { isEnabled = true, timeoutMs = 2000 } = options ?? {};
+  const { isEnabled = true, timeoutMs = 2000, ignoreSelector } = options ?? {};
 
   const { isInputFocused } = useInputFocusDetection();
 
@@ -48,6 +49,14 @@ export function useKeySequence(
         return;
       }
 
+      if (
+        ignoreSelector &&
+        event.target instanceof HTMLElement &&
+        event.target.matches(ignoreSelector)
+      ) {
+        return;
+      }
+
       currentKeySequenceRef.current = [
         ...currentKeySequenceRef.current,
         event.key,
@@ -65,7 +74,13 @@ export function useKeySequence(
       }
       timeoutIdRef.current = setTimeout(resetKeySequence, timeoutMs);
     },
-    [targetKeySequence, timeoutMs, resetKeySequence, onSequenceMatchedRef],
+    [
+      targetKeySequence,
+      timeoutMs,
+      resetKeySequence,
+      onSequenceMatchedRef,
+      ignoreSelector,
+    ],
   );
 
   useEffect(() => {

--- a/studio/src/pages/RequestorPage/NavigationPanel/NavigationPanel.tsx
+++ b/studio/src/pages/RequestorPage/NavigationPanel/NavigationPanel.tsx
@@ -26,12 +26,20 @@ export function NavigationPanel() {
     setParams({ [FILTER_TAB_KEY]: newTab }, { replace: true });
   });
 
-  useKeySequence(["g", "r"], () => {
-    setTab("routes");
-  });
-  useKeySequence(["g", "a"], () => {
-    setTab("requests");
-  });
+  useKeySequence(
+    ["g", "r"],
+    () => {
+      setTab("routes");
+    },
+    { ignoreSelector: "[contenteditable]" },
+  );
+  useKeySequence(
+    ["g", "a"],
+    () => {
+      setTab("requests");
+    },
+    { ignoreSelector: "[contenteditable]" },
+  );
 
   return (
     <Tabs

--- a/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
+++ b/studio/src/pages/RequestorPage/RequestorPageContent/RequestorPageContent.tsx
@@ -141,7 +141,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
     () => {
       togglePanel("logsPanel");
     },
-    { description: "Open logs panel" },
+    { description: "Open logs panel", ignoreSelector: "[contenteditable]" },
   );
 
   useKeySequence(
@@ -149,7 +149,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
     () => {
       togglePanel("timelinePanel");
     },
-    { description: "Open timeline panel" },
+    { description: "Open timeline panel", ignoreSelector: "[contenteditable]" },
   );
 
   useKeySequence(
@@ -159,6 +159,7 @@ export const RequestorPageContent: React.FC<RequestorPageContentProps> = (
     },
     {
       description: "Open AI assistant panel",
+      ignoreSelector: "[contenteditable]",
     },
   );
 


### PR DESCRIPTION
We want to ignore key sequences coming from input-like elements, like our fancy inputs that are actually contenteditables.

This PR also adds new behavior to submission events triggered from within the CodeMirrorInput component. By default, we now blur the component if there's a submission handler defined. The point here is that you can submit the request from the form, then if you do `g+t` the timeline will pop open. 