### PR TITLE
Go back to manually specifying the asset version that @fiberplane/hono should use for the playground 

### DIFF
--- a/examples/hono-openapi/src/index.ts
+++ b/examples/hono-openapi/src/index.ts
@@ -1,13 +1,13 @@
 import { createFiberplane } from "@fiberplane/hono";
 import { instrument } from "@fiberplane/hono-otel";
-import { describeRoute, openAPISpecs } from "hono-openapi";
-import { resolver, validator as zValidator } from "hono-openapi/zod";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
-import { basicAuth } from "hono/basic-auth";
-import * as schema from "./db/schema";
 import { Hono } from "hono";
+import { describeRoute, openAPISpecs } from "hono-openapi";
+import { resolver, validator as zValidator } from "hono-openapi/zod";
+import { basicAuth } from "hono/basic-auth";
 import z from "zod";
+import * as schema from "./db/schema";
 import "zod-openapi/extend";
 
 // TODO - Figure out how to use drizzle with "@hono/zod-openapi"
@@ -244,7 +244,9 @@ app.get(
 
 // Define a simple route to test the API (this is not part of the OpenAPI spec)
 app.get("/", (c) => {
-  return c.html("Hello Hono OpenAPI! Visit <a href=\"/fp\">/fp</a> to see the Fiberplane api explorer.");
+  return c.html(
+    'Hello Hono OpenAPI! Visit <a href="/fp">/fp</a> to see the Fiberplane api explorer.',
+  );
 });
 
 // Mount the Fiberplane middleware

--- a/packages/fiberplane-hono/package.json
+++ b/packages/fiberplane-hono/package.json
@@ -32,7 +32,8 @@
     "lint": "biome lint .",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
-    "watch": "nodemon --watch src --ext ts,js,json --exec \"pnpm run build\""
+    "watch": "nodemon --watch src --ext ts,js,json --exec \"pnpm run build\"",
+    "prepublishOnly": "node scripts/check-version-consistency.js"
   },
   "devDependencies": {
     "@types/node": "*",

--- a/packages/fiberplane-hono/scripts/check-version-consistency.js
+++ b/packages/fiberplane-hono/scripts/check-version-consistency.js
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+
+// Define some colors
+const colors = {
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+};
+
+function getPackageVersion() {
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+  );
+  return packageJson.version;
+}
+
+function getMiddlewareVersion() {
+  const middlewarePath = path.join(process.cwd(), "src/middleware.ts");
+  const middlewareContent = fs.readFileSync(middlewarePath, "utf8");
+
+  // Extract version from ASSETS_VERSION constant
+  const versionMatch = middlewareContent.match(
+    /ASSETS_VERSION\s*=\s*["']([^"']+)["']/,
+  );
+  if (!versionMatch) {
+    throw new Error("Could not find ASSETS_VERSION in middleware.ts");
+  }
+
+  return versionMatch[1];
+}
+
+function checkVersions() {
+  const packageVersion = getPackageVersion();
+  const middlewareVersion = getMiddlewareVersion();
+
+  if (packageVersion !== middlewareVersion) {
+    console.error(
+      `\n${colors.red}${colors.bold}⚠️  Version mismatch detected! ⚠️${colors.reset}\n`,
+    );
+    console.error(
+      `${colors.yellow}package.json version:${colors.reset} ${colors.bold}${packageVersion}${colors.reset}`,
+    );
+    console.error(
+      `${colors.yellow}middleware.ts ASSETS_VERSION:${colors.reset} ${colors.bold}${middlewareVersion}${colors.reset}\n`,
+    );
+    console.error(`${colors.red}Action Required:${colors.reset}`);
+    console.error(`1. Open ${colors.bold}src/middleware.ts${colors.reset}`);
+    console.error(
+      `2. Locate the ${colors.bold}ASSETS_VERSION${colors.reset} constant`,
+    );
+    console.error(
+      `3. Update it to match package.json: ${colors.bold}export const ASSETS_VERSION = "${packageVersion}"${colors.reset}\n`,
+    );
+    console.error(
+      `${colors.yellow}Note:${colors.reset} This value must be manually updated whenever package.json version changes`,
+    );
+    console.error(
+      "This ensures the CDN URL points to the correct package version.\n",
+    );
+    console.error(
+      "We faced issues with platform interoperability when importing the package.json directly in our code.\n",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `${colors.green}✓ Version consistency check passed${colors.reset}`,
+  );
+}
+
+checkVersions();

--- a/packages/fiberplane-hono/src/middleware.ts
+++ b/packages/fiberplane-hono/src/middleware.ts
@@ -1,5 +1,4 @@
 import type { Context, Env, MiddlewareHandler } from "hono";
-import packageJson from "../package.json" assert { type: "json" };
 import {
   DEFAULT_PLAYGROUND_SERVICES_URL,
   ENV_FIBERPLANE_OTEL_TOKEN,
@@ -12,9 +11,18 @@ import { logIfDebug } from "./debug";
 import { createRouter } from "./router";
 import type { EmbeddedOptions, ResolvedEmbeddedOptions } from "./types";
 import { getFromEnv } from "./utils/env";
+// NOTE - We faced issues between Wrangler and Node environments when importing package.json directly in our code.
+//        Recent versions of Node wanted us to use `with` syntax,
+//        but Wrangler didn't support it yet.
+//
+// import packageJson from "../package.json" assert { type: "json" };
 
-const VERSION = packageJson.version;
-const CDN_URL = `https://cdn.jsdelivr.net/npm/@fiberplane/hono@${VERSION}/dist/playground/`;
+/**
+ * The version of assets to use for the playground ui.
+ * This should correspond to the package.json version of the `@fiberplane/hono` package.
+ */
+export const ASSETS_VERSION = "0.5.0-beta.1";
+const CDN_URL = `https://cdn.jsdelivr.net/npm/@fiberplane/hono@${ASSETS_VERSION}/dist/playground/`;
 
 export const createFiberplane =
   <E extends Env>(options: EmbeddedOptions<E>): MiddlewareHandler =>


### PR DESCRIPTION
We faced issues between Wrangler and Node environments when importing package.json directly in our code to determine the current version of the package and use that info to reference the assets of the playground on jsdelivr

- Recent versions of Node wanted us to use `with` syntax instead of `assert`
- Wrangler doesn't support `with` syntax yet

This PR goes back to manually specifying the version inside `src/middleware.ts` but adds a prepulish npm hook to make sure the package.json and the ASSET_VERSION const are in sync 