### PR TITLE
Respect the `content` prop, gate `/fp/api`, modularize the playground api client, and more!

### DIFF
--- a/packages/embedded/package.json
+++ b/packages/embedded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiberplane/embedded",
-  "version": "0.0.30-alpha.5",
+  "version": "0.0.30-alpha.6",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/embedded/package.json
+++ b/packages/embedded/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@fiberplane/embedded",
+<<<<<<< HEAD
   "version": "0.0.30-alpha.6",
+=======
+  "version": "0.0.30-alpha.3",
+>>>>>>> 78781c2a (Bump embedded package.json to alpha.3)
   "type": "module",
   "exports": {
     ".": {

--- a/packages/embedded/package.json
+++ b/packages/embedded/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@fiberplane/embedded",
-<<<<<<< HEAD
   "version": "0.0.30-alpha.6",
-=======
-  "version": "0.0.30-alpha.3",
->>>>>>> 78781c2a (Bump embedded package.json to alpha.3)
   "type": "module",
   "exports": {
     ".": {

--- a/packages/embedded/src/constants.ts
+++ b/packages/embedded/src/constants.ts
@@ -1,1 +1,2 @@
-export const PLAYGROUND_SERVICES_URL = "https://playground-services.mies.workers.dev";
+export const PLAYGROUND_SERVICES_URL =
+  "https://playground-services.mies.workers.dev";

--- a/packages/embedded/src/router.ts
+++ b/packages/embedded/src/router.ts
@@ -16,7 +16,13 @@ export function createRouter<E extends Env>(
   // We therefore remove the apiKey
   const { apiKey, fpxEndpoint, ...sanitizedOptions } = options;
 
-  app.route("/api", createApiRoutes(apiKey, fpxEndpoint));
+  if (apiKey) {
+    app.route("/api", createApiRoutes(apiKey, fpxEndpoint));
+  } else {
+    app.use("/api/*", async (c) => {
+      return c.json({ error: "Fiberplane API key is not set" }, 402);
+    });
+  }
 
   const embeddedPlayground = createEmbeddedPlayground(sanitizedOptions);
   app.route("/", embeddedPlayground);

--- a/packages/embedded/src/routes/api/assistant.ts
+++ b/packages/embedded/src/routes/api/assistant.ts
@@ -3,11 +3,11 @@ import { PLAYGROUND_SERVICES_URL } from "../../constants.js";
 
 export default function createAssistantApiRoute(apiKey: string) {
   const app = new Hono();
-  
+
   // Proxy all requests to fp-services but attach a token
   app.all("*", async (c) => {
     const url = `${PLAYGROUND_SERVICES_URL}${c.req.path}`;
-  
+
     const contentType = c.req.header("content-type");
     const headers = new Headers();
     // Only include the bare minimum authentication and content-type headers
@@ -15,13 +15,13 @@ export default function createAssistantApiRoute(apiKey: string) {
     if (contentType) {
       headers.set("content-type", contentType);
     }
-  
+
     return fetch(url, {
       method: c.req.method,
       headers,
       body: c.req.raw.body,
     });
   });
-  
+
   return app;
 }

--- a/packages/embedded/src/routes/api/reports.ts
+++ b/packages/embedded/src/routes/api/reports.ts
@@ -3,11 +3,11 @@ import { PLAYGROUND_SERVICES_URL } from "../../constants.js";
 
 export default function createReportsApiRoute(apiKey: string) {
   const app = new Hono();
-  
+
   // Proxy all requests to fp-services but attach a token
   app.all("*", async (c) => {
     const url = `${PLAYGROUND_SERVICES_URL}${c.req.path}`;
-  
+
     const contentType = c.req.header("content-type");
     const headers = new Headers();
     // Only include the bare minimum authentication and content-type headers
@@ -15,13 +15,13 @@ export default function createReportsApiRoute(apiKey: string) {
     if (contentType) {
       headers.set("content-type", contentType);
     }
-  
+
     return fetch(url, {
       method: c.req.method,
       headers,
       body: c.req.raw.body,
     });
   });
-  
+
   return app;
 }

--- a/packages/embedded/src/routes/api/traces.ts
+++ b/packages/embedded/src/routes/api/traces.ts
@@ -13,7 +13,6 @@ export default function createTracesApiRoute(fpxEndpoint?: string) {
     try {
       const fpxBaseUrl = new URL(fpxEndpoint).origin;
       const requestUrl = `${fpxBaseUrl}/v1/traces`;
-      console.log("GET /traces - requestUrl", requestUrl);
       const response = await fetch(requestUrl, {
         headers: {
           "Content-Type": "application/json",
@@ -36,7 +35,6 @@ export default function createTracesApiRoute(fpxEndpoint?: string) {
       const fpxBaseUrl = new URL(fpxEndpoint).origin;
       const traceId = c.req.param("traceId");
       const requestUrl = `${fpxBaseUrl}/v1/traces/${traceId}/spans`;
-      console.log("GET /traces/:traceId/spans - requestUrl", requestUrl);
       const response = await fetch(requestUrl, {
         headers: {
           "Content-Type": "application/json",

--- a/packages/embedded/src/routes/api/workflows.ts
+++ b/packages/embedded/src/routes/api/workflows.ts
@@ -3,11 +3,11 @@ import { PLAYGROUND_SERVICES_URL } from "../../constants.js";
 
 export default function createWorkflowsApiRoute(apiKey: string) {
   const app = new Hono();
-  
+
   // Proxy all requests to fp-services but attach a token
   app.all("*", async (c) => {
     const url = `${PLAYGROUND_SERVICES_URL}${c.req.path}`;
-  
+
     const contentType = c.req.header("content-type");
     const headers = new Headers();
     // Only include the bare minimum authentication and content-type headers
@@ -15,13 +15,13 @@ export default function createWorkflowsApiRoute(apiKey: string) {
     if (contentType) {
       headers.set("content-type", contentType);
     }
-  
+
     return fetch(url, {
       method: c.req.method,
       headers,
       body: c.req.raw.body,
     });
   });
-  
+
   return app;
 }

--- a/packages/embedded/src/types.ts
+++ b/packages/embedded/src/types.ts
@@ -1,5 +1,13 @@
 export interface EmbeddedOptions {
-  apiKey: string;
+  /**
+   * (Optional) The API key to use for the embedded playground.
+   *
+   * If not provided, certain features like the Workflow Builder will be disabled.
+   */
+  apiKey?: string;
+  /**
+   * (Optional) The URL of the CDN to use for the embedded playground UI.
+   */
   cdn?: string;
   openapi?: OpenAPIOptions;
 }
@@ -16,8 +24,9 @@ export interface OpenAPIOptions {
   /**
    * The URL of the (JSON) OpenAPI spec.
    *
-   * Example: "/openapi.json" if on the same origin
-   * Example: "http://api.myapp.biz/openapi.json" if on a different origin
+   * Examples:
+   * - Same origin: "/openapi.json"
+   * - Different origin: "http://api.myapp.biz/openapi.json"
    */
   url?: string;
   /**

--- a/packages/embedded/src/types.ts
+++ b/packages/embedded/src/types.ts
@@ -1,12 +1,14 @@
 export interface EmbeddedOptions {
   /**
-   * (Optional) The API key to use for the embedded playground.
+   * (Optional) Fiberplane API key to use for the embedded playground api.
    *
    * If not provided, certain features like the Workflow Builder will be disabled.
    */
   apiKey?: string;
   /**
-   * (Optional) The URL of the CDN to use for the embedded playground UI.
+   * (Optional) URL of a custom CDN to use for the embedded playground UI.
+   *
+   * If not provided, the default CDN will be used.
    */
   cdn?: string;
   openapi?: OpenAPIOptions;

--- a/packages/embedded/src/types.ts
+++ b/packages/embedded/src/types.ts
@@ -13,6 +13,15 @@ export interface SanitizedEmbeddedOptions
   extends Omit<ResolvedEmbeddedOptions, "apiKey"> {}
 
 export interface OpenAPIOptions {
+  /**
+   * The URL of the (JSON) OpenAPI spec.
+   *
+   * Example: "/openapi.json" if on the same origin
+   * Example: "http://api.myapp.biz/openapi.json" if on a different origin
+   */
   url?: string;
+  /**
+   * A JSON-stringified object representing an OpenAPI spec.
+   */
   content?: string;
 }

--- a/playground/index.html
+++ b/playground/index.html
@@ -13,24 +13,177 @@
       const options = {
         mountedPath: "/",
         openapi: {
-          // NOTE - This config assumes you have a local server running on :8787 with the OpenAPI spec exposed at /openapi.json
+          // This config assumes you have a local server running on :8787 with the OpenAPI spec exposed at /openapi.json
+          //
           url: "http://localhost:8787/openapi.json",
-          // NOTE - You can test a raw spec by using the `content` property instead of `url`, 
-          //        and passing in an object representing an OpenAPI spec
-          // content: JSON.stringify({
-          //   openapi: "3.1.0",
-          //   info: {
-          //     title: "Test API",
-          //     version: "1.0.0",
-          //   },
-          //   // ...
-          // }),
+
+          // You can also test a raw spec by using the `content` property instead of `url`, 
+          // and passing in a JSON-stringified object representing an OpenAPI spec
+          //
+          // content: __fpGetRawOpenApiSpec(),
         },
         // NOTE - This option here is **only for local development** to be able to test the tracing UI in the playground
         // Assumes you have Fiberplane Studio running as a sidecar to ingest traces on :8788
         fpxEndpoint: "http://localhost:8788/v1/traces",
       };
+
       document.getElementById("root").dataset.options = JSON.stringify(options);
+
+      /**
+       * A helper function to get a JSON-stringified object representing an OpenAPI spec
+       * Since this index.html is not ultimately used by the embedded package,
+       * it's safe to include a global helper function like this.
+       */
+      function __fpGetRawOpenApiSpec() {
+        return JSON.stringify({
+          openapi: "3.0.0",
+          info: {
+            title: "Music Library API",
+            description: "API for managing a music library with artists, albums, and songs",
+            version: "1.0.0"
+          },
+          tags: [
+            {
+              name: "Artists",
+              description: "Operations about artists"
+            },
+            {
+              name: "Albums",
+              description: "Operations about albums"
+            },
+            {
+              name: "Songs",
+              description: "Operations about songs"
+            }
+          ],
+          // servers: [
+          //   {
+          //     url: "http://localhost:8787",
+          //     description: "Local server"
+          //   }
+          // ],
+          paths: {
+            "/api/artists": {
+              get: {
+                tags: ["Artists"],
+                summary: "List artists",
+                description: "Retrieve a paginated list of artists. Can be filtered by genre to find artists of a specific musical style.",
+                parameters: [
+                  {
+                    name: "genre",
+                    in: "query",
+                    description: "Filter artists by genre",
+                    required: false,
+                    schema: {
+                      type: "string"
+                    }
+                  }
+                ],
+                responses: {
+                  "200": {
+                    description: "List of artists",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          type: "object",
+                          properties: {
+                            artists: {
+                              type: "array",
+                              items: {
+                                $ref: "#/components/schemas/Artist"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              post: {
+                tags: ["Artists"],
+                summary: "Create a new artist",
+                description: "Add a new artist to the music library with their basic information and biography.",
+                requestBody: {
+                  required: true,
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/NewArtist"
+                      }
+                    }
+                  }
+                },
+                responses: {
+                  "201": {
+                    description: "Artist created",
+                    content: {
+                      "application/json": {
+                        schema: {
+                          $ref: "#/components/schemas/Artist"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+          },
+          components: {
+            schemas: {
+              NewArtist: {
+                type: "object",
+                required: ["name", "genre"],
+                properties: {
+                  name: {
+                    type: "string",
+                    example: "The Beatles"
+                  },
+                  genre: {
+                    type: "string",
+                    example: "Rock"
+                  },
+                  country: {
+                    type: "string",
+                    example: "United Kingdom"
+                  },
+                  biography: {
+                    type: "string"
+                  }
+                }
+              },
+              Artist: {
+                allOf: [
+                  { $ref: "#/components/schemas/NewArtist" },
+                  {
+                    type: "object",
+                    required: ["id", "createdAt"],
+                    properties: {
+                      id: {
+                        type: "integer",
+                        example: 1
+                      },
+                      createdAt: {
+                        type: "string",
+                        format: "date-time"
+                      }
+                    }
+                  }
+                ]
+              },
+              Error: {
+                type: "object",
+                properties: {
+                  error: {
+                    type: "string",
+                    example: "Resource not found"
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
     </script>
   </body>
 </html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -21,10 +21,7 @@
           // and passing in a JSON-stringified object representing an OpenAPI spec
           //
           // content: __fpGetRawOpenApiSpec(),
-        },
-        // NOTE - This option here is **only for local development** to be able to test the tracing UI in the playground
-        // Assumes you have Fiberplane Studio running as a sidecar to ingest traces on :8788
-        fpxEndpoint: "http://localhost:8788/v1/traces",
+        }
       };
 
       document.getElementById("root").dataset.options = JSON.stringify(options);

--- a/playground/src/Layout/Layout.tsx
+++ b/playground/src/Layout/Layout.tsx
@@ -2,15 +2,15 @@ import { useStudioStore } from "@/components/playground/store";
 import { Button } from "@/components/ui/button";
 import { createLink, useMatches } from "@tanstack/react-router";
 import { UserCircle } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, forwardRef } from "react";
 import { cn } from "../utils";
 import { BottomBar } from "./BottomBar";
 import { SettingsScreen } from "./Settings";
 
-const NavButtonComponent = ({
-  className,
-  ...props
-}: React.ComponentProps<"a">) => {
+const NavButtonComponent = forwardRef<
+  HTMLAnchorElement,
+  React.ComponentProps<"a">
+>(({ className, ...props }, ref) => {
   const matches = useMatches();
   const isActive = matches.some((match) => match.routeId === props.href);
 
@@ -21,10 +21,12 @@ const NavButtonComponent = ({
       className={cn("h-6 hover:bg-input", isActive && "bg-input")}
       asChild
     >
-      <a {...props} className={cn(className)} />
+      <a {...props} ref={ref} className={cn(className)} />
     </Button>
   );
-};
+});
+
+NavButtonComponent.displayName = "NavButtonComponent";
 
 const NavButton = createLink(NavButtonComponent);
 

--- a/playground/src/components/ErrorScreen.tsx
+++ b/playground/src/components/ErrorScreen.tsx
@@ -2,12 +2,12 @@ import { Icon } from "@iconify/react";
 
 export function ErrorScreen(props: {
   error: Error;
-  title: string;
-  message: string;
+  title?: string;
+  message?: string;
 }) {
   const { error: _error, message } = props;
   const title = props.title ?? "Error";
-
+  const errorMessage = message ?? "An error occurred";
   return (
     <div className="min-h-screen bg-background">
       <div className="flex flex-col items-center justify-center h-screen gap-2">
@@ -19,7 +19,7 @@ export function ErrorScreen(props: {
         />
         <div className="flex flex-col items-center gap-1">
           <h2 className="text-lg font-medium">{title}</h2>
-          <p className="text-sm">{message}</p>
+          <p className="text-sm">{errorMessage}</p>
         </div>
       </div>
     </div>

--- a/playground/src/components/ErrorScreen.tsx
+++ b/playground/src/components/ErrorScreen.tsx
@@ -1,0 +1,27 @@
+import { Icon } from "@iconify/react";
+
+export function ErrorScreen(props: {
+  error: Error;
+  title: string;
+  message: string;
+}) {
+  const { error: _error, message } = props;
+  const title = props.title ?? "Error";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="flex flex-col items-center justify-center h-screen gap-2">
+        <Icon
+          icon="lucide:alert-triangle"
+          width={48}
+          height={48}
+          className="text-danger"
+        />
+        <div className="flex flex-col items-center gap-1">
+          <h2 className="text-lg font-medium">{title}</h2>
+          <p className="text-sm">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/FeatureDisabledScreen.tsx
+++ b/playground/src/components/FeatureDisabledScreen.tsx
@@ -2,12 +2,10 @@ import { Icon } from "@iconify/react";
 
 export function FeatureDisabledScreen(props: {
   error: Error;
-  title?: string;
+  title: string;
   message: string;
 }) {
-  const { error: _error, message } = props;
-  const title = props.title ?? "Feature Disabled";
-
+  const { error: _error, message, title } = props;
   return (
     <div className="min-h-screen bg-background">
       <div className="flex flex-col items-center justify-center h-screen gap-2">

--- a/playground/src/components/FeatureDisabledScreen.tsx
+++ b/playground/src/components/FeatureDisabledScreen.tsx
@@ -1,0 +1,27 @@
+import { Icon } from "@iconify/react";
+
+export function FeatureDisabledScreen(props: {
+  error: Error;
+  title?: string;
+  message: string;
+}) {
+  const { error: _error, message } = props;
+  const title = props.title ?? "Feature Disabled";
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="flex flex-col items-center justify-center h-screen gap-2">
+        <Icon
+          icon="lucide:lock"
+          width={48}
+          height={48}
+          className="text-muted-foreground"
+        />
+        <div className="flex flex-col items-center gap-1">
+          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <p className="text-foreground/70 text-center max-w-md">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/playground/store/slices/settingsSlice.ts
+++ b/playground/src/components/playground/store/slices/settingsSlice.ts
@@ -5,7 +5,8 @@ import {
   FEATURE_FLAG_WORKFLOWS,
   type FeatureFlag,
 } from "@/constants";
-import { safeParseJson } from "@/utils";
+// HACK - Importing this from a separate file from within the root utils dir is a hack to avoid circular dependencies.
+import { safeParseJson } from "@/utils/safe-parse-json";
 import { z } from "zod";
 import type { StateCreator } from "zustand";
 import { enforceTerminalDraftParameter } from "../../KeyValueForm";

--- a/playground/src/lib/api/api.ts
+++ b/playground/src/lib/api/api.ts
@@ -10,16 +10,12 @@ import {
   parseErrorResponse,
 } from "./errors";
 import { safeParseBodyText } from "./utils";
+import { fpFetch } from "./fetch";
 
 export const api = {
-  getWorkflows: async () => {
-    const basePrefix = getFpApiBasePath();
-    const response = await fetch(`${basePrefix}/api/workflows`);
-    if (!response.ok) {
-      const error = await parseErrorResponse(response);
-      throw error;
-    }
-    return response.json();
+  getWorkflows: async (): Promise<ApiResponse<Workflow[]>> => {
+    const response = await fpFetch<ApiResponse<Workflow[]>>("/api/workflows");
+    return response;
   },
 
   getWorkflow: async (id: string): Promise<ApiResponse<Workflow>> => {

--- a/playground/src/lib/api/api.ts
+++ b/playground/src/lib/api/api.ts
@@ -5,7 +5,7 @@ import {
   TraceSummarySchema,
 } from "@fiberplane/fpx-types";
 import { FetchOpenApiSpecError, isFailedToFetchError } from "./errors";
-import { baseFetch, fpFetch, getFpApiBasePath } from "./fetch";
+import { baseFetch, fpFetch } from "./fetch";
 import { safeParseBodyText } from "./utils";
 
 export const api = {
@@ -61,28 +61,17 @@ export const api = {
     );
   },
 
-  // TODO - Clarify the use of fpxEndpointHost, I already forgot how that param is used
-  getTraces: async (fpxEndpointHost: string) => {
-    const basePrefix = getFpApiBasePath();
-    const tracesUrl = fpxEndpointHost
-      ? `${fpxEndpointHost}/v1/traces`
-      : `${basePrefix}/api/traces`;
-    const data = await baseFetch(tracesUrl);
+  getTraces: async () => {
+    const data = await fpFetch("/api/traces");
     return {
       data: TraceListResponseSchema.parse(data),
     };
   },
 
   getTrace: async (
-    fpxEndpointHost: string,
     id: string,
   ): Promise<ApiResponse<TraceDetailSpansResponse>> => {
-    const basePrefix = getFpApiBasePath();
-    const tracesUrl = fpxEndpointHost
-      ? `${fpxEndpointHost}/v1/traces/${id}/spans`
-      : `${basePrefix}/api/traces/${id}/spans`;
-
-    const data = await baseFetch(tracesUrl);
+    const data = await fpFetch(`/api/traces/${id}/spans`);
     const parsedTrace = TraceSummarySchema.parse({
       traceId: id,
       spans: data,

--- a/playground/src/lib/api/api.ts
+++ b/playground/src/lib/api/api.ts
@@ -9,8 +9,8 @@ import {
   isFailedToFetchError,
   parseErrorResponse,
 } from "./errors";
-import { safeParseBodyText } from "./utils";
 import { fpFetch } from "./fetch";
+import { safeParseBodyText } from "./utils";
 
 export const api = {
   getWorkflows: async (): Promise<ApiResponse<Workflow[]>> => {

--- a/playground/src/lib/api/errors.ts
+++ b/playground/src/lib/api/errors.ts
@@ -1,0 +1,70 @@
+export class FpApiError extends Error {
+  statusCode?: number;
+  details?: string;
+
+  constructor(message: string, statusCode?: number, details?: string) {
+    super(message);
+    this.name = "FpApiError";
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+
+export class FetchOpenApiSpecError extends Error {
+  path?: string;
+  statusCode?: number;
+  details?: string;
+
+  constructor(
+    message: string,
+    path?: string,
+    statusCode?: number,
+    details?: string,
+  ) {
+    super(message);
+    this.name = "FetchOpenApiSpecError";
+    this.path = path;
+    this.statusCode = statusCode;
+    this.details = details;
+  }
+}
+/**
+ * Parses an error response from the API into an `FpApiError`.
+ */
+export async function parseErrorResponse(
+  response: Response,
+): Promise<FpApiError> {
+  const contentType = response.headers.get("content-type");
+  let message = `Request failed with status ${response.status}`;
+  let details: string | undefined;
+
+  try {
+    if (contentType?.includes("application/json")) {
+      const error = await response.json();
+      message = error.message || message;
+      details = JSON.stringify(error);
+    } else if (contentType?.includes("text/")) {
+      message = await response.text();
+    }
+  } catch (_error) {
+    // If parsing fails, retain the default message
+  }
+
+  return new FpApiError(message, response.status, details);
+}
+
+export function isFeatureDisabledError(error: unknown) {
+  return isFpApiError(error) && error.statusCode === 402;
+}
+
+function isFpApiError(error: unknown): error is FpApiError {
+  return error instanceof FpApiError;
+}
+
+export function isFetchOpenApiSpecError(error: unknown) {
+  return error instanceof FetchOpenApiSpecError;
+}
+
+export function isFailedToFetchError(error: unknown) {
+  return error instanceof Error && error.message === "Failed to fetch";
+}

--- a/playground/src/lib/api/fetch.ts
+++ b/playground/src/lib/api/fetch.ts
@@ -53,7 +53,7 @@ export async function fpFetch<T>(
 /**
  * Returns the fiberplane api base path, unless we're running in dev mode.
  */
-function getFpApiBasePath(): string {
+export function getFpApiBasePath(): string {
   // If we're running the SPA in dev mode directly, there's no need to add the base path
   if (import.meta.env.DEV) {
     return "";

--- a/playground/src/lib/api/fetch.ts
+++ b/playground/src/lib/api/fetch.ts
@@ -1,0 +1,72 @@
+import { parseEmbeddedConfig } from "@/utils";
+import { parseErrorResponse } from "./errors";
+
+/**
+ * Performs a fetch call, checks for errors, and processes the response.
+ * @NOTE - This function does NOT add the fp api base path to the url.
+ *
+ * @param path - The URL to fetch
+ * @param options - Optional fetch options
+ * @param parser - An optional parser function for processing the response
+ * @returns The processed response of type T
+ */
+export async function baseFetch<T>(
+  url: string,
+  options?: RequestInit,
+  parser?: (response: Response) => Promise<T>,
+): Promise<T> {
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    const error = await parseErrorResponse(response);
+    throw error;
+  }
+
+  return parser ? parser(response) : response.json();
+}
+
+/**
+ * Performs a fetch call, checks for errors, and processes the response.
+ *
+ * @NOTE - This function adds the fiberplane api base path to the url.
+ *
+ * @param path - The relative path (on the same origin) to fetch
+ * @param options - Optional fetch options
+ * @param parser - An optional parser function for processing the response
+ *
+ * @returns The processed response of type T
+ */
+export async function fpFetch<T>(
+  path: string,
+  options?: RequestInit,
+  parser?: (response: Response) => Promise<T>,
+): Promise<T> {
+  if (!path.startsWith("/")) {
+    throw new Error("path must be relative to the origin");
+  }
+
+  const basePrefix = getFpApiBasePath();
+  const url = `${basePrefix}${path}`;
+  return baseFetch(url, options, parser);
+}
+
+/**
+ * Returns the fiberplane api base path, unless we're running in dev mode.
+ */
+function getFpApiBasePath(): string {
+  // If we're running the SPA in dev mode directly, there's no need to add the base path
+  if (import.meta.env.DEV) {
+    return "";
+  }
+
+  // This case should never happen, since the UI should fail
+  // when the root element's `dataset.options` are not found
+  const rootElement = document.getElementById("root");
+  if (!rootElement?.dataset.options) {
+    return "";
+  }
+
+  const { mountedPath } = parseEmbeddedConfig(rootElement);
+
+  return mountedPath;
+}

--- a/playground/src/lib/api/index.ts
+++ b/playground/src/lib/api/index.ts
@@ -1,0 +1,2 @@
+export { api } from "./api";
+export { isFetchOpenApiSpecError, isFeatureDisabledError } from "./errors";

--- a/playground/src/lib/api/utils.ts
+++ b/playground/src/lib/api/utils.ts
@@ -1,0 +1,7 @@
+export async function safeParseBodyText(response: Response) {
+  try {
+    return await response.text();
+  } catch (_error) {
+    return undefined;
+  }
+}

--- a/playground/src/lib/hooks/useOpenApiSpec.ts
+++ b/playground/src/lib/hooks/useOpenApiSpec.ts
@@ -12,7 +12,7 @@ export function openApiSpecQueryOptions(openapi: OpenApiContext | undefined) {
     queryKey: OPENAPI_CACHE_KEY,
     queryFn: async () => {
       if (openapi?.content) {
-        return JSON.stringify(openapi.content);
+        return openapi.content;
       }
 
       if (!openapi?.url) {

--- a/playground/src/lib/hooks/useOpenApiSpec.ts
+++ b/playground/src/lib/hooks/useOpenApiSpec.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
 
 export const OPENAPI_CACHE_KEY = ["openapi-spec"];
 
@@ -19,12 +20,8 @@ export function openApiSpecQueryOptions(openapi: OpenApiContext | undefined) {
         return undefined;
       }
 
-      const response = await fetch(openapi.url);
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      return response.text();
+      const stringifiedSpec = await api.getOpenApiSpec(openapi.url);
+      return stringifiedSpec;
     },
     enabled: !!openapi?.url || !!openapi?.content,
     staleTime: Number.POSITIVE_INFINITY,

--- a/playground/src/lib/hooks/useTraces.ts
+++ b/playground/src/lib/hooks/useTraces.ts
@@ -8,28 +8,25 @@ import { api } from "../api";
 
 export const TRACES_KEY = "traces";
 
-export const tracesQueryOptions = (fpxEndpointHost: string) => ({
+export const tracesQueryOptions = (isEnabled: boolean) => ({
   queryKey: [TRACES_KEY],
-  queryFn: () => api.getTraces(fpxEndpointHost),
+  queryFn: () => api.getTraces(),
   // TODO - use TraceListResponseSchema to parse response
   select: (response: ApiResponse<TraceListResponse>) => response.data,
-  enabled: !!fpxEndpointHost,
+  enabled: isEnabled,
 });
 
-export function useTraces(fpxEndpointHost: string) {
-  return useQuery(tracesQueryOptions(fpxEndpointHost));
+export function useTraces(isEnabled: boolean) {
+  return useQuery(tracesQueryOptions(isEnabled));
 }
 
-export const traceQueryOptions = (
-  fpxEndpointHost: string,
-  traceId: string,
-) => ({
+export const traceQueryOptions = (traceId: string) => ({
   queryKey: [TRACES_KEY, traceId],
-  queryFn: () => api.getTrace(fpxEndpointHost, traceId),
+  queryFn: () => api.getTrace(traceId),
   select: (response: ApiResponse<TraceDetailSpansResponse>) => response.data,
-  enabled: !!fpxEndpointHost && !!traceId,
+  enabled: !!traceId,
 });
 
-export function useTrace(fpxEndpointHost: string, id: string) {
-  return useQuery(traceQueryOptions(fpxEndpointHost, id));
+export function useTrace(id: string) {
+  return useQuery(traceQueryOptions(id));
 }

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -36,7 +36,7 @@ declare module "@tanstack/react-router" {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <TooltipProvider>
         <QueryClientProvider client={queryClient}>
           <RouterProvider router={router} />

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -15,14 +15,13 @@ if (rootElement === null) {
 
 // NOTE: Mounted path defines which path the whole playground is mounted on. The
 // client router needs to know this so it can generate correct links
-const { mountedPath, openapi, fpxEndpointHost } =
-  parseEmbeddedConfig(rootElement);
+const { mountedPath, openapi } = parseEmbeddedConfig(rootElement);
 
 const queryClient = new QueryClient();
 const router = createRouter({
   routeTree,
   basepath: mountedPath,
-  context: { queryClient, openapi, fpxEndpointHost },
+  context: { queryClient, openapi },
   defaultPreload: "intent",
   defaultPreloadStaleTime: 10 * 1000,
 });

--- a/playground/src/routes/__root.tsx
+++ b/playground/src/routes/__root.tsx
@@ -1,4 +1,6 @@
+import { ErrorScreen } from "@/components/ErrorScreen";
 import { WorkflowCommand } from "@/components/WorkflowCommand";
+import { isFetchOpenApiSpecError } from "@/lib/api";
 import { openApiSpecQueryOptions } from "@/lib/hooks/useOpenApiSpec";
 import { Icon } from "@iconify/react";
 import type { QueryClient } from "@tanstack/react-query";
@@ -40,6 +42,18 @@ export const Route = createRootRouteWithContext<{
     console.error("Error loading openapi spec", error);
   },
   errorComponent: ({ error, info }) => {
+    if (isFetchOpenApiSpecError(error)) {
+      return (
+        <ErrorScreen
+          error={error}
+          title="Error fetching OpenAPI spec"
+          message={
+            error.message ??
+            "Something went wrong while loading the OpenAPI spec."
+          }
+        />
+      );
+    }
     return (
       <ErrorBoundary
         error={error}
@@ -78,7 +92,7 @@ function ErrorBoundary({
         />
         <p className="text-lg">
           {error.message}
-          {info?.componentStack}
+          {process.env.NODE_ENV !== "production" ? info?.componentStack : null}
         </p>
       </div>
       {/*  Commented out because they're annoying but leaving them here in case you need them */}

--- a/playground/src/routes/__root.tsx
+++ b/playground/src/routes/__root.tsx
@@ -15,7 +15,6 @@ export const Route = createRootRouteWithContext<{
         content?: string;
       }
     | undefined;
-  fpxEndpointHost?: string;
 }>()({
   component: RootComponent,
   loader: async ({ context }) => {

--- a/playground/src/routes/__root.tsx
+++ b/playground/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { WorkflowCommand } from "@/components/WorkflowCommand";
 import { openApiSpecQueryOptions } from "@/lib/hooks/useOpenApiSpec";
-import { Icon } from "@iconify/react/dist/iconify.js";
+import { Icon } from "@iconify/react";
 import type { QueryClient } from "@tanstack/react-query";
 import { Outlet, createRootRouteWithContext } from "@tanstack/react-router";
 import React from "react";

--- a/playground/src/routes/traces.$traceId.tsx
+++ b/playground/src/routes/traces.$traceId.tsx
@@ -381,12 +381,9 @@ export const Route = createFileRoute("/traces/$traceId")({
     spanId: z.string().optional(),
   }),
   component: TraceDetail,
-  loader: async ({
-    context: { queryClient, fpxEndpointHost },
-    params: { traceId },
-  }) => {
+  loader: async ({ context: { queryClient }, params: { traceId } }) => {
     const response = await queryClient.ensureQueryData(
-      traceQueryOptions(fpxEndpointHost ?? "", traceId),
+      traceQueryOptions(traceId),
     );
     return { trace: { traceId, spans: response.data } };
   },

--- a/playground/src/routes/traces.index.tsx
+++ b/playground/src/routes/traces.index.tsx
@@ -33,9 +33,11 @@ import { useMemo, useState } from "react";
 
 export const Route = createFileRoute("/traces/")({
   component: TracesOverview,
-  loader: async ({ context: { queryClient, fpxEndpointHost } }) => {
+  loader: async ({ context: { queryClient } }) => {
+    // TODO - Pull this from the store
+    const tracingEnabled = true;
     const response = await queryClient.ensureQueryData(
-      tracesQueryOptions(fpxEndpointHost ?? ""),
+      tracesQueryOptions(tracingEnabled),
     );
     return { traces: response.data };
   },
@@ -163,14 +165,10 @@ export function ErrorBoundary(props: {
 }) {
   const { error } = props;
   const [isOpen, setIsOpen] = useState(false);
-  const { fpxEndpointHost, mountedPath, openapi, parseError } = useDebugInfo();
+  const { mountedPath, openapi, parseError } = useDebugInfo();
 
-  let message = "Make sure you have a Fiberplane sidecar running";
-  if (!fpxEndpointHost) {
-    message = "Fiberplane tracing endpoint is not set";
-  } else if (error) {
-    message = error.message;
-  }
+  // TODO - Make more friendly errors
+  const message = error.message;
 
   return (
     <div className="flex flex-col items-center justify-center h-full p-4">
@@ -226,16 +224,6 @@ export function ErrorBoundary(props: {
                   </code>
                 </CardContent>
               </Card>
-              <Card className="bg-muted/50">
-                <CardContent className="p-3">
-                  <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    Tracing Endpoint Host ((Local only))
-                  </p>
-                  <code className="text-sm">
-                    {fpxEndpointHost ?? "not found"}
-                  </code>
-                </CardContent>
-              </Card>
             </div>
           </CollapsibleContent>
         </Collapsible>
@@ -245,7 +233,6 @@ export function ErrorBoundary(props: {
 }
 
 type DebugInfo = {
-  fpxEndpointHost: string | undefined | null;
   mountedPath: string | undefined | null;
   openapi: Record<string, unknown> | undefined | null;
   parseError: Error | null | unknown;
@@ -257,7 +244,6 @@ function useDebugInfo(): DebugInfo {
       const rootElement = document.getElementById("root");
       if (!rootElement) {
         return {
-          fpxEndpointHost: null,
           mountedPath: null,
           openapi: null,
           parseError: { message: "Root element not found" },
@@ -269,7 +255,6 @@ function useDebugInfo(): DebugInfo {
       };
     } catch (parseError) {
       return {
-        fpxEndpointHost: null,
         mountedPath: null,
         openapi: null,
         parseError,

--- a/playground/src/routes/traces.tsx
+++ b/playground/src/routes/traces.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/traces")({
 
 function TracesLayout() {
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <Layout>
         <Outlet />
       </Layout>

--- a/playground/src/routes/workflows.tsx
+++ b/playground/src/routes/workflows.tsx
@@ -1,4 +1,6 @@
 import { Layout } from "@/Layout";
+import { ErrorScreen } from "@/components/ErrorScreen";
+import { FeatureDisabledScreen } from "@/components/FeatureDisabledScreen";
 import { WorkflowSidebar } from "@/components/WorkflowSidebar";
 import { CommandBar } from "@/components/playground/CommandBar/CommandBar";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -8,6 +10,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { useIsLgScreen } from "@/hooks";
+import { isFpApiError } from "@/lib/api";
 import { workflowsQueryOptions } from "@/lib/hooks/useWorkflows";
 import { cn } from "@/lib/utils";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
@@ -18,12 +21,32 @@ import { useHotkeys } from "react-hotkeys-hook";
 export const Route = createFileRoute("/workflows")({
   component: WorkflowLayout,
   loader: async ({ context: { queryClient } }) => {
+    // FIXME - The types are wonky here, `workflowsResponse` is `any`
     const workflowsResponse = await queryClient.ensureQueryData(
       workflowsQueryOptions(),
     );
+
     return {
       workflows: workflowsResponse.data,
     };
+  },
+  errorComponent: ({ error }) => {
+    if (isFpApiError(error) && error.statusCode === 402) {
+      return (
+        <FeatureDisabledScreen
+          error={error}
+          title="Workflows are Disabled"
+          message="To use workflows, configure Fiberplane with an API key."
+        />
+      );
+    }
+    return (
+      <ErrorScreen
+        error={error}
+        title="Error loading Workflows"
+        message="An unknown error occurred, which is our least favourite kind of error."
+      />
+    );
   },
 });
 

--- a/playground/src/routes/workflows.tsx
+++ b/playground/src/routes/workflows.tsx
@@ -10,7 +10,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { useIsLgScreen } from "@/hooks";
-import { isFpApiError } from "@/lib/api";
+import { isFeatureDisabledError } from "@/lib/api";
 import { workflowsQueryOptions } from "@/lib/hooks/useWorkflows";
 import { cn } from "@/lib/utils";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/workflows")({
     };
   },
   errorComponent: ({ error }) => {
-    if (isFpApiError(error) && error.statusCode === 402) {
+    if (isFeatureDisabledError(error)) {
       return (
         <FeatureDisabledScreen
           error={error}

--- a/playground/src/routes/workflows.tsx
+++ b/playground/src/routes/workflows.tsx
@@ -45,7 +45,7 @@ function WorkflowLayout() {
   // const maxSize = Math.min(50, (500 / width) * 100);
 
   return (
-    <ThemeProvider defaultTheme="light" storageKey="vite-ui-theme">
+    <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
       <Layout>
         <div className={cn("h-[calc(100vh-70px)]", "grid", "gap-2", "p-2")}>
           <CommandBar open={commandBarOpen} setOpen={setCommandBarOpen} />

--- a/playground/src/utils/config-parser.ts
+++ b/playground/src/utils/config-parser.ts
@@ -4,7 +4,7 @@
  * The config should be serialized into the DOM as a data attribute.
  */
 export function parseEmbeddedConfig(rootElement: HTMLElement) {
-  const { mountedPath, openapi, fpxEndpoint } = JSON.parse(
+  const { mountedPath, openapi } = JSON.parse(
     rootElement.dataset.options as string,
   ) as {
     mountedPath: string;
@@ -12,19 +12,10 @@ export function parseEmbeddedConfig(rootElement: HTMLElement) {
       url?: string;
       content?: string;
     };
-    fpxEndpoint?: string;
   };
-
-  // NOTE - This option here is **only for local development** to be able to test the tracing UI in the playground
-  let fpxEndpointHost: string | undefined = undefined;
-  if (fpxEndpoint) {
-    const url = new URL(fpxEndpoint);
-    fpxEndpointHost = url.origin;
-  }
 
   return {
     mountedPath,
     openapi,
-    fpxEndpointHost,
   };
 }

--- a/playground/src/utils/env-vars.ts
+++ b/playground/src/utils/env-vars.ts
@@ -1,0 +1,21 @@
+export function isSensitiveEnvVar(key: string) {
+  if (!key) {
+    return false;
+  }
+
+  return (
+    key.includes("APIKEY") ||
+    key.includes("API_KEY") ||
+    key.includes("ACCESS") ||
+    key.includes("AUTH_") ||
+    key.includes("CREDENTIALS") ||
+    key.includes("CERTIFICATE") ||
+    key.includes("PASSPHRASE") ||
+    key.includes("DATABASE_URL") ||
+    key.includes("CONNECTION_STRING") ||
+    key.includes("SECRET") ||
+    key.includes("PASSWORD") ||
+    key.includes("PRIVATE") ||
+    key.includes("TOKEN")
+  );
+}

--- a/playground/src/utils/http-method-color.ts
+++ b/playground/src/utils/http-method-color.ts
@@ -1,0 +1,12 @@
+export function getHttpMethodTextColor(method: string) {
+  return {
+    GET: "text-info",
+    POST: "text-success",
+    PUT: "text-warning",
+    PATCH: "text-warning",
+    DELETE: "text-danger",
+    OPTIONS: "text-info",
+    HEAD: "text-info",
+    WS: "text-success",
+  }[String(method).toUpperCase()];
+}

--- a/playground/src/utils/index.ts
+++ b/playground/src/utils/index.ts
@@ -11,9 +11,11 @@ import { twMerge } from "tailwind-merge";
 export * from "./screen-size";
 export * from "./otel-helpers";
 export * from "./vendorify-traces";
+export { isSensitiveEnvVar } from "./env-vars";
 export { renderFullLogMessage } from "./render-log-message";
 export { truncateWithEllipsis } from "./truncate";
 export { parseEmbeddedConfig } from "./config-parser";
+export { safeParseJson } from "./safe-parse-json";
 export function formatDate(d: Date | string) {
   return format(new Date(d), "HH:mm:ss.SSS");
 }
@@ -196,16 +198,6 @@ export function formatHeaders(headers: Record<string, string>): string {
     .join("\n");
 }
 
-export const safeParseJson = (jsonString: string) => {
-  try {
-    const parsed = JSON.parse(jsonString);
-    return parsed;
-  } catch (error) {
-    console.error("Failed to parse JSON:", error);
-    return null;
-  }
-};
-
 export function getHttpMethodTextColor(method: string) {
   return {
     GET: "text-info",
@@ -217,28 +209,6 @@ export function getHttpMethodTextColor(method: string) {
     HEAD: "text-info",
     WS: "text-success",
   }[String(method).toUpperCase()];
-}
-
-export function isSensitiveEnvVar(key: string) {
-  if (!key) {
-    return false;
-  }
-
-  return (
-    key.includes("APIKEY") ||
-    key.includes("API_KEY") ||
-    key.includes("ACCESS") ||
-    key.includes("AUTH_") ||
-    key.includes("CREDENTIALS") ||
-    key.includes("CERTIFICATE") ||
-    key.includes("PASSPHRASE") ||
-    key.includes("DATABASE_URL") ||
-    key.includes("CONNECTION_STRING") ||
-    key.includes("SECRET") ||
-    key.includes("PASSWORD") ||
-    key.includes("PRIVATE") ||
-    key.includes("TOKEN")
-  );
 }
 
 export function constructPlaygroundBody(bodyValue: string): PlaygroundBody {

--- a/playground/src/utils/index.ts
+++ b/playground/src/utils/index.ts
@@ -15,6 +15,7 @@ export { isSensitiveEnvVar } from "./env-vars";
 export { renderFullLogMessage } from "./render-log-message";
 export { truncateWithEllipsis } from "./truncate";
 export { parseEmbeddedConfig } from "./config-parser";
+export { getHttpMethodTextColor } from "./http-method-color";
 export { safeParseJson } from "./safe-parse-json";
 export function formatDate(d: Date | string) {
   return format(new Date(d), "HH:mm:ss.SSS");
@@ -196,19 +197,6 @@ export function formatHeaders(headers: Record<string, string>): string {
   return Object.entries(headers)
     .map(([key, value]) => `${key}: ${value}`)
     .join("\n");
-}
-
-export function getHttpMethodTextColor(method: string) {
-  return {
-    GET: "text-info",
-    POST: "text-success",
-    PUT: "text-warning",
-    PATCH: "text-warning",
-    DELETE: "text-danger",
-    OPTIONS: "text-info",
-    HEAD: "text-info",
-    WS: "text-success",
-  }[String(method).toUpperCase()];
 }
 
 export function constructPlaygroundBody(bodyValue: string): PlaygroundBody {

--- a/playground/src/utils/safe-parse-json.ts
+++ b/playground/src/utils/safe-parse-json.ts
@@ -1,0 +1,9 @@
+export const safeParseJson = (jsonString: string) => {
+  try {
+    const parsed = JSON.parse(jsonString);
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse JSON:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
- Fix playground's usage of `content`, the JSON-serialize api spec from `options.openapi.content`. So now the embedded package supports passing a spec directly to the middleware

- Adds comments in playground's `index.html` to help with testing the `content` property on the openapi options serialized into the DOM

- Add docstrings to parameters in the embedded middleware so their documentation appears in intellisense popvers
  <img width="571" alt="image" src="https://github.com/user-attachments/assets/4307cd53-28d0-4554-9379-0eda29dcfa4e" />

- Make the `apiKey` prop optional, and if it is not present, do not mount the `/fp/api` routes inside the embedded middleware

- Change Theme default to be "system" instead of "light"

- Use a common error message parser for all `lib/api/api.ts` methods

- Add error screen to Workflows when the embedded middleware doesn't have an API key present
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/e7df9cb5-a383-44f7-9713-83d40c0719a6" />

- Add an error screen to the app when the OpenAPI spec is not fetched 
  <img width="600" alt="image" src="https://github.com/user-attachments/assets/d9b53120-dcd4-42f4-9233-18297b318f4a" />
