### PR TITLE
Update client library docs + README to mention cf binding instrumentation

### DIFF
--- a/packages/client-library-otel/README.md
+++ b/packages/client-library-otel/README.md
@@ -1,4 +1,4 @@
-# Fiberplane Hono Opentelemetry Library
+# Fiberplane Hono OpenTelemetry Library
 
 This is a client library that will send telemetry data to a *local* Fiberplane Studio server upon every incoming request and outgoing response, in order to be visualized in the Studio UI.
 

--- a/packages/client-library-otel/README.md
+++ b/packages/client-library-otel/README.md
@@ -25,7 +25,7 @@ npm create hono@latest my-hono-project
 Install the Fiberplane Hono Opentelemetry Library
 
 ```sh
-npm i @fiberplane/hono-otel@beta
+npm i @fiberplane/hono-otel
 ```
 
 Add middleware to your project
@@ -61,10 +61,12 @@ It assumes you already have a Hono app running locally.
 
 ### Installation
 
-Install the library in your project. At writing, the library is in beta, so you need to install it with the `@beta` tag:
+Install the library in your project. If you're feeling adventurous, you can install the `canary` version:
 
 ```bash
-npm install @fiberplane/hono-otel@beta
+npm install @fiberplane/hono-otel@latest
+# or
+npm install @fiberplane/hono-otel@canary
 ```
 
 Wrap your Hono app with the `instrument` function:
@@ -111,7 +113,7 @@ The options are:
 
 - `monitor.fetch`: Whether to create traces for all fetch requests. (Default: `true`)
 - `monitor.logging`: Whether to proxy `console.*` functions to send logging data to a local Fiberplane Studio server. (Default: `true`)
-- `monitor.cfBindings`: Whether to proxy Cloudflare bindings (D1, R2, KV, AI) to add instrumentation to them. (Default: `false`)
+- `monitor.cfBindings`: Whether to proxy Cloudflare bindings (D1, R2, KV, AI) to add instrumentation to them. (Default: `true`)
 - `libraryDebugMode`: Whether to enable debug logging in the library. (Default: `false`)
 
 Here is an example:
@@ -128,12 +130,12 @@ export default instrument(app, {
   // Enable debug logging in the library
   libraryDebugMode: true,
   monitor: {
-    // Don't create traces for fetch requests
+    // Do not create traces for fetch requests
     fetch: false,
-    // Don't proxy `console.*` functions to send logging data to a local FPX server
+    // Do not proxy `console.*` functions to send logging data to a local FPX server
     logging: false,
-    // Proxy Cloudflare bindings (D1, R2, KV, AI) to add instrumentation to them
-    cfBindings: true,
+    // Do not proxy Cloudflare bindings (D1, R2, KV, AI, Service Bindings) to add instrumentation to them
+    cfBindings: false,
   },
 });
 ```

--- a/packages/client-library-otel/README.md
+++ b/packages/client-library-otel/README.md
@@ -1,6 +1,4 @@
-# Fiberplane Hono Opentelemetry Library (BETA)
-
-> **Note:** This library is in beta, and is still under active development.
+# Fiberplane Hono Opentelemetry Library
 
 This is a client library that will send telemetry data to a *local* Fiberplane Studio server upon every incoming request and outgoing response, in order to be visualized in the Studio UI.
 

--- a/www/src/content/docs/docs/components/client-library.mdx
+++ b/www/src/content/docs/docs/components/client-library.mdx
@@ -90,6 +90,8 @@ The client library allows you to override the default behavior of the `instrumen
 
 By default, `instrument` will change the behavior of `fetch` and `console.*` methods, in order to produce telemetry data for all `fetch` requests and logging events.
 
+If your code runs inside a Cloudflare Worker, then the client library also proxies Cloudflare bindings automatically.
+
 You can disable these features by setting the following configuration parameters to `false`:
 
 ```js ins={9-14} title="index.ts"
@@ -105,9 +107,27 @@ export default instrument(app, {
     // Don't create traces for fetch requests
     fetch: false,
     // Don't proxy `console.*` functions to send logging data to a local FPX server
-    logging: false
-  }
+    logging: false,
+    // Don't proxy Cloudflare bindings automatically
+    cfBindings: false,
+  },
 });
 ```
+
+### Autoinstrumented Cloudflare bindings
+
+If your code runs inside a Cloudflare Worker, then the client library also proxies the following Cloudflare bindings automatically:
+
+- R2
+- Workers Ai
+- KV
+- D1
+- Service Bindings to other Cloudflare Workers
+
+These will show up as spans in your request timeline in Fiberplane Studio, along with relevant metadata and request context.
+
+For instance, you can see the SQL query executed on D1, the R2 bucket that was accessed, or the arguments passed to the service binding to another Cloudflare Worker.
+
+***
 
 To explore more of what the client library can do, check out the code on [Github](https://github.com/fiberplane/fpx/tree/main/packages/client-library-otel).


### PR DESCRIPTION
Two things:

- Update the docs page to mention Cloudflare bindings instrumentation
- Update the client library readme because it was rather out of date in general (still mentioned the `@beta` tag everywhere) 