### PR TITLE
Fix screenshot size on mobile

### DIFF
--- a/www/src/components/Hero.astro
+++ b/www/src/components/Hero.astro
@@ -246,10 +246,11 @@ const imageAttrs = {
 
       figure {
         --figure-block-padding: 2rem;
-        height: 80cqi;
+        height: 90cqi;
 
         img {
           height: calc(100% - var(--figure-block-padding) * 2);
+          height: 88%;
           border-radius: 8px;
           translate: var(--sl-nav-pad-x) 0;
         }


### PR DESCRIPTION
Before & after:

![Screen Shot 2025-02-10 at 11 14 23](https://github.com/user-attachments/assets/b0da33a7-601c-4022-8443-4fc699e8a7a0)

![Screen Shot 2025-02-10 at 11 14 14](https://github.com/user-attachments/assets/486d1a65-8713-4d73-b04a-ad975ffc21db)
