### PR TITLE
Finalize February releases 

### DIFF
--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.8.0-canary.5",
+  "version": "0.8.0-canary.6",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/core": "1.9.0",

--- a/packages/client-library-otel/package.json
+++ b/packages/client-library-otel/package.json
@@ -4,7 +4,7 @@
   "author": "Fiberplane<info@fiberplane.com>",
   "type": "module",
   "main": "dist/index.js",
-  "version": "0.8.0-canary.6",
+  "version": "0.8.0",
   "dependencies": {
     "@opentelemetry/api": "~1.9.0",
     "@opentelemetry/core": "1.9.0",

--- a/packages/fiberplane-hono/package.json
+++ b/packages/fiberplane-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiberplane/hono",
   "type": "module",
-  "version": "0.4.4-beta.4",
+  "version": "0.4.4",
   "author": "Fiberplane<info@fiberplane.com>",
   "repository": {
     "type": "git",

--- a/packages/fiberplane-hono/package.json
+++ b/packages/fiberplane-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiberplane/hono",
   "type": "module",
-  "version": "0.4.4-beta.3",
+  "version": "0.4.4-beta.4",
   "author": "Fiberplane<info@fiberplane.com>",
   "repository": {
     "type": "git",

--- a/packages/fiberplane-hono/src/routes/runner/utils.ts
+++ b/packages/fiberplane-hono/src/routes/runner/utils.ts
@@ -15,6 +15,12 @@ export async function getWorkflowById<E extends Env>(
   const app = c.get("userApp");
   const env = c.get("userEnv");
 
+  if (!app) {
+    throw new HTTPException(500, {
+      message: "app is not configured for running workflows",
+    });
+  }
+
   const path = `/api/workflows/${workflowId}`;
   const request = new Request(`${PLAYGROUND_SERVICES_URL}${path}`, {
     method: "GET",

--- a/packages/fiberplane-hono/src/types.ts
+++ b/packages/fiberplane-hono/src/types.ts
@@ -74,7 +74,7 @@ export interface EmbeddedOptions<E extends Env> {
   /**
    * The Hono app to use for the embedded runner.
    */
-  app: AnyHono<E>;
+  app?: AnyHono<E>;
 
   /**
    * A custom fetch function to use for internal fiberplane api requests.
@@ -95,7 +95,7 @@ export interface ResolvedEmbeddedOptions<E extends Env>
   mountedPath: string;
   otelEndpoint?: string;
   otelToken?: string;
-  userApp: AnyHono<E>;
+  userApp?: AnyHono<E>;
   userEnv: Env;
   userExecutionCtx: ExecutionContext | null;
   cdn: string;
@@ -122,7 +122,7 @@ export interface OpenAPIOptions {
 export interface FiberplaneAppType<E extends Env> {
   Variables: {
     debug: boolean;
-    userApp: AnyHono<E>;
+    userApp?: AnyHono<E>;
     userEnv: E;
     userExecutionCtx: ExecutionContext;
   };


### PR DESCRIPTION
- Make it optional to pass `app` parameter to `createFiberplane`
- Bump versions of fiberplane-hono and otel-client-library

Both versions are already released:

- `@fiberplane/hono` - `0.4.4`
- `@fiberplane/hono-otel` - `0.8.0`