### PR TITLE
Update source-analysis publishing configuration

### DIFF
--- a/packages/source-analysis/.npmignore
+++ b/packages/source-analysis/.npmignore
@@ -1,0 +1,56 @@
+node_modules
+vitest.config.ts
+test-cases
+
+
+# Ignore sample related content
+.wrangler
+wrangler.toml
+sample
+
+# do not publish src
+src/*
+
+# do not publish tsconfig
+tsconfig.json
+
+# do not publish biome config
+biome.jsonc
+
+# Change them to your taste:
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb
+
+# mac
+.DS_Store
+
+# env files
+.env
+.envrc
+.dev.vars
+.dev.vars.example
+
+# VS Code
+.vscode/*
+*.code-workspace
+
+# CLion
+.idea
+
+# TypeScript / Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+node_modules
+package-lock.json
+yarn-error.log
+
+# Build tools
+.parcel-cache*
+.nx/cache
+*.tsbuildinfo

--- a/packages/source-analysis/package.json
+++ b/packages/source-analysis/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@fiberplane/source-analysis",
-  "private": false,
   "version": "0.1.0",
   "type": "module",
   "types": "./dist/index.d.ts",
+  "author": "Fiberplane<info@fiberplane.com>",
   "exports": {
     ".": "./dist/index.js"
   },
@@ -15,6 +15,10 @@
     "preview": "vite preview",
     "test": "vitest"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT or Apache 2",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241011.0",
     "@fiberplane/hono-otel": "^0.3.1",


### PR DESCRIPTION
Needed to add some bells and whistles to be able to publish the `source-analysis` package

***

**Update**: This package has been published and tested with studio 0.11.0 (now canary)