### PR TITLE
Remove custom text body component 

### DIFF
--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBody.tsx
@@ -52,7 +52,12 @@ export function ResponseBody({
         <div
           className={cn("overflow-hidden overflow-y-auto w-full", className)}
         >
-          <ResponseBodyText body={body.value} className={className} />
+          <ResponseBodyText
+            body={body.value}
+            className={className}
+            defaultExpanded
+            minHeight="0"
+          />
         </div>
       );
     }
@@ -110,12 +115,15 @@ export function ResponseBody({
       );
     }
 
-    // For text responses, just split into lines and render with rudimentary line numbers
     // TODO - if response is empty, show that in a ux friendly way, with 204 for example
-
     return (
       <div className={cn("overflow-hidden overflow-y-auto w-full", className)}>
-        <ResponseBodyText body={body ?? ""} className={className} />
+        <ResponseBodyText
+          body={body ?? ""}
+          className={className}
+          defaultExpanded
+          minHeight="0"
+        />
       </div>
     );
   }

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
@@ -1,7 +1,7 @@
+import { CodeMirrorTextEditor } from "@/components/CodeMirrorEditor/CodeMirrorTextEditor";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils";
 import { useMemo, useState } from "react";
-import { CodeMirrorTextEditor } from "@/components/CodeMirrorEditor/CodeMirrorTextEditor";
 
 export function ResponseBodyText({
   body,
@@ -9,18 +9,24 @@ export function ResponseBodyText({
   maxPreviewLines = null,
   defaultExpanded = false,
   className,
+  minHeight = "100px",
 }: {
   body: string;
   maxPreviewLength?: number | null;
   maxPreviewLines?: number | null;
   defaultExpanded?: boolean;
   className?: string;
+  minHeight?: string;
 }) {
   const [isExpanded, setIsExpanded] = useState(!!defaultExpanded);
   const toggleIsExpanded = () => setIsExpanded((e) => !e);
 
-  const { previewBody, hiddenLinesCount, hiddenCharsCount, shouldShowExpandButton } =
-    useTextPreview(body, isExpanded, maxPreviewLength, maxPreviewLines);
+  const {
+    previewBody,
+    hiddenLinesCount,
+    hiddenCharsCount,
+    shouldShowExpandButton,
+  } = useTextPreview(body, isExpanded, maxPreviewLength, maxPreviewLines);
 
   return (
     <div className={cn("w-full", className)}>
@@ -28,10 +34,10 @@ export function ResponseBodyText({
         value={isExpanded ? body : previewBody}
         readOnly={true}
         onChange={() => {}}
-        minHeight="100px"
-        maxHeight={isExpanded ? undefined : "300px"}
+        minHeight={minHeight}
+        maxHeight={isExpanded ? "800px" : "300px"}
       />
-      
+
       {shouldShowExpandButton && (
         <div
           className={cn(
@@ -87,7 +93,11 @@ function useTextPreview(
     }
 
     let previewLines = previewBody?.split("\n");
-    if (maxPreviewLines && !isExpanded && previewLines.length > maxPreviewLines) {
+    if (
+      maxPreviewLines &&
+      !isExpanded &&
+      previewLines.length > maxPreviewLines
+    ) {
       previewLines = previewLines.slice(0, maxPreviewLines);
       previewBody = `${previewLines.join("\n")}...`;
       hiddenLinesCount = allLinesCount - previewLines.length;

--- a/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
+++ b/studio/src/pages/RequestorPage/ResponsePanel/ResponseBody/ResponseBodyText.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/utils";
 import { useMemo, useState } from "react";
+import { CodeMirrorTextEditor } from "@/components/CodeMirrorEditor/CodeMirrorTextEditor";
 
 export function ResponseBodyText({
   body,
@@ -18,19 +19,19 @@ export function ResponseBodyText({
   const [isExpanded, setIsExpanded] = useState(!!defaultExpanded);
   const toggleIsExpanded = () => setIsExpanded((e) => !e);
 
-  // For text responses, just split into lines and render with rudimentary line numbers
-  const { lines, hiddenLinesCount, hiddenCharsCount, shouldShowExpandButton } =
+  const { previewBody, hiddenLinesCount, hiddenCharsCount, shouldShowExpandButton } =
     useTextPreview(body, isExpanded, maxPreviewLength, maxPreviewLines);
 
-  // TODO - if response is empty, show that in a ux friendly way, with 204 for example
-
   return (
-    <div
-      className={cn("overflow-hidden overflow-y-auto w-full py-2", className)}
-    >
-      <pre className="text-sm font-mono text-gray-300 whitespace-pre-wrap">
-        <code className="h-full">{lines}</code>
-      </pre>
+    <div className={cn("w-full", className)}>
+      <CodeMirrorTextEditor
+        value={isExpanded ? body : previewBody}
+        readOnly={true}
+        onChange={() => {}}
+        minHeight="100px"
+        maxHeight={isExpanded ? undefined : "300px"}
+      />
+      
       {shouldShowExpandButton && (
         <div
           className={cn(
@@ -78,7 +79,7 @@ function useTextPreview(
       ? allLinesCount > maxPreviewLines
       : false;
 
-    // If we're not expanded, we want to show a preview of the body depending on the maxPreviewLength
+    // If we're not expanded, we want to show a preview of the body
     let previewBody = body;
     if (maxPreviewLength && exceedsMaxPreviewLength && !isExpanded) {
       previewBody = body ? `${body.slice(0, maxPreviewLength)}...` : "";
@@ -86,29 +87,14 @@ function useTextPreview(
     }
 
     let previewLines = previewBody?.split("\n");
-    if (
-      maxPreviewLines &&
-      !isExpanded &&
-      previewLines.length > maxPreviewLines
-    ) {
+    if (maxPreviewLines && !isExpanded && previewLines.length > maxPreviewLines) {
       previewLines = previewLines.slice(0, maxPreviewLines);
       previewBody = `${previewLines.join("\n")}...`;
       hiddenLinesCount = allLinesCount - previewLines.length;
     }
 
-    const lines = (isExpanded ? body : previewBody)
-      ?.split("\n")
-      ?.map((line, index) => (
-        <div key={index} className="flex h-full">
-          <span className="w-8 text-right pr-2 text-gray-500 bg-muted mr-1">
-            {index + 1}
-          </span>
-          <span>{line}</span>
-        </div>
-      ));
-
     return {
-      lines,
+      previewBody,
       shouldShowExpandButton: exceedsMaxPreviewLength || exceedsMaxPreviewLines,
       hiddenLinesCount,
       hiddenCharsCount,


### PR DESCRIPTION
For requestor responses, if the response is text (or html for that matter) we will render it inside a ridiculous hand crafted component I wrote in the summer.

This led to some wonkiness with misaligned line numbering, overflow, etc.

This PR modifies the Response panel to use the new `CodeMirrorTextEditor` component (set to readonly) in order to render these text responses a little more cleanly

Before:

<img width="1578" alt="image" src="https://github.com/user-attachments/assets/fa1e8110-e62c-47c1-ac5b-dbf50d5930f3">

After:

<img width="1574" alt="image" src="https://github.com/user-attachments/assets/3812134f-aa2e-4c3d-b7c8-ccdd1eba6e00">
