### PR TITLE
Register decorated Agent classes as namespaces

### DIFF
--- a/examples/simple-agent/src/app.tsx
+++ b/examples/simple-agent/src/app.tsx
@@ -56,7 +56,9 @@ export default function Chat() {
   };
 
   const agent = useAgent(
-    agentName ? { agent: "chat", name: agentName } : { agent: "chat" },
+    agentName
+      ? { agent: "chat-client", name: agentName }
+      : { agent: "chat-client" },
   );
 
   const {

--- a/examples/simple-agent/src/server.ts
+++ b/examples/simple-agent/src/server.ts
@@ -9,14 +9,14 @@ import {
   generateId,
   streamText,
 } from "ai";
-import { Fiber, fiberplane } from "../../../packages/agents/dist";
+import { Fiber, fiberplane } from "@fiberplane/agents";
 import { executions, tools } from "./tools";
 import { processToolCalls } from "./utils";
 
 // Environment variables type definition
 export type Env = {
   OPENAI_API_KEY: string;
-  Chat: AgentNamespace<Chat>;
+  ChatClient: AgentNamespace<ChatClient>;
 };
 
 interface MemoryState {

--- a/examples/simple-agent/src/server.ts
+++ b/examples/simple-agent/src/server.ts
@@ -1,6 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createOpenAI } from "@ai-sdk/openai";
-import { Fiber, fiberplane } from "@fiberplane/agents";
 import { type AgentNamespace, type Schedule, routeAgentRequest } from "agents";
 import { AIChatAgent } from "agents/ai-chat-agent";
 import {
@@ -10,6 +9,7 @@ import {
   generateId,
   streamText,
 } from "ai";
+import { Fiber, fiberplane } from "../../../packages/agents/dist";
 import { executions, tools } from "./tools";
 import { processToolCalls } from "./utils";
 
@@ -31,14 +31,15 @@ interface MemoryState {
 }
 
 // we use ALS to expose the agent context to the tools
-export const agentContext = new AsyncLocalStorage<Chat>();
+export const agentContext = new AsyncLocalStorage<ChatClient>();
 
-export { Chat };
+export { ChatClient };
+
 /**
  * Chat Agent implementation that handles real-time AI chat interactions
  */
 @Fiber()
-class Chat extends AIChatAgent<Env, MemoryState> {
+class ChatClient extends AIChatAgent<Env, MemoryState> {
   initialState = { memories: {} };
 
   /**

--- a/examples/simple-agent/wrangler.jsonc
+++ b/examples/simple-agent/wrangler.jsonc
@@ -14,15 +14,15 @@
   "durable_objects": {
     "bindings": [
       {
-        "name": "Chat",
-        "class_name": "Chat"
+        "name": "ChatClient",
+        "class_name": "ChatClient"
       }
     ]
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["Chat"]
+      "new_sqlite_classes": ["ChatClient"]
     }
   ],
   "observability": {

--- a/packages/agents-ui/src/components/App.tsx
+++ b/packages/agents-ui/src/components/App.tsx
@@ -25,9 +25,18 @@ export function App() {
   if (data?.length === 0) {
     return (
       <Layout reset={reset}>
-        <div className="flex items-center gap-2">
-          <HeartHandshake className="w-4 h-4" />
-          <span>No agents found</span>
+        <div className="h-full grid items-center justify-center">
+          <div className="grid gap-2 mx-auto border p-4 rounded-lg max-w-[400px]">
+            <div className="flex items-center gap-2 justify-center">
+              <HeartHandshake className="w-4 h-4" />
+              <span>Oops. No agents found!</span>
+            </div>
+            <p className="text-muted-foreground">
+              Please make sure you've decorated your Agents classes with the{" "}
+              <code className="font-mono text-warning">`@Fiber()`</code>{" "}
+              decorator
+            </p>
+          </div>
         </div>
       </Layout>
     );

--- a/packages/agents/src/agentInstances.ts
+++ b/packages/agents/src/agentInstances.ts
@@ -1,0 +1,38 @@
+import { type KebabCase, toKebabCase } from "./util";
+
+type Namespace = KebabCase<string>;
+type AgentDetails = {
+  className: string;
+  instances: Array<string>;
+};
+const agentInstances = new Map<Namespace, AgentDetails>();
+
+export function registerAgent(agent: string) {
+  const namespace = toKebabCase(agent);
+  if (!agentInstances.has(namespace)) {
+    agentInstances.set(namespace, {
+      className: agent,
+      instances: [],
+    });
+  }
+}
+
+export function registerAgentInstance(agent: string, instance: string) {
+  const namespace = toKebabCase(agent);
+  const details = agentInstances.get(namespace) || {
+    className: agent,
+    instances: [],
+  };
+
+  const existingInstances = details.instances;
+  if (!existingInstances.includes(instance)) {
+    existingInstances.push(instance);
+  }
+}
+
+export function getAgents() {
+  return Array.from(agentInstances.entries()).map(([namespace, details]) => ({
+    ...details,
+    id: namespace as string,
+  }));
+}

--- a/packages/agents/src/util.ts
+++ b/packages/agents/src/util.ts
@@ -42,3 +42,45 @@ export async function tryCatch<T, E = Error>(
     return { data: null, error: error as E };
   }
 }
+
+// TODO - Add more introspection to see if the durable object is an agent
+// which is what we are looking for
+export function isDurableObjectNamespace(
+  value: unknown,
+): value is DurableObjectNamespace<Rpc.DurableObjectBranded | undefined> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    value.constructor.name === "DurableObjectNamespace" &&
+    "newUniqueId" in value &&
+    "idFromName" in value &&
+    "idFromString" in value &&
+    "get" in value &&
+    "jurisdiction" in value &&
+    typeof value.newUniqueId === "function" &&
+    typeof value.idFromName === "function" &&
+    typeof value.idFromString === "function" &&
+    typeof value.get === "function" &&
+    typeof value.jurisdiction === "function"
+  );
+}
+
+/**
+ * Converts a string to kebab-case
+ * @param str The input string to convert
+ * @returns The kebab-case version of the input string
+ */
+export function toKebabCase(str: string): KebabCase<string> {
+  return str
+    .replace(/([a-z])([A-Z])/g, "$1-$2") // Convert camelCase to kebab-case
+    .replace(/[\s_]+/g, "-") // Replace spaces and underscores with hyphens
+    .toLowerCase() as KebabCase<string>;
+}
+
+/**
+ * Type for kebab-case strings
+ * This is a branded type that ensures type safety for kebab-case strings
+ */
+export type KebabCase<T extends string> = T extends string
+  ? string & { readonly __kebabCase: unique symbol }
+  : never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19374,10 +19374,6 @@ snapshots:
     dependencies:
       acorn: 8.14.0
 
-  acorn-jsx@5.3.2(acorn@8.14.1):
-    dependencies:
-      acorn: 8.14.1
-
   acorn-walk@8.3.2: {}
 
   acorn-walk@8.3.4:
@@ -20808,7 +20804,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.14.1
+      acorn: 8.14.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
 
@@ -23047,8 +23043,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.14.1
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       micromark-extension-mdx-expression: 3.0.0
       micromark-extension-mdx-jsx: 3.0.1
       micromark-extension-mdx-md: 2.0.0


### PR DESCRIPTION
And log a warning if we encounter durable objects that have not been decorated (or more precise when we can't correlate a decorated class with a durable object binding)

Also improved the empty state of the admin console slightly:
![localhost_6660_ (1)](https://github.com/user-attachments/assets/9e6ca320-f271-47e1-9934-fe372a64dc2b)

