### PR TITLE
Fix client library issue 

### DIFF
--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/packages/client-library-otel/src/patch/cf-bindings.ts
+++ b/packages/client-library-otel/src/patch/cf-bindings.ts
@@ -427,7 +427,7 @@ function isCloudflareKVBinding(o: unknown) {
  * ```
  */
 function getConstructorName(o: unknown) {
-  return Object.getPrototypeOf(o).constructor.name;
+  return Object.getPrototypeOf(o)?.constructor?.name;
 }
 
 /**

--- a/www/src/content/changelog/!canary.mdx
+++ b/www/src/content/changelog/!canary.mdx
@@ -11,3 +11,5 @@ draft: true
 - Fixed issue where the payload (body) of certain historical requests was not displayed in studio request UI.
 - Fixed issue where websocket connections timed out after a minute of inactivity in studio.
 - Fixed issue where ordering of historical requests was incorrect.
+
+- Client library: Fixed issue where an environment binding with a `null` prototype would cause a runtime error.


### PR DESCRIPTION
We called `getPrototype` on an object to get its constructor name, but if the constructor prototype was null, then we'd crash the user's api

This fixes the issue