### PR TITLE
Set the scope of `this` to the `connection`

### DIFF
--- a/packages/agents/src/index.tsx
+++ b/packages/agents/src/index.tsx
@@ -324,7 +324,10 @@ export function Fiber<E = unknown, S = unknown>() {
                 });
 
                 // Call the original send method
-                return Reflect.get(target, prop, receiver).call(this, message);
+                return Reflect.get(target, prop, receiver).call(
+                  target,
+                  message,
+                );
               };
             }
 


### PR DESCRIPTION
This avoids an illegal invocation error in certain cases where there's an incorrect `this` reference.