### PR TITLE
Add partition keys to workflows

### DIFF
--- a/packages/fiberplane-hono/package.json
+++ b/packages/fiberplane-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiberplane/hono",
   "type": "module",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0",
   "author": "Fiberplane<info@fiberplane.com>",
   "repository": {
     "type": "git",

--- a/packages/fiberplane-hono/src/middleware.ts
+++ b/packages/fiberplane-hono/src/middleware.ts
@@ -21,7 +21,7 @@ import { getFromEnv } from "./utils/env";
  * The version of assets to use for the playground ui.
  * This should correspond to the package.json version of the `@fiberplane/hono` package.
  */
-export const ASSETS_VERSION = "0.5.0-beta.1";
+export const ASSETS_VERSION = "0.5.0";
 const CDN_URL = `https://cdn.jsdelivr.net/npm/@fiberplane/hono@${ASSETS_VERSION}/dist/playground/`;
 
 export const createFiberplane =

--- a/packages/fiberplane-hono/src/router.ts
+++ b/packages/fiberplane-hono/src/router.ts
@@ -1,5 +1,4 @@
 import { type Env, Hono } from "hono";
-import { contextStorage } from "hono/context-storage";
 import { logIfDebug } from "./debug";
 import { webStandardFetch } from "./fetch";
 import createApiRoutes from "./routes/api";
@@ -11,6 +10,7 @@ import type {
   FiberplaneAppType,
   ResolvedEmbeddedOptions,
 } from "./types";
+import { contextStorage } from "./utils";
 
 // We use a factory pattern to create routes, which allows for clean dependency injection
 // of the apiKey. This keeps the implementation isolated and prevents us from having to

--- a/packages/fiberplane-hono/src/routes/api/workflows.ts
+++ b/packages/fiberplane-hono/src/routes/api/workflows.ts
@@ -37,7 +37,6 @@ export default function createWorkflowsApiRoute<E extends Env>(
       headers.set("content-type", contentType);
     }
 
-
     if (partitionKey) {
       headers.set("X-Fiberplane-Partition-Key", partitionKey);
       logIfDebug(

--- a/packages/fiberplane-hono/src/routes/api/workflows.ts
+++ b/packages/fiberplane-hono/src/routes/api/workflows.ts
@@ -21,6 +21,8 @@ export default function createWorkflowsApiRoute<E extends Env>(
     const url = `${fiberplaneServicesUrl}${c.req.path}`;
 
     const contentType = c.req.header("content-type");
+    const partitionKey = c.req.header("X-Fiberplane-Partition-Key");
+
     const headers = new Headers();
     // Only include the bare minimum authentication and content-type headers
     headers.set("Authorization", `Bearer ${apiKey}`);
@@ -33,6 +35,18 @@ export default function createWorkflowsApiRoute<E extends Env>(
         contentType,
       );
       headers.set("content-type", contentType);
+    }
+
+
+    if (partitionKey) {
+      headers.set("X-Fiberplane-Partition-Key", partitionKey);
+      logIfDebug(
+        c,
+        "[workflows]",
+        `- ${c.req.method} ${c.req.path} -`,
+        "partition key attached to proxied request:",
+        partitionKey,
+      );
     }
 
     const result = fetchFn(url, {

--- a/packages/fiberplane-hono/src/routes/api/workflows.ts
+++ b/packages/fiberplane-hono/src/routes/api/workflows.ts
@@ -11,17 +11,18 @@ export default function createWorkflowsApiRoute<E extends Env>(
 
   // Proxy all requests to fp-services but attach a token
   app.all("*", async (c) => {
-    logIfDebug(
-      c,
-      "[workflows]",
-      `- ${c.req.method} ${c.req.path} -`,
-      "Proxying request to fiberplane api",
-    );
-
     const url = `${fiberplaneServicesUrl}${c.req.path}`;
 
     const contentType = c.req.header("content-type");
     const partitionKey = c.req.header("X-Fiberplane-Partition-Key");
+
+    logIfDebug(
+      c,
+      "[workflows]",
+      `- ${c.req.method} ${c.req.path} -`,
+      "Proxying request to: ",
+      url,
+    );
 
     const headers = new Headers();
     // Only include the bare minimum authentication and content-type headers

--- a/packages/fiberplane-hono/src/routes/runner/index.test.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.test.ts
@@ -1,11 +1,11 @@
 import { Hono } from "hono";
 import type { Env } from "hono";
-import { contextStorage } from "../../utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createFiberplane } from "../../middleware";
 import type { Workflow } from "../../schemas/workflows";
 import type { FiberplaneAppType } from "../../types";
+import { contextStorage } from "../../utils";
 
 const mockWorkflow: Workflow = {
   workflowId: "test-workflow",

--- a/packages/fiberplane-hono/src/routes/runner/index.test.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.test.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "hono";
-import { contextStorage } from "hono/context-storage";
+import { contextStorage } from "../../utils";
 import { HTTPException } from "hono/http-exception";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createFiberplane } from "../../middleware";

--- a/packages/fiberplane-hono/src/routes/runner/index.test.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.test.ts
@@ -174,6 +174,7 @@ describe("Workflow Runner", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Fiberplane-Partition-Key": "test-partition",
         },
         body: JSON.stringify({
           name: "Test Resource",
@@ -204,6 +205,7 @@ describe("Workflow Runner", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Fiberplane-Partition-Key": "test-partition",
         },
         body: JSON.stringify({
           name: "Test Resource",
@@ -224,6 +226,7 @@ describe("Workflow Runner", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Fiberplane-Partition-Key": "test-partition",
         },
         body: JSON.stringify({
           description: "Test Description",
@@ -263,6 +266,7 @@ describe("Workflow Runner", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Fiberplane-Partition-Key": "test-partition",
         },
         body: JSON.stringify({
           name: "Test Resource",
@@ -285,6 +289,7 @@ describe("Workflow Runner", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-Fiberplane-Partition-Key": "test-partition",
         },
         body: JSON.stringify({
           name: "Test Resource",
@@ -295,5 +300,28 @@ describe("Workflow Runner", () => {
     );
 
     expect(res.status).toBe(404);
+  });
+
+  it("should require X-Fiberplane-Partition-Key header", async () => {
+    const res = await app.request(
+      "/w/test-workflow",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          // Missing X-Fiberplane-Partition-Key header
+        },
+        body: JSON.stringify({
+          name: "Test Resource",
+          description: "Test Description",
+        }),
+      },
+      {},
+      mockExecutionCtx,
+    );
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe("Missing `X-Fiberplane-Partition-Key` header");
   });
 });

--- a/packages/fiberplane-hono/src/routes/runner/index.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.ts
@@ -77,7 +77,10 @@ export default function createRunnerRoute<E extends Env>(
       const partitionKey = c.req.header("X-Fiberplane-Partition-Key");
 
       if (!partitionKey) {
-        return c.json({ error: "Missing `X-Fiberplane-Partition-Key` header" }, 400);
+        return c.json(
+          { error: "Missing `X-Fiberplane-Partition-Key` header" },
+          400,
+        );
       }
 
       const { data: workflow } = await getWorkflowById(

--- a/packages/fiberplane-hono/src/routes/runner/index.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.ts
@@ -7,8 +7,8 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { logIfDebug } from "../../debug";
 import type { Step, Workflow } from "../../schemas/workflows";
-import { getContext } from "../../utils";
 import type { FiberplaneAppType } from "../../types";
+import { getContext } from "../../utils";
 import {
   type HttpRequestParams,
   type WorkflowContext,

--- a/packages/fiberplane-hono/src/routes/runner/index.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.ts
@@ -74,10 +74,17 @@ export default function createRunnerRoute<E extends Env>(
     sValidator("param", z.object({ workflowId: z.string() })),
     async (c) => {
       const { workflowId } = c.req.valid("param");
+      const partitionKey = c.req.header("X-Fiberplane-Partition-Key");
+
+      if (!partitionKey) {
+        return c.json({ error: "Missing `X-Fiberplane-Partition-Key` header" }, 400);
+      }
+
       const { data: workflow } = await getWorkflowById(
         workflowId,
         apiKey,
         fiberplaneServicesUrl,
+        partitionKey,
       );
 
       const validator = new Validator(workflow.inputs);

--- a/packages/fiberplane-hono/src/routes/runner/index.ts
+++ b/packages/fiberplane-hono/src/routes/runner/index.ts
@@ -3,11 +3,11 @@
 import { Validator } from "@cfworker/json-schema";
 import { sValidator } from "@hono/standard-validator";
 import { type Env, Hono } from "hono";
-import { getContext } from "hono/context-storage";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import { logIfDebug } from "../../debug";
 import type { Step, Workflow } from "../../schemas/workflows";
+import { getContext } from "../../utils";
 import type { FiberplaneAppType } from "../../types";
 import {
   type HttpRequestParams,

--- a/packages/fiberplane-hono/src/routes/runner/utils.ts
+++ b/packages/fiberplane-hono/src/routes/runner/utils.ts
@@ -9,6 +9,7 @@ export async function getWorkflowById<E extends Env>(
   workflowId: string,
   apiKey: string,
   fiberplaneServicesUrl: string,
+  partitionKey: string,
 ): Promise<{ data: Workflow }> {
   const c = getContext<FiberplaneAppType<E>>();
 
@@ -26,6 +27,7 @@ export async function getWorkflowById<E extends Env>(
     method: "GET",
     headers: {
       Authorization: `Bearer ${apiKey}`,
+      "X-Fiberplane-Partition-Key": partitionKey,
     },
   });
 

--- a/packages/fiberplane-hono/src/routes/runner/utils.ts
+++ b/packages/fiberplane-hono/src/routes/runner/utils.ts
@@ -1,5 +1,5 @@
 import type { Context, Env } from "hono";
-import { getContext } from "hono/context-storage";
+import { getContext } from "../../utils";
 import { HTTPException } from "hono/http-exception";
 import { type ZodError, z } from "zod";
 import type { Workflow } from "../../schemas/workflows";

--- a/packages/fiberplane-hono/src/routes/runner/utils.ts
+++ b/packages/fiberplane-hono/src/routes/runner/utils.ts
@@ -1,9 +1,9 @@
 import type { Context, Env } from "hono";
-import { getContext } from "../../utils";
 import { HTTPException } from "hono/http-exception";
 import { type ZodError, z } from "zod";
 import type { Workflow } from "../../schemas/workflows";
 import type { FiberplaneAppType } from "../../types";
+import { getContext } from "../../utils";
 
 export async function getWorkflowById<E extends Env>(
   workflowId: string,

--- a/packages/fiberplane-hono/src/utils/context-storage.ts
+++ b/packages/fiberplane-hono/src/utils/context-storage.ts
@@ -21,7 +21,7 @@ const polyfillGetContext = <E extends Env = Env>(): Context<E> => {
   if (!context) {
     throw new Error("Context is not available");
   }
-  
+
   return context as Context<E>;
 };
 
@@ -31,14 +31,12 @@ let getContext = polyfillGetContext;
 
 // Try to import from the official Hono package
 // We use dynamic import to avoid errors if the module doesn't exist
-import("hono/context-storage").then((honoContextStorage) => {
-  // If we get here, the module exists, so we can use it
-  contextStorage = honoContextStorage.contextStorage;
-  getContext = honoContextStorage.getContext;
-  console.log("Using official Hono context-storage");
-}).catch(() => {
-  // Module doesn't exist, we'll use the polyfill
-  console.log("Hono context-storage not found, using polyfill");
-});
+import("hono/context-storage")
+  .then((honoContextStorage) => {
+    // If we get here, the module exists, so we can use it
+    contextStorage = honoContextStorage.contextStorage;
+    getContext = honoContextStorage.getContext;
+  })
+  .catch(() => {});
 
-export { contextStorage, getContext }; 
+export { contextStorage, getContext };

--- a/packages/fiberplane-hono/src/utils/context-storage.ts
+++ b/packages/fiberplane-hono/src/utils/context-storage.ts
@@ -1,0 +1,44 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { Context, Env, MiddlewareHandler } from "hono";
+
+// Create our polyfill implementation using AsyncLocalStorage
+const asyncLocalStorage = new AsyncLocalStorage<Context>();
+
+/**
+ * Polyfill for Hono's contextStorage middleware
+ */
+const polyfillContextStorage = (): MiddlewareHandler => {
+  return async function contextStorage(c, next) {
+    await asyncLocalStorage.run(c, next);
+  };
+};
+
+/**
+ * Polyfill for Hono's getContext function
+ */
+const polyfillGetContext = <E extends Env = Env>(): Context<E> => {
+  const context = asyncLocalStorage.getStore();
+  if (!context) {
+    throw new Error("Context is not available");
+  }
+  
+  return context as Context<E>;
+};
+
+// Default to using the polyfill
+let contextStorage = polyfillContextStorage;
+let getContext = polyfillGetContext;
+
+// Try to import from the official Hono package
+// We use dynamic import to avoid errors if the module doesn't exist
+import("hono/context-storage").then((honoContextStorage) => {
+  // If we get here, the module exists, so we can use it
+  contextStorage = honoContextStorage.contextStorage;
+  getContext = honoContextStorage.getContext;
+  console.log("Using official Hono context-storage");
+}).catch(() => {
+  // Module doesn't exist, we'll use the polyfill
+  console.log("Hono context-storage not found, using polyfill");
+});
+
+export { contextStorage, getContext }; 

--- a/packages/fiberplane-hono/src/utils/index.ts
+++ b/packages/fiberplane-hono/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { getFromEnv } from "./env";
+export { contextStorage, getContext } from "./context-storage";

--- a/packages/playground/src/components/playground/Settings/SettingsPage.tsx
+++ b/packages/playground/src/components/playground/Settings/SettingsPage.tsx
@@ -133,8 +133,8 @@ export function SettingsPage() {
                     OpenTelemetry Traces
                   </label>
                   <p className="text-sm text-muted-foreground">
-                    Enable visualization and analysis of OpenTelemetry traces for
-                    your API requests. Contact Fiberplane to set this up.
+                    Enable visualization and analysis of OpenTelemetry traces
+                    for your API requests. Contact Fiberplane to set this up.
                   </p>
                 </div>
               </div>

--- a/packages/playground/src/components/playground/Settings/SettingsPage.tsx
+++ b/packages/playground/src/components/playground/Settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { ThemeSelect } from "@/components/theme-select";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -10,12 +11,19 @@ import { useStudioStore } from "../store";
 import { Auths } from "./Auths";
 
 export function SettingsPage() {
-  const { setFeatureEnabled, isWorkflowsEnabled, isTracingEnabled } =
-    useStudioStore(
-      "setFeatureEnabled",
-      "isWorkflowsEnabled",
-      "isTracingEnabled",
-    );
+  const {
+    setFeatureEnabled,
+    isWorkflowsEnabled,
+    isTracingEnabled,
+    partitionKey,
+    setPartitionKey,
+  } = useStudioStore(
+    "setFeatureEnabled",
+    "isWorkflowsEnabled",
+    "isTracingEnabled",
+    "partitionKey",
+    "setPartitionKey",
+  );
 
   return (
     <div className="p-8 max-w-2xl space-y-12">
@@ -46,57 +54,89 @@ export function SettingsPage() {
             </p>
           </div>
           <div className="space-y-4 p-4 border rounded-lg">
-            <div className="flex items-center space-x-4">
-              <Switch
-                id="feature-workflows"
-                checked={isWorkflowsEnabled}
-                onCheckedChange={(enabled) =>
-                  setFeatureEnabled(FEATURE_FLAG_WORKFLOWS, enabled)
-                }
-              />
-              <div className="space-y-1.5">
-                <label
-                  htmlFor="feature-workflows"
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  Workflows
-                </label>
-                <p className="text-sm text-muted-foreground">
-                  Enable support for creating and managing API workflows.
-                  Requires an API key from Fiberplane, which you can request in
-                  <a
-                    href={DISCORD_INVITE_URL}
-                    className="text-primary/80 inline-flex ml-1 items-baseline underline gap-1 hover:text-primary"
-                    target="_blank"
-                    rel="noreferrer"
+            <div className="grid grid-cols-[auto_1fr] gap-4">
+              <div className="pt-1">
+                <Switch
+                  id="feature-workflows"
+                  checked={isWorkflowsEnabled}
+                  onCheckedChange={(enabled) =>
+                    setFeatureEnabled(FEATURE_FLAG_WORKFLOWS, enabled)
+                  }
+                />
+              </div>
+              <div>
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="feature-workflows"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                   >
-                    Discord
-                  </a>
-                  .
-                </p>
+                    Workflows
+                  </label>
+                  <p className="text-sm text-muted-foreground">
+                    Enable support for creating and managing API workflows.
+                    Requires an API key from Fiberplane, which you can request
+                    in
+                    <a
+                      href={DISCORD_INVITE_URL}
+                      className="text-primary/80 inline-flex ml-1 items-baseline underline gap-1 hover:text-primary"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Discord
+                    </a>
+                    .
+                  </p>
+                </div>
+                {isWorkflowsEnabled && (
+                  <div className="mt-4 space-y-2">
+                    <div>
+                      <label
+                        htmlFor="partition-key"
+                        className="text-sm font-medium leading-none"
+                      >
+                        Partition Key
+                      </label>
+                    </div>
+                    <Input
+                      id="partition-key"
+                      value={partitionKey}
+                      onChange={(e) => setPartitionKey(e.target.value)}
+                      placeholder="Enter partition key"
+                      className="max-w-md"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      The partition key used for workflow operations.
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
+
             <Separator />
 
-            <div className="flex items-center space-x-4">
-              <Switch
-                id="feature-traces"
-                checked={isTracingEnabled}
-                onCheckedChange={(enabled) =>
-                  setFeatureEnabled(FEATURE_FLAG_TRACES, enabled)
-                }
-              />
-              <div className="space-y-1.5">
-                <label
-                  htmlFor="feature-traces"
-                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-                >
-                  OpenTelemetry Traces
-                </label>
-                <p className="text-sm text-muted-foreground">
-                  Enable visualization and analysis of OpenTelemetry traces for
-                  your API requests. Contact Fiberplane to set this up.
-                </p>
+            <div className="grid grid-cols-[auto_1fr] gap-4">
+              <div className="pt-1">
+                <Switch
+                  id="feature-traces"
+                  checked={isTracingEnabled}
+                  onCheckedChange={(enabled) =>
+                    setFeatureEnabled(FEATURE_FLAG_TRACES, enabled)
+                  }
+                />
+              </div>
+              <div>
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="feature-traces"
+                    className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  >
+                    OpenTelemetry Traces
+                  </label>
+                  <p className="text-sm text-muted-foreground">
+                    Enable visualization and analysis of OpenTelemetry traces for
+                    your API requests. Contact Fiberplane to set this up.
+                  </p>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/playground/src/components/playground/store/slices/settingsSlice.ts
+++ b/packages/playground/src/components/playground/store/slices/settingsSlice.ts
@@ -286,10 +286,7 @@ export const settingsSlice: StateCreator<
         const state = { ...initialState };
         state.partitionKey = key;
 
-        localStorage.setItem(
-          SETTINGS_STORAGE_KEY,
-          JSON.stringify(state),
-        );
+        localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(state));
 
         return state;
       }),

--- a/packages/playground/src/components/playground/store/slices/settingsSlice.ts
+++ b/packages/playground/src/components/playground/store/slices/settingsSlice.ts
@@ -280,12 +280,12 @@ export const settingsSlice: StateCreator<
 
         return state;
       }),
-    
+
     setPartitionKey: (key: string) =>
       set((initialState: StudioState): StudioState => {
         const state = { ...initialState };
         state.partitionKey = key;
-        
+
         localStorage.setItem(
           SETTINGS_STORAGE_KEY,
           JSON.stringify({
@@ -293,7 +293,7 @@ export const settingsSlice: StateCreator<
             partitionKey: state.partitionKey,
           }),
         );
-        
+
         return state;
       }),
   };

--- a/packages/playground/src/components/playground/store/slices/settingsSlice.ts
+++ b/packages/playground/src/components/playground/store/slices/settingsSlice.ts
@@ -288,10 +288,7 @@ export const settingsSlice: StateCreator<
 
         localStorage.setItem(
           SETTINGS_STORAGE_KEY,
-          JSON.stringify({
-            ...state,
-            partitionKey: state.partitionKey,
-          }),
+          JSON.stringify(state),
         );
 
         return state;

--- a/packages/playground/src/components/playground/store/slices/settingsSlice.ts
+++ b/packages/playground/src/components/playground/store/slices/settingsSlice.ts
@@ -65,6 +65,7 @@ const loadSettingsFromStorage = (): {
   isTracingEnabled: boolean;
   shouldShowTopNav: boolean;
   isErrorReportingEnabled: boolean;
+  partitionKey: string;
 } => {
   const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
   if (!stored) {
@@ -76,6 +77,7 @@ const loadSettingsFromStorage = (): {
       isTracingEnabled: false,
       isErrorReportingEnabled: false,
       shouldShowTopNav: false,
+      partitionKey: "",
     };
   }
 
@@ -89,6 +91,7 @@ const loadSettingsFromStorage = (): {
       isTracingEnabled: false,
       isErrorReportingEnabled: false,
       shouldShowTopNav: false,
+      partitionKey: "",
     };
   }
 
@@ -120,6 +123,7 @@ const loadSettingsFromStorage = (): {
     isTracingEnabled,
     shouldShowTopNav,
     isErrorReportingEnabled,
+    partitionKey: parsed.partitionKey || "",
   };
 };
 
@@ -137,6 +141,9 @@ export interface SettingsSlice {
   shouldShowTopNav: boolean;
   enabledFeatures: FeatureFlag[];
 
+  // Workflow settings
+  partitionKey: string;
+
   // Actions
   addAuthorization: (
     authorization: Authorization & Pick<Partial<Authorization>, "id">,
@@ -145,6 +152,7 @@ export interface SettingsSlice {
   removeAuthorization: (id: string) => void;
   setPersistentAuthHeaders: (headers: KeyValueElement[]) => void;
   setFeatureEnabled: (feature: FeatureFlag, enabled: boolean) => void;
+  setPartitionKey: (key: string) => void;
 }
 
 export const settingsSlice: StateCreator<
@@ -270,6 +278,22 @@ export const settingsSlice: StateCreator<
           }),
         );
 
+        return state;
+      }),
+    
+    setPartitionKey: (key: string) =>
+      set((initialState: StudioState): StudioState => {
+        const state = { ...initialState };
+        state.partitionKey = key;
+        
+        localStorage.setItem(
+          SETTINGS_STORAGE_KEY,
+          JSON.stringify({
+            ...state,
+            partitionKey: state.partitionKey,
+          }),
+        );
+        
         return state;
       }),
   };

--- a/packages/playground/src/lib/api/fetch.ts
+++ b/packages/playground/src/lib/api/fetch.ts
@@ -1,4 +1,5 @@
 import { parseEmbeddedConfig } from "@/utils";
+import { getStudioStoreState } from "@/components/playground/store/hooks/useStudioStore";
 import { parseErrorResponse } from "./errors";
 
 /**
@@ -53,10 +54,28 @@ export async function fpFetch<T>(
   // HACK - Force our client library to not trace requests to the internal API
   if (options.headers instanceof Headers) {
     options.headers.set("x-fpx-ignore", "true");
+    
+    // Add partition key header if available
+    const { partitionKey } = getStudioStoreState();
+    if (partitionKey) {
+      options.headers.set("X-Fiberplane-Partition-Key", partitionKey);
+    }
   } else if (Array.isArray(options.headers)) {
     options.headers.push(["x-fpx-ignore", "true"]);
+    
+    // Add partition key header if available
+    const { partitionKey } = getStudioStoreState();
+    if (partitionKey) {
+      options.headers.push(["X-Fiberplane-Partition-Key", partitionKey]);
+    }
   } else {
     options.headers["x-fpx-ignore"] = "true";
+    
+    // Add partition key header if available
+    const { partitionKey } = getStudioStoreState();
+    if (partitionKey) {
+      options.headers["X-Fiberplane-Partition-Key"] = partitionKey;
+    }
   }
 
   const basePrefix = getFpApiBasePath();

--- a/packages/playground/src/lib/api/fetch.ts
+++ b/packages/playground/src/lib/api/fetch.ts
@@ -1,5 +1,5 @@
-import { parseEmbeddedConfig } from "@/utils";
 import { getStudioStoreState } from "@/components/playground/store/hooks/useStudioStore";
+import { parseEmbeddedConfig } from "@/utils";
 import { parseErrorResponse } from "./errors";
 
 /**
@@ -54,7 +54,7 @@ export async function fpFetch<T>(
   // HACK - Force our client library to not trace requests to the internal API
   if (options.headers instanceof Headers) {
     options.headers.set("x-fpx-ignore", "true");
-    
+
     // Add partition key header if available
     const { partitionKey } = getStudioStoreState();
     if (partitionKey) {
@@ -62,7 +62,7 @@ export async function fpFetch<T>(
     }
   } else if (Array.isArray(options.headers)) {
     options.headers.push(["x-fpx-ignore", "true"]);
-    
+
     // Add partition key header if available
     const { partitionKey } = getStudioStoreState();
     if (partitionKey) {
@@ -70,7 +70,7 @@ export async function fpFetch<T>(
     }
   } else {
     options.headers["x-fpx-ignore"] = "true";
-    
+
     // Add partition key header if available
     const { partitionKey } = getStudioStoreState();
     if (partitionKey) {


### PR DESCRIPTION
This adds UI and package changes to allow the user to set partition keys in order to access workflows. Partition keys is a stopgap solution to identify the API user using the playground. 

Note: don't merge this until the Fiberplane API changes are merged and deployed