### PR TITLE
Bump fiberplane-hono version to 0.5.2

### DIFF
--- a/packages/fiberplane-hono/package.json
+++ b/packages/fiberplane-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fiberplane/hono",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Fiberplane<info@fiberplane.com>",
   "repository": {
     "type": "git",

--- a/packages/fiberplane-hono/src/middleware.ts
+++ b/packages/fiberplane-hono/src/middleware.ts
@@ -21,7 +21,7 @@ import { getFromEnv } from "./utils/env";
  * The version of assets to use for the playground ui.
  * This should correspond to the package.json version of the `@fiberplane/hono` package.
  */
-export const ASSETS_VERSION = "0.5.1";
+export const ASSETS_VERSION = "0.5.2";
 const CDN_URL = `https://cdn.jsdelivr.net/npm/@fiberplane/hono@${ASSETS_VERSION}/dist/playground/`;
 
 export const createFiberplane =


### PR DESCRIPTION
last build didn't have the assets in it 

already released 0.5.2