### PR TITLE
Fix issue with editing bodies in the requestor request view

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.1",
+  "version": "0.11.0",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/packages/source-analysis/package.json
+++ b/packages/source-analysis/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiberplane/source-analysis",
-  "private": true,
-  "version": "0.0.0",
+  "private": false,
+  "version": "0.1.0",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/studio/src/components/CodeMirrorEditor/CodeMirrorTextEditor.tsx
+++ b/studio/src/components/CodeMirrorEditor/CodeMirrorTextEditor.tsx
@@ -1,0 +1,56 @@
+import "./CodeMirrorEditorCssOverrides.css";
+
+import { duotoneDark } from "@uiw/codemirror-theme-duotone";
+import CodeMirror, { basicSetup, EditorView } from "@uiw/react-codemirror";
+import { useMemo } from "react";
+import { createOnSubmitKeymap, escapeKeymap } from "./keymaps";
+import { customTheme, duotonePlaintextOverride } from "./themes";
+
+type CodeMirrorEditorProps = {
+  height?: string;
+  minHeight?: string;
+  maxHeight?: string;
+  theme?: string;
+  readOnly?: boolean;
+  value?: string;
+  onChange: (value?: string) => void;
+  onSubmit?: () => void;
+};
+
+export function CodeMirrorTextEditor(props: CodeMirrorEditorProps) {
+  const {
+    height,
+    value,
+    onChange,
+    readOnly,
+    minHeight = "200px",
+    maxHeight,
+    onSubmit,
+  } = props;
+
+  const extensions = useMemo(
+    () => [
+      createOnSubmitKeymap(onSubmit, false),
+      basicSetup({
+        searchKeymap: false,
+      }),
+      EditorView.lineWrapping,
+      escapeKeymap,
+    ],
+    [onSubmit],
+  );
+
+  return (
+    <CodeMirror
+      value={value}
+      height={height}
+      maxHeight={maxHeight}
+      minHeight={minHeight}
+      extensions={extensions}
+      onChange={onChange}
+      theme={[duotoneDark, duotonePlaintextOverride, customTheme]}
+      readOnly={readOnly}
+      basicSetup={false}
+    />
+  );
+}

--- a/studio/src/components/CodeMirrorEditor/index.ts
+++ b/studio/src/components/CodeMirrorEditor/index.ts
@@ -1,4 +1,5 @@
 export { CodeMirrorSqlEditor } from "./CodeMirrorSqlEditor";
 export { CodeMirrorTypescriptEditor } from "./CodeMirrorTypescriptEditor";
 export { CodeMirrorJsonEditor } from "./CodeMirrorJsonEditor";
+export { CodeMirrorTextEditor } from "./CodeMirrorTextEditor";
 export { CodeMirrorInput } from "./CodeMirrorInput";

--- a/studio/src/components/CodeMirrorEditor/themes.ts
+++ b/studio/src/components/CodeMirrorEditor/themes.ts
@@ -7,3 +7,9 @@ export const customTheme = EditorView.theme({
     background: "transparent !important",
   },
 });
+
+export const duotonePlaintextOverride = EditorView.theme({
+  ".cm-line": {
+    color: "#eeebff",
+  },
+});

--- a/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
+++ b/studio/src/pages/RequestorPage/RequestPanel/RequestPanel.tsx
@@ -16,7 +16,10 @@ import { BottomToolbar } from "./BottomToolbar";
 import { FileUploadForm } from "./FileUploadForm";
 import { PathParamForm } from "./PathParamForm";
 import "./styles.css";
-import { CodeMirrorJsonEditor } from "@/components/CodeMirrorEditor";
+import {
+  CodeMirrorJsonEditor,
+  CodeMirrorTextEditor,
+} from "@/components/CodeMirrorEditor";
 import { useRequestorStore } from "../store";
 
 type RequestPanelProps = {
@@ -236,9 +239,20 @@ export const RequestPanel = memo(function RequestPanel(
               setBody(undefined);
             }}
           />
-          {(body.type === "json" || body.type === "text") && (
-            <CodeMirrorJsonEditor
+          {/* TODO - Have a proper text editor */}
+          {body.type === "text" && (
+            <CodeMirrorTextEditor
               onChange={setBody}
+              value={body.value}
+              maxHeight="800px"
+              onSubmit={onSubmit}
+            />
+          )}
+          {body.type === "json" && (
+            <CodeMirrorJsonEditor
+              onChange={(bodyValue) =>
+                setBody({ type: "json", value: bodyValue })
+              }
               value={body.value}
               maxHeight="800px"
               onSubmit={onSubmit}

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -1,9 +1,10 @@
 ---
-date: 2024-10-18
+date: 2024-10-19
 version: canary
 draft: true
 ---
 
 ### Features
+* Improved code analysis. Through the new @fiberplane/source-analysis package a more flexbile and thorough source code implementation is included
 
 ### Bug fixes


### PR DESCRIPTION
We used the same component to render editable request bodies that were text and json. 

This caused an issue — when we ran `setBody` for json bodies it would change the body type to be `text`. No good.

Also, it make text bodies hard to read.

This PR does the following:

1. Create a new `CodeMirrorTextEditor` component for rendering editable text bodies
2. Modify the RequestPanel to use `CodeMirrorTextEditor` for text bodies, and `CodeMirrorJsonEditor` for json bodies.
3. Set the proper body type of json when editing a json body