### PR TITLE
Fix replace import.meta.env that was prone to breaking with just a build-time replaced value

### DIFF
--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -3,10 +3,14 @@ import path from "node:path";
 import { build } from "tsup";
 import { build as viteBuild } from "vite";
 import pkg from "../package.json";
+import { execSync } from "node:child_process";
 
 async function run() {
   // Store original directory to return to it later
   const originalDir = process.cwd();
+
+  // Get the current git commit hash
+  const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 
   console.log("Building agents library...");
 
@@ -18,6 +22,9 @@ async function run() {
     // external: ["vite", "cloudflare:workers", "react", "zod", "agents"],
     external: Object.keys(pkg.dependencies || {}),
     clean: true,
+    define: {
+      __COMMIT_HASH__: JSON.stringify(commitHash),
+    },
   });
 
   // Define paths for agents-ui

--- a/packages/agents/scripts/build.ts
+++ b/packages/agents/scripts/build.ts
@@ -1,9 +1,9 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { build } from "tsup";
 import { build as viteBuild } from "vite";
 import pkg from "../package.json";
-import { execSync } from "node:child_process";
 
 async function run() {
   // Store original directory to return to it later

--- a/packages/agents/src/global.d.ts
+++ b/packages/agents/src/global.d.ts
@@ -1,0 +1,1 @@
+declare const __COMMIT_HASH__: string; 

--- a/packages/agents/src/routing.tsx
+++ b/packages/agents/src/routing.tsx
@@ -10,7 +10,8 @@ import {
 } from "./utils";
 
 const version = packageJson.version;
-const commitHash = typeof __COMMIT_HASH__ !== "undefined" ? __COMMIT_HASH__ : "";
+const commitHash =
+  typeof __COMMIT_HASH__ !== "undefined" ? __COMMIT_HASH__ : "";
 
 function createFpApp(customPath = "/fp") {
   const app = new Hono().basePath(customPath);

--- a/packages/agents/src/routing.tsx
+++ b/packages/agents/src/routing.tsx
@@ -10,7 +10,7 @@ import {
 } from "./utils";
 
 const version = packageJson.version;
-const commitHash = import.meta.env.GIT_COMMIT_HASH ?? "";
+const commitHash = typeof __COMMIT_HASH__ !== "undefined" ? __COMMIT_HASH__ : "";
 
 function createFpApp(customPath = "/fp") {
   const app = new Hono().basePath(customPath);

--- a/packages/agents/tsup.config.ts
+++ b/packages/agents/tsup.config.ts
@@ -1,6 +1,9 @@
 // TODO(laurynas): refactor the build.ts to support watch mode and remove this
 // it's just for the dev script
 import { defineConfig } from "tsup";
+import { execSync } from "node:child_process";
+
+const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -9,4 +12,7 @@ export default defineConfig({
   sourcemap: true,
   external: ["vite", "cloudflare:workers", "react", "zod", "agents"],
   outDir: "dist",
+  define: {
+    __COMMIT_HASH__: JSON.stringify(commitHash),
+  },
 });

--- a/packages/agents/tsup.config.ts
+++ b/packages/agents/tsup.config.ts
@@ -1,7 +1,7 @@
+import { execSync } from "node:child_process";
 // TODO(laurynas): refactor the build.ts to support watch mode and remove this
 // it's just for the dev script
 import { defineConfig } from "tsup";
-import { execSync } from "node:child_process";
 
 const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 


### PR DESCRIPTION
The previous (incomplete) iteration of importing `GIT_COMMIT_HASH` env var with `import.meta.env` was breaking the runtime.

This uses a global `__COMMIT_HASH__` that now gets a properly replaced hardcoded commit hash value.

Addresses #586 