### PR TITLE
Add links to docs in various settings

### DIFF
--- a/legacy/apps/studio/studio-api/src/routes/settings.ts
+++ b/legacy/apps/studio/studio-api/src/routes/settings.ts
@@ -73,4 +73,16 @@ app.post("/v0/settings", cors(), async (ctx) => {
   return ctx.json(updatedSettings);
 });
 
+/**
+ * Documentation Links
+ */
+app.get("/v0/settings/docs", cors(), async (ctx) => {
+  const documentationLinks = {
+    apiKey: "https://docs.fiberplane.com/ai-api-keys",
+    aiProvider: "https://docs.fiberplane.com/ai-credits",
+    model: "https://docs.fiberplane.com/ai-models",
+  };
+  return ctx.json(documentationLinks);
+});
+
 export default app;

--- a/legacy/apps/studio/studio-frontend/src/pages/SettingsPage/AISettingsForm.tsx
+++ b/legacy/apps/studio/studio-frontend/src/pages/SettingsPage/AISettingsForm.tsx
@@ -166,7 +166,7 @@ export function AISettingsForm({
                   <div className="flex flex-col gap-2">
                     <FormLabel>AI Provider</FormLabel>
                     <FormDescription>
-                      Select the AI provider for request autofill.
+                      Select the AI provider for request autofill. For more information, see the <a href="https://docs.fiberplane.com/ai-providers">Fiberplane AI Providers documentation</a>.
                     </FormDescription>
                   </div>
                   <FormControl>
@@ -212,6 +212,9 @@ export function AISettingsForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel className="pr-2">Model</FormLabel>
+                        <FormDescription>
+                          For more information on the available models, see the <a href="https://docs.fiberplane.com/ai-models">Fiberplane AI Models documentation</a>.
+                        </FormDescription>
                         <FormControl>
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
@@ -250,6 +253,9 @@ export function AISettingsForm({
                     render={({ field }) => (
                       <FormItem>
                         <FormLabel>API Key</FormLabel>
+                        <FormDescription>
+                          For more information on obtaining an API key, see the <a href="https://docs.fiberplane.com/ai-api-keys">Fiberplane AI API Keys documentation</a>.
+                        </FormDescription>
                         <FormControl>
                           <ApiKeyInput
                             value={field.value ?? ""}

--- a/legacy/apps/studio/studio-frontend/src/pages/SettingsPage/SettingsPage.tsx
+++ b/legacy/apps/studio/studio-frontend/src/pages/SettingsPage/SettingsPage.tsx
@@ -148,6 +148,26 @@ function SettingsLayout({
         </TabsContent>
         <TabsContent className="m-0" value={AI_TAB}>
           <AISettingsForm settings={settings} />
+          <div className="mt-4">
+            <h4 className="text-md font-medium">Documentation Links</h4>
+            <ul className="list-disc list-inside">
+              <li>
+                <a href="https://docs.fiberplane.com/ai-api-keys" target="_blank" rel="noopener noreferrer">
+                  How to get API key from OpenAI
+                </a>
+              </li>
+              <li>
+                <a href="https://docs.fiberplane.com/ai-credits" target="_blank" rel="noopener noreferrer">
+                  Credits explanation for Fiberplane AI
+                </a>
+              </li>
+              <li>
+                <a href="https://docs.fiberplane.com/ai-models" target="_blank" rel="noopener noreferrer">
+                  Documentation explaining various models
+                </a>
+              </li>
+            </ul>
+          </div>
         </TabsContent>
         <TabsContent className="m-0" value={PROXY_REQUESTS_TAB}>
           <ProxyRequestsSettingsForm settings={settings} />


### PR DESCRIPTION
Add links to documentation in various settings for better user guidance.

* **AISettingsForm.tsx**
  - Add link to Fiberplane AI Providers documentation in the `FormDescription` for the `aiProvider` field.
  - Add link to Fiberplane AI Models documentation in the `FormDescription` for the `model` field.
  - Add link to Fiberplane AI API Keys documentation in the `FormDescription` for the `apiKey` field.

* **SettingsPage.tsx**
  - Add a section with links to documentation for obtaining an API key from OpenAI, credits explanation for Fiberplane AI, and various models.

* **settings.ts**
  - Add a new route to provide documentation links for API key, AI provider, and models.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fiberplane/fiberplane/pull/585?shareId=a8d1d2a6-b948-4092-a9ed-b9ffe6cc6103).