### PR TITLE
Update all the versions to be in line with what is published

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.2",
+  "version": "0.12.3",
   "name": "@fiberplane/studio",
   "description": "Local development debugging interface for Hono apps",
   "author": "Fiberplane<info@fiberplane.com>",

--- a/packages/source-analysis/package.json
+++ b/packages/source-analysis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/source-analysis",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "types": "./dist/index.d.ts",
   "author": "Fiberplane<info@fiberplane.com>",


### PR DESCRIPTION
Ran into issues when publishing a canary because package.json versions were not in sync 

This PR fixes 