### PR TITLE
Rip out use of Hono router in the UI for path matching logic

### DIFF
--- a/.github/workflows/build_frontends.yml
+++ b/.github/workflows/build_frontends.yml
@@ -8,12 +8,14 @@ on:
       - "api/**"
       - "packages/client-library-otel/**"
       - "studio/**"
+      - "playground/**"
   push:
     branches: ["main", "release-*"]
     paths:
       - "api/**"
       - "packages/client-library-otel/**"
       - "studio/**"
+      - "playground/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -65,6 +67,9 @@ jobs:
         run: pnpm --recursive typecheck
 
       # Testing
+
+      - name: Test Playground
+        run: pnpm --filter @fiberplane/playground test
 
       - name: Test Studio API
         run: pnpm --filter @fiberplane/studio test

--- a/playground/package.json
+++ b/playground/package.json
@@ -56,7 +56,6 @@
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",
     "date-fns": "^4.1.0",
-    "hono": "^4.6.16",
     "lucide-react": "^0.471.1",
     "openapi-types": "^12.1.3",
     "proxy-memoize": "^3.0.1",

--- a/playground/src/components/playground/queries/hooks/fiberplane-embedded/spec-to-api-routes.ts
+++ b/playground/src/components/playground/queries/hooks/fiberplane-embedded/spec-to-api-routes.ts
@@ -15,9 +15,6 @@ export function specToApiRoutes(
 
   // Iterate through paths and methods to create ApiRoute objects
   for (const [path, pathItem] of Object.entries(spec.paths)) {
-    // Convert {param} to :param in path
-    const transformedPath = path.replace(/\{([^}]+)\}/g, ":$1");
-
     for (const [method, operation] of Object.entries(pathItem)) {
       const upperMethod = method.toUpperCase();
       if (isValidMethod(upperMethod)) {
@@ -28,9 +25,10 @@ export function specToApiRoutes(
           new Set(),
           new Map(),
         );
+
         routes.push({
           id,
-          path: transformedPath,
+          path,
           method: upperMethod,
           // `summary` is the succint title of the operation
           summary: dereferencedOperation.summary,

--- a/playground/src/components/playground/routes/index.ts
+++ b/playground/src/components/playground/routes/index.ts
@@ -1,2 +1,2 @@
 export { useRoutes } from "./hooks";
-export { findMatchedRoute, findAllSmartRouterMatches } from "./match";
+export { findMatchedRoute } from "./match";

--- a/playground/src/components/playground/routes/match.test.ts
+++ b/playground/src/components/playground/routes/match.test.ts
@@ -1,15 +1,9 @@
 import type { ApiRoute, RequestMethod } from "../types";
-import { findFirstSmartRouterMatch } from "./match";
-
-const toRoute = (
-  path: string,
-  method: RequestMethod,
-  registrationOrder = -1,
-) => ({
+import { findMatchedRoute } from "./match";
+const toRoute = (path: string, method: RequestMethod) => ({
   id: 1,
   path,
   method,
-  registrationOrder,
   openApiSpec: null,
 });
 
@@ -17,52 +11,37 @@ describe("findSmartRouterMatch", () => {
   const routes: ApiRoute[] = [
     toRoute("/test", "GET"),
     toRoute("/test", "POST"),
-    toRoute("/users/:userId", "GET"),
-    toRoute("/users/:userId", "PATCH"),
-    toRoute("/users/:userId/comments/:commentId", "GET"),
-    toRoute("/users/:userId/comments/:commentId", "PATCH"),
+    toRoute("/users/{userId}", "GET"),
+    toRoute("/users/{userId}", "PATCH"),
+    toRoute("/users/{userId}/comments/{commentId}", "GET"),
+    toRoute("/users/{userId}/comments/{commentId}", "PATCH"),
     toRoute("/ws", "GET"),
   ];
 
   it("should return a match for the given pathname and method", () => {
-    const match = findFirstSmartRouterMatch(routes, "/test", "GET");
+    const match = findMatchedRoute(routes, "/test", "GET");
     expect(match).toBeTruthy();
   });
 
   it("should return a match for the given pathname and method", () => {
-    const match = findFirstSmartRouterMatch(routes, "/test", "POST");
+    const match = findMatchedRoute(routes, "/test", "POST");
     expect(match).toBeTruthy();
   });
 
   // NOTE - Basically just testing router behavior but this is a sanity check for me
   it("should return null if no match is found (params in route)", () => {
-    const match = findFirstSmartRouterMatch(routes, "/users", "GET");
+    const match = findMatchedRoute(routes, "/users", "GET");
     expect(match).toBeNull();
   });
 
   it("should return a match for the given pathname and method", () => {
-    const match = findFirstSmartRouterMatch(routes, "/users/1", "GET");
+    const match = findMatchedRoute(routes, "/users/1", "GET");
     expect(match).toBeTruthy();
     expect(match?.route).toBeDefined();
     expect(match?.route?.method).toBe("GET");
-    expect(match?.route?.path).toBe("/users/:userId");
+    expect(match?.route?.path).toBe("/users/{userId}");
     expect(match?.pathParams).toMatchObject({
       userId: "1",
     });
-  });
-});
-
-describe("findFirstSmartRouterMatch - registered routes precedence", () => {
-  const routes: ApiRoute[] = [
-    // Unregesterd route - should not be matched first
-    toRoute("/test/:k", "GET", -1),
-    // Registered route - should be matched first
-    toRoute("/test/:key", "GET", 1),
-  ];
-
-  it("should return registered route with higher precedence", () => {
-    const match = findFirstSmartRouterMatch(routes, "/test/123", "GET");
-    expect(match).toBeTruthy();
-    expect(match?.route?.path).toBe("/test/:key");
   });
 });

--- a/playground/src/components/playground/routes/match.ts
+++ b/playground/src/components/playground/routes/match.ts
@@ -1,7 +1,3 @@
-import type { ParamIndexMap, ParamStash } from "hono/router";
-import { RegExpRouter } from "hono/router/reg-exp-router";
-import { SmartRouter } from "hono/router/smart-router";
-import { TrieRouter } from "hono/router/trie-router";
 import type { ApiRoute } from "../types";
 
 type MatchedRouteResult = {
@@ -12,179 +8,63 @@ type MatchedRouteResult = {
 } | null;
 
 /**
- * Looks for a single matching route given the pathname, method, and request type
- * Precedence should always occur as follows:
- * - First checks registered routes
- * - Then checks unregistered routes
- *
- * As of writing, precedence is enforced via sorting the routes (in a helper function for finding smart router matches)
- *
- * If the router throws an error when matching, we return the first route that matches exactly on:
- * - pathname
- * - method
- * - requestType
- *
- * @param routes
- * @param pathname
- * @param method
- * @param requestType
- * @returns
+ * Converts an OpenAPI-style path pattern to a regex pattern
+ * e.g. /users/{id} -> /users/([^/]+)
+ */
+function pathToRegex(path: string): RegExp {
+  const pattern = path.replace(/\{([^}]+)\}/g, "([^/]+)");
+  return new RegExp(`^${pattern}$`);
+}
+
+/**
+ * Extracts parameter names from an OpenAPI-style path
+ * e.g. /users/{id}/posts/{postId} -> ["id", "postId"]
+ */
+function extractParamNames(path: string): string[] {
+  const matches = path.match(/\{([^}]+)\}/g) || [];
+  return matches.map((match) => match.slice(1, -1));
+}
+
+/**
+ * Looks for a single matching route given the pathname and method
  */
 export function findMatchedRoute(
   routes: ApiRoute[],
   pathname: string | undefined,
   method: string | undefined,
 ): MatchedRouteResult {
-  if (pathname && method) {
-    const smartMatch = findFirstSmartRouterMatch(routes, pathname, method);
-
-    if (smartMatch?.route) {
-      return { route: smartMatch.route, pathParams: smartMatch.pathParams };
-    }
+  if (!pathname || !method) {
+    return null;
   }
 
-  // HACK - This is a backup in case the smart router throws an error
   for (const route of routes) {
-    if (route.path === pathname && route.method === method) {
+    if (route.method !== method) {
+      continue;
+    }
+
+    // Exact match
+    if (route.path === pathname) {
       return { route };
+    }
+
+    // Check for parameterized match
+    const regex = pathToRegex(route.path);
+    const match = pathname.match(regex);
+
+    if (match) {
+      const paramNames = extractParamNames(route.path);
+      const paramValues = match.slice(1); // First element is the full match
+
+      const pathParams = Object.fromEntries(
+        paramNames.map((name, index) => [name, paramValues[index]]),
+      );
+
+      return {
+        route,
+        pathParams,
+      };
     }
   }
 
   return null;
 }
-
-/**
- * Return the first matching route (or middleware!) from the smart router
- */
-export function findFirstSmartRouterMatch(
-  routes: ApiRoute[],
-  pathname: string,
-  method: string,
-) {
-  return findAllSmartRouterMatches(routes, pathname, method)?.[0] ?? null;
-}
-
-/**
- * Returns all matching routes (or middleware!) from the smart router
- *
- * @TODO - Remove this eventually as we no longer want to be tied to Hono for route matching on the frontend.
- */
-export function findAllSmartRouterMatches(
-  unsortedRoutes: ApiRoute[],
-  pathname: string,
-  method: string,
-) {
-  const routes = [...unsortedRoutes];
-
-  // HACK - We need to be able to associate route handlers back to the ApiRoute definition
-  const functionHandlerLookupTable: Map<() => void, ApiRoute> = new Map();
-
-  const routers = [new RegExpRouter(), new TrieRouter()];
-  const router = new SmartRouter({ routers });
-  for (const route of routes) {
-    if (route.method && route.path) {
-      const handler = () => {};
-      router.add(route.method, route.path, handler);
-      // Add the noop handler to the lookup table,
-      // so if there's a match, we can use the handler to look up the OG route definition
-      functionHandlerLookupTable.set(handler, route);
-    }
-  }
-
-  // Matching against a pathname like `/users/:` will throw,
-  // so we need to be defensive
-  try {
-    const match = router.match(method, pathname);
-    const allAreEmpty = isMatchResultEmpty(match);
-
-    if (allAreEmpty) {
-      return null;
-    }
-
-    const matches = unpackMatches(match);
-
-    if (matches.length === 0) {
-      return null;
-    }
-
-    const routeMatches = matches.map((match) => {
-      const handler = match[0];
-      const pathParams = match[1];
-      return {
-        route: functionHandlerLookupTable.get(handler as () => void),
-        pathParams,
-      };
-    });
-
-    return routeMatches;
-  } catch (e) {
-    console.error("Error matching routes", e);
-    return null;
-  }
-}
-
-// type Result<T> = [[T, ParamIndexMap][], ParamStash] | [[T, Params][]]
-//
-// - [unknown, Params][] = [unknown, Record<P extends string, string | string[]>]
-// - [unknown, ParamIndexMap][] = [unknown, Record<string, number>]
-// - ParamStash = string[]
-const isMatchResultEmpty = <R extends SmartRouter<T>, T>(
-  result: ReturnType<R["match"]>,
-) => {
-  if (result.length === 2) {
-    return result[0].every((m) => {
-      return m[0] === undefined && m[1] === undefined;
-    });
-  }
-  if (result.length === 1) {
-    return result.every((m) => {
-      return m[0] === undefined && m[1] === undefined;
-    });
-  }
-};
-
-/**
- * Transforms a route match result into an array of matches with path parameter values
- */
-const unpackMatches = <R extends SmartRouter<T>, T>(
-  result: ReturnType<R["match"]>,
-) => {
-  const matches = [];
-  if (result.length === 2) {
-    for (const m of result[0]) {
-      if (m[0] !== undefined) {
-        const handler = m[0];
-        const paramIndexMap = m[1];
-        const paramStash = result[1];
-        const pathParams = paramIndexMapToObject(paramIndexMap, paramStash);
-        matches.push([handler, pathParams] as [
-          unknown,
-          Record<string, string>,
-        ]);
-      }
-    }
-  }
-  if (result.length === 1) {
-    for (const m of result[0]) {
-      if (m[0] !== undefined) {
-        matches.push(m);
-      }
-    }
-  }
-  return matches;
-};
-
-const paramIndexMapToObject = (
-  paramIndexMap: ParamIndexMap,
-  paramStash: ParamStash,
-): Record<string, string> => {
-  return Object.fromEntries(
-    Object.entries(paramIndexMap).map(([key, value]) => {
-      // For a RegExpRouter, the paramStash is the result of a regex match
-      // and the values are the indices of the parsed values in the match
-      // so we need to map the indices to the actual values
-      const actualValue = paramStash?.[value];
-      return [key, actualValue];
-    }),
-  );
-};

--- a/playground/src/components/playground/store/slices/requestResponseSlice.ts
+++ b/playground/src/components/playground/store/slices/requestResponseSlice.ts
@@ -11,9 +11,9 @@ import {
   addBaseUrl,
   extractMatchedPathParams,
   extractPathParams,
-  insertPathParams,
   mapPathParamKey,
   removeBaseUrl,
+  resolvePathWithParameters,
 } from "../utils";
 import {
   generateFakeData,
@@ -60,7 +60,6 @@ export const requestResponseSlice: StateCreator<
       }
 
       const fakeData = generateFakeData(openApiSpec, activeRoute.path);
-
       // Transform data to match form state types
       set((state) => {
         state.body = transformToFormBody(fakeData.body);
@@ -81,8 +80,8 @@ export const requestResponseSlice: StateCreator<
           }),
         );
         if (fakePathParams.length > 0) {
-          // NOTE - Do not call `setPathParams` here, it messes with the form
-          const nextPath = insertPathParams(
+          // NOTE - Do not call `state.setPathParams(...)` here, it messes with the form inputs and clears the path params
+          const nextPath = resolvePathWithParameters(
             state.activeRoute?.path ?? state.path,
             fakePathParams,
           );
@@ -157,7 +156,7 @@ export const requestResponseSlice: StateCreator<
 
   setPathParams: (pathParams) =>
     set((state) => {
-      const nextPath = insertPathParams(
+      const nextPath = resolvePathWithParameters(
         state.activeRoute?.path ?? state.path,
         pathParams,
       );

--- a/playground/src/components/playground/store/slices/requestResponseSlice.ts
+++ b/playground/src/components/playground/store/slices/requestResponseSlice.ts
@@ -11,6 +11,7 @@ import {
   addBaseUrl,
   extractMatchedPathParams,
   extractPathParams,
+  insertPathParams,
   mapPathParamKey,
   removeBaseUrl,
 } from "../utils";
@@ -80,12 +81,11 @@ export const requestResponseSlice: StateCreator<
           }),
         );
         if (fakePathParams.length > 0) {
-          const nextPath = fakePathParams.reduce((accPath, param) => {
-            if (param.enabled) {
-              return accPath.replace(`:${param.key}`, param.value || param.key);
-            }
-            return accPath;
-          }, state.activeRoute?.path ?? state.path);
+          // NOTE - Do not call `setPathParams` here, it messes with the form
+          const nextPath = insertPathParams(
+            state.activeRoute?.path ?? state.path,
+            fakePathParams,
+          );
           state.path = addBaseUrl(state.serviceBaseUrl, nextPath);
           state.pathParams = fakePathParams;
         }
@@ -157,12 +157,10 @@ export const requestResponseSlice: StateCreator<
 
   setPathParams: (pathParams) =>
     set((state) => {
-      const nextPath = pathParams.reduce((accPath, param) => {
-        if (param.enabled) {
-          return accPath.replace(`:${param.key}`, param.value || param.key);
-        }
-        return accPath;
-      }, state.activeRoute?.path ?? state.path);
+      const nextPath = insertPathParams(
+        state.activeRoute?.path ?? state.path,
+        pathParams,
+      );
       state.path = addBaseUrl(state.serviceBaseUrl, nextPath);
       state.pathParams = pathParams;
     }),

--- a/playground/src/components/playground/store/utils-faker.ts
+++ b/playground/src/components/playground/store/utils-faker.ts
@@ -2,6 +2,7 @@ import type {
   OpenAPIOperation,
   OpenAPISchema,
 } from "../RequestPanel/RouteDocumentation";
+import { extractPathParams } from "./utils";
 
 type FakeDataOutput = {
   queryParams: Record<string, string>;
@@ -9,11 +10,6 @@ type FakeDataOutput = {
   pathParams: Record<string, string>;
   body: unknown;
 };
-
-function extractPathParams(path: string): string[] {
-  const matches = path.match(/:[a-zA-Z_][a-zA-Z0-9_]*/g);
-  return matches ? matches.map((m) => m.slice(1)) : [];
-}
 
 function generateSmartFakeValue(
   schema: OpenAPISchema,

--- a/playground/src/components/playground/store/utils.ts
+++ b/playground/src/components/playground/store/utils.ts
@@ -2,7 +2,7 @@ import type { findMatchedRoute } from "../routes";
 import type { ApiRoute } from "../types";
 import type { RequestMethod } from "../types";
 import type { Authorization } from "./slices/settingsSlice";
-import type { PlaygroundState } from "./types";
+import type { KeyValueParameter, PlaygroundState } from "./types";
 
 export const _getActiveRoute = (state: PlaygroundState): ApiRoute => {
   return (
@@ -40,18 +40,16 @@ export function apiRouteToInputMethod(route: ApiRoute): RequestMethod {
 }
 
 /**
- * Extracts path parameters from a path
- *
- * @TODO - Rewrite to use Hono router
+ * Extracts path parameters from a path using OpenAPI-style format
+ * e.g. /users/{id} instead of /users/:id
  *
  * @param path
  * @returns
  */
 export function extractPathParams(path: string) {
-  const regex = /\/(:[a-zA-Z0-9_-]+)/g;
+  const regex = /\/{([^}]+)}/g;
 
   const result: Array<string> = [];
-  // let match = regex.exec(path);
   let lastIndex = -1;
   while (true) {
     const match = regex.exec(path);
@@ -66,9 +64,9 @@ export function extractPathParams(path: string) {
     }
     lastIndex = regex.lastIndex;
 
-    // HACK - Remove the `:` at the beginning of the match, to make things consistent with Hono router path param matching
-    const keyWithoutColon = match[1].slice(1);
-    result.push(keyWithoutColon);
+    // Extract the parameter name from inside the curly braces
+    const paramName = match[1];
+    result.push(paramName);
   }
   return result;
 }
@@ -81,13 +79,22 @@ export function extractMatchedPathParams(
   matchedRoute: ReturnType<typeof findMatchedRoute>,
 ) {
   return Object.entries(matchedRoute?.pathParams ?? {}).map(([key, value]) => {
-    const nextValue = value === `:${key}` ? "" : value;
+    const nextValue = value === `{${key}}` ? "" : value;
     return {
       ...mapPathParamKey(key),
       value: nextValue,
       enabled: !!nextValue,
     };
   });
+}
+
+export function insertPathParams(
+  path: string,
+  pathParams: KeyValueParameter[],
+) {
+  return pathParams.reduce((acc, param) => {
+    return acc.replace(`{${param.key}}`, param.value || param.key);
+  }, path);
 }
 
 /**

--- a/playground/src/components/playground/store/utils.ts
+++ b/playground/src/components/playground/store/utils.ts
@@ -88,7 +88,11 @@ export function extractMatchedPathParams(
   });
 }
 
-export function insertPathParams(
+/**
+ * Given an OpenAPI path and a list of path parameters,
+ * replace the path parameters in the path with the actual values
+ */
+export function resolvePathWithParameters(
   path: string,
   pathParams: KeyValueParameter[],
 ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,9 +958,6 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
-      hono:
-        specifier: ^4.6.16
-        version: 4.6.16
       lucide-react:
         specifier: ^0.471.1
         version: 0.471.1(react@18.3.1)


### PR DESCRIPTION
- Switch to using OpenAPI-style paths (`/users/{id}` instead of `/users/:id`)
- Remove dependency on Hono's router(s) for determining matching routes in the sidebar and extracting path parameters
- Remove Hono from package.json
- Run `playground` tests in CI