### PR TITLE
Fix invocations of `fetch` with Worker service bindings

### DIFF
--- a/examples/service-bindings/meow/src/index.ts
+++ b/examples/service-bindings/meow/src/index.ts
@@ -15,4 +15,15 @@ app.get("/", async (c) => {
   return c.text(`Meow from above! ☁️🪿🐈 (But dog says "${bark}")`);
 });
 
+app.get("/geese-to-bark-at", async (c) => {
+  const geeseResponse = await c.env.WOOF.fetch(c.req.raw);
+  try {
+    const geese = await geeseResponse.json();
+    console.log(geese);
+    return c.json(geese as Array<unknown>);
+  } catch (_e) {
+    return c.json({ error: "Failed to parse geese response as JSON" }, 500);
+  }
+});
+
 export default instrument(app);

--- a/examples/service-bindings/woof/src/index.ts
+++ b/examples/service-bindings/woof/src/index.ts
@@ -17,8 +17,8 @@ export class WoofWorker extends WorkerEntrypoint {
 
   // From Cloudflare docs: "Currently, entrypoints without a named handler are not supported"
   // TODO - Check if this is still the case that we need a fetch handler?
-  async fetch() {
-    return new Response(null, { status: 404 });
+  async fetch(request: Request | string) {
+    return fetch("https://placegoose.mies.workers.dev/geese");
   }
 }
 

--- a/examples/service-bindings/woof/src/index.ts
+++ b/examples/service-bindings/woof/src/index.ts
@@ -17,7 +17,7 @@ export class WoofWorker extends WorkerEntrypoint {
 
   // From Cloudflare docs: "Currently, entrypoints without a named handler are not supported"
   // TODO - Check if this is still the case that we need a fetch handler?
-  async fetch(request: Request | string) {
+  async fetch(_request: Request | string) {
     return fetch("https://placegoose.mies.workers.dev/geese");
   }
 }

--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/packages/client-library-otel/src/patch/cf-bindings.ts
+++ b/packages/client-library-otel/src/patch/cf-bindings.ts
@@ -161,6 +161,11 @@ function proxyServiceBinding(o: object, bindingName: string) {
         // The name for the span, which will show up in the UI
         const name = `${bindingName}.${serviceMethod}`;
 
+        // For the `fetch` method, we need to bind `this` (the javascript `this` keyword) to the service target,
+        // otherwise `fetch` will fail!
+        // For RPC calls we do not need to do any special `this` binding
+        const shouldBindThis = serviceMethod === "fetch";
+
         const measuredBinding = measure(
           {
             name,
@@ -181,7 +186,7 @@ function proxyServiceBinding(o: object, bindingName: string) {
             },
             onError: handleError,
           },
-          serviceValue,
+          shouldBindThis ? serviceValue.bind(serviceTarget) : serviceValue,
         );
 
         return measuredBinding;


### PR DESCRIPTION
Updates the client library to correctly proxy `fetch` calls to service bindings

The issue was that calling `fetch` on a worker service binding required the proxied `fetch` to still be bound to the WorkerEntrypoint. Basically, the client library needs to have some special logic for when it wraps `fetch` in a call to `measure`