### PR TITLE
Add tooltip for sidebar toggle

### DIFF
--- a/studio/src/Layout/SidePanel/SidePanelTrigger.tsx
+++ b/studio/src/Layout/SidePanel/SidePanelTrigger.tsx
@@ -1,5 +1,12 @@
+import { KeyboardShortcutKey } from "@/components/KeyboardShortcut";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useRequestorStore } from "@/pages/RequestorPage/store";
+import { isMac } from "@/utils";
 import { Icon } from "@iconify/react/dist/iconify.js";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -14,15 +21,29 @@ export function SidePanelTrigger() {
   });
 
   return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="p-0.5 w-6 h-6"
-      onClick={() => togglePanel("sidePanel")}
-    >
-      <Icon
-        icon={`lucide:panel-left-${sidePanel === "open" ? "close" : "open"}`}
-      />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="p-0.5 w-6 h-6"
+          onClick={() => togglePanel("sidePanel")}
+        >
+          <Icon
+            icon={`lucide:panel-left-${sidePanel === "open" ? "close" : "open"}`}
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        className="bg-slate-900 px-2 py-1.5 text-white flex gap-1.5"
+        align="start"
+      >
+        Open Side Panel
+        <div className="flex gap-0.5">
+          <KeyboardShortcutKey>{isMac ? "⌘" : "Ctrl"}</KeyboardShortcutKey>{" "}
+          <KeyboardShortcutKey>B</KeyboardShortcutKey>
+        </div>
+      </TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
We didn't have a tooltip explaining the keyboard shortcut for the sidepanel (thanks @ambergristle)

<img width="198" alt="image" src="https://github.com/user-attachments/assets/0de6359d-8606-49c4-bf5c-eedcbafd035b">
