### PR TITLE
Fix shared types package

### DIFF
--- a/api/bin/cli.js
+++ b/api/bin/cli.js
@@ -23,7 +23,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const args = process.argv.slice(2);
-// Handle emptystring script (I don't think this happens in practice but let's be defensive)
+// Handle empty string script (I don't think this happens in practice but let's be defensive)
 const script = (args[0] ?? "").trim();
 
 // HACK - If no script is specified, migrate the db then start running studio

--- a/packages/source-analysis/package.json
+++ b/packages/source-analysis/package.json
@@ -5,7 +5,19 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
   },
   "scripts": {
     "build": "tsc && tsc-alias",

--- a/packages/source-analysis/package.json
+++ b/packages/source-analysis/package.json
@@ -5,19 +5,7 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
-    }
-  },
-  "publishConfig": {
-    "access": "public",
-    "exports": {
-      ".": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
-      }
-    }
+    ".": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc && tsc-alias",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,10 +4,19 @@
   "version": "0.0.9",
   "type": "module",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
   },
   "license": "MIT or Apache 2",
   "scripts": {

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -34,14 +34,17 @@ export const AnthropicModelOptions: Partial<
   "claude-3-opus-20240229": "Claude 3 Opus",
   "claude-3-sonnet-20240229": "Claude 3 Sonnet",
   "claude-3-haiku-20240307": "Claude 3 Haiku",
-  "claude-3-5-sonnet-20240620": "Claude 3.5 Sonnet",
+  "claude-3-5-haiku-20241022": "Claude 3.5 Haiku",
+  "claude-3-5-sonnet-20241022": "Claude 3.5 Sonnet",
 };
 
 export const AnthropicModelSchema = z.union([
   z.literal("claude-3-opus-20240229"),
   z.literal("claude-3-sonnet-20240229"),
   z.literal("claude-3-haiku-20240307"),
+  z.literal("claude-3-5-haiku-20241022"),
   z.literal("claude-3-5-sonnet-20240620"),
+  z.literal("claude-3-5-sonnet-20241022"),
 ]);
 
 export type AnthropicModel = z.infer<typeof AnthropicModelSchema>;

--- a/webhonc/tsconfig.json
+++ b/webhonc/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "lib": ["ESNext"],
-    "types": ["@cloudflare/workers-types", "@fiberplane/fpx-types"],
+    "types": ["@cloudflare/workers-types"],
     "jsx": "react-jsx",
     "jsxImportSource": "hono/jsx",
     "rootDir": "."


### PR DESCRIPTION
Shared types have been a bit of a pain to work with. This is an attempt at fixing that.

The gist of it is that we are doing some package.json voodoo to point to `src/*` directly as opposed to `dist/*`. TypeScript imports then resolve in the respective consumers while developing.

Because we are publishing the package to `npm`, we change the `exports` field in `package.json` to point to the `dist/*` files in the `publishConfig` section.
